### PR TITLE
Replace partner logos

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -123,7 +123,7 @@
         <div class="p-card--strip u-no-padding">
           <div class="p-strip is-shallow">
             <a href="https://snapcraft.io">
-              <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/d50d2bf5-products-snapcraft-wht-aubergine4.svg" alt="Snapcraft logo">
+              <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/11776603-snapcraft_lrg.svg" alt="Snapcraft logo">
             </a>
           </div>
           <div class="p-card__content">
@@ -138,7 +138,7 @@
         <div class="p-card--strip u-no-padding">
           <div class="p-strip is-shallow">
             <a href="https://ubuntu.com/openstack">
-              <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/0be1c93f-products-openstack-wht-aubergine5.svg" alt="OpenStack logo">
+              <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/0694ab7a-openstack_lrg.svg" alt="OpenStack logo">
             </a>
           </div>
           <div class="p-card__content">
@@ -151,7 +151,7 @@
         <div class="p-card--strip u-no-padding">
           <div class="p-strip is-shallow">
             <a href="https://ubuntu.com/kubernetes">
-              <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/2365c0c0-products-kubernetes-wht-aubergine4.svg" alt="Kubernetes logo">
+              <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/32ef9123-kubernetes_lrg.svg" alt="Kubernetes logo">
             </a>
           </div>
           <div class="p-card__content">


### PR DESCRIPTION
## Done

- Replace partner logos

## QA

- Check out this feature branch
- Run the site using the command `./run`
- View the site locally in your web browser at: [http://0.0.0.0:8002](http://0.0.0.0:8002)
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Make sure partners logo are replaced with [these](https://github.com/canonical-web-and-design/web-squad/issues/1534)


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/1534
