### PR TITLE
Add content to the overview tab of careers pages

### DIFF
--- a/static/sass/_pattern_headings.scss
+++ b/static/sass/_pattern_headings.scss
@@ -26,4 +26,25 @@
       width: 75px;
     }
   }
+
+  .p-heading-icon--h1 {
+    h1 {
+      display: inline-block; 
+      margin-right: $sph-inner;
+    }
+
+    img {
+      height: 3rem;
+      vertical-align: middle;
+      position: relative;
+      top: -0.5rem;
+    }
+
+    @media (max-width: $breakpoint-medium) {
+      img {
+        height: 2rem;
+        top: -0.35rem;
+      }
+    }
+  }
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -4,7 +4,6 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="description" content="" />
     <meta name="description" content="{% block meta_description %}Canonical produces Ubuntu, provides commercial services for Ubuntu’s users, and works with hardware manufacturers, software vendors and cloud partners to certify Ubuntu.{% endblock %}" />
     <meta name="author" content="Canonical Ltd" />
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -4,7 +4,8 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="description" content="Canonical produces Ubuntu, provides commercial services for Ubuntu’s users, and works with hardware manufacturers, software vendors and cloud partners to certify Ubuntu. " />
+    <meta name="description" content="" />
+    <meta name="description" content="{% block meta_description %}Canonical produces Ubuntu, provides commercial services for Ubuntu’s users, and works with hardware manufacturers, software vendors and cloud partners to certify Ubuntu.{% endblock %}" />
     <meta name="author" content="Canonical Ltd" />
 
     <link rel="shortcut icon" href="https://assets.ubuntu.com/v1/0843d517-favicon.ico" type="image/x-icon" />

--- a/templates/careers/admin.html
+++ b/templates/careers/admin.html
@@ -1,11 +1,34 @@
 {% extends '/careers/careers_base.html' %}
 
-{% block title %}
-  <h1>Admin</h1>
-{% endblock %}
+{% block title %}<h1>Admin</h1>{% endblock %}
 
 {% block overview %}
-
+  <div class="row">
+    <div class="col-12">
+      <p>
+        <strong>Canonical is a completely new kind of organisation - almost entirely distributed, we are a global team of technology leaders who collaborate online to enable the transformation of enterprise software to open source. We have a few office locations, but almost everybody works from home. Teams get together every few months at locations around the world to plan and coordinate their projects.</strong>
+      </p>
+      <p>
+        All of this means that administration is central to the effective running of the company. Hundreds of distributed team members count on effective processes to support their travel and operations. Our admin team run events, control expenses, manage travel and coordinate meetings. We are trusted to hold the global team accountable to the company policies. We ensure that the business operates smoothly and we have a significant impact on the quality of the experience that people have at the company.
+      </p>
+      <p>
+        We are a multi-skilled and multi-cultural team. We encourage new members of the team to develop skills across the entire range of admin challenges so that we can help one another as needed and bring our joint insights to bear on continuous improvement. Our team is largely based in offices in Austin, Boston, London, Taipei and Beijing, but we offer some flexibility to work from home. We often run company events around the world in person, so you need the latitude to be in a completely different timezone for up to two weeks at a time, three or four times a year.
+      </p>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12">
+      <hr />
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12">
+      <p class="p-muted-heading">
+        <span style="text-transform: capitalize">Austin&nbsp;&#124;&nbsp;Beijing&nbsp;&#124;&nbsp;Boston&nbsp;&#124;&nbsp;London&nbsp;&#124;&nbsp;Taipei</span>
+      </p>
+      <a href="#">Apply now&nbsp;&rsaquo;</a>
+    </div>
+  </div>
 {% endblock %}
 
 {% block available_roles %}

--- a/templates/careers/admin.html
+++ b/templates/careers/admin.html
@@ -1,32 +1,44 @@
 {% extends '/careers/careers_base.html' %}
 
-{% block title %}<h1>Admin</h1>{% endblock %}
+{% block hero %}
+  <section class="p-strip--image is-dark is-deep u-no-padding--top u-no-padding--bottom u-extra-space">
+    <div class="p-strip--suru-background">
+      <div class="row">
+        <div class="col-6">
+          <h1>Admin</h1>
+        </div>
+      </div>
+    </div>
+  </section>
+{% endblock %}
 
 {% block overview %}
-  <div class="row">
-    <div class="col-12">
-      <p>
-        <strong>Canonical is a completely new kind of organisation - almost entirely distributed, we are a global team of technology leaders who collaborate online to enable the transformation of enterprise software to open source. We have a few office locations, but almost everybody works from home. Teams get together every few months at locations around the world to plan and coordinate their projects.</strong>
-      </p>
-      <p>
-        All of this means that administration is central to the effective running of the company. Hundreds of distributed team members count on effective processes to support their travel and operations. Our admin team run events, control expenses, manage travel and coordinate meetings. We are trusted to hold the global team accountable to the company policies. We ensure that the business operates smoothly and we have a significant impact on the quality of the experience that people have at the company.
-      </p>
-      <p>
-        We are a multi-skilled and multi-cultural team. We encourage new members of the team to develop skills across the entire range of admin challenges so that we can help one another as needed and bring our joint insights to bear on continuous improvement. Our team is largely based in offices in Austin, Boston, London, Taipei and Beijing, but we offer some flexibility to work from home. We often run company events around the world in person, so you need the latitude to be in a completely different timezone for up to two weeks at a time, three or four times a year.
-      </p>
+  <div class="p-strip is-shallow u-extra-space tab-content" id="overview">
+    <div class="row">
+      <div class="col-12">
+        <p>
+          <strong>Canonical is a completely new kind of organisation - almost entirely distributed, we are a global team of technology leaders who collaborate online to enable the transformation of enterprise software to open source. We have a few office locations, but almost everybody works from home. Teams get together every few months at locations around the world to plan and coordinate their projects.</strong>
+        </p>
+        <p>
+          All of this means that administration is central to the effective running of the company. Hundreds of distributed team members count on effective processes to support their travel and operations. Our admin team run events, control expenses, manage travel and coordinate meetings. We are trusted to hold the global team accountable to the company policies. We ensure that the business operates smoothly and we have a significant impact on the quality of the experience that people have at the company.
+        </p>
+        <p>
+          We are a multi-skilled and multi-cultural team. We encourage new members of the team to develop skills across the entire range of admin challenges so that we can help one another as needed and bring our joint insights to bear on continuous improvement. Our team is largely based in offices in Austin, Boston, London, Taipei and Beijing, but we offer some flexibility to work from home. We often run company events around the world in person, so you need the latitude to be in a completely different timezone for up to two weeks at a time, three or four times a year.
+        </p>
+      </div>
     </div>
-  </div>
-  <div class="row">
-    <div class="col-12">
-      <hr />
+    <div class="row">
+      <div class="col-12">
+        <hr />
+      </div>
     </div>
-  </div>
-  <div class="row">
-    <div class="col-12">
-      <p class="p-muted-heading">
-        <span style="text-transform: capitalize">Austin&nbsp;&#124;&nbsp;Beijing&nbsp;&#124;&nbsp;Boston&nbsp;&#124;&nbsp;London&nbsp;&#124;&nbsp;Taipei</span>
-      </p>
-      <a href="#">Apply now&nbsp;&rsaquo;</a>
+    <div class="row">
+      <div class="col-12">
+        <p class="p-muted-heading">
+          <span style="text-transform: capitalize">Austin&nbsp;&#124;&nbsp;Beijing&nbsp;&#124;&nbsp;Boston&nbsp;&#124;&nbsp;London&nbsp;&#124;&nbsp;Taipei</span>
+        </p>
+        <a href="#">Apply now&nbsp;&rsaquo;</a>
+      </div>
     </div>
   </div>
 {% endblock %}

--- a/templates/careers/admin.html
+++ b/templates/careers/admin.html
@@ -30,11 +30,3 @@
     </div>
   </div>
 {% endblock %}
-
-{% block available_roles %}
-
-{% endblock %}
-
-{% block send_cv %}
-
-{% endblock %}

--- a/templates/careers/careers_base.html
+++ b/templates/careers/careers_base.html
@@ -213,4 +213,5 @@
   })
 </script>
 
+
 {% endblock %}

--- a/templates/careers/careers_base.html
+++ b/templates/careers/careers_base.html
@@ -1,13 +1,6 @@
 {% extends 'base.html' %} {% block content %}
-<section class="p-strip--image is-dark is-deep u-no-padding--top u-no-padding--bottom u-extra-space">
-  <div class="p-strip--suru-background">
-    <div class="row">
-      <div class="col-6">
-        {% block title %}{% endblock %}
-      </div>
-    </div>
-  </div>
-</section>
+
+{% block hero %}{% endblock %}
 
 <section class="p-strip u-extra-space">
   <div class="row">
@@ -33,10 +26,7 @@
             <a href="/careers/design" class="p-link--soft">Design</a>
           </li>
           <li class="p-content-list-section__item js-navigation-link">
-            <a href="/careers/project" class="p-link--soft">Project</a>
-          </li>
-          <li class="p-content-list-section__item js-navigation-link">
-            <a href="/careers/management" class="p-link--soft">Management</a>
+            <a href="/careers/project-management" class="p-link--soft">Project Management</a>
           </li>
           <li class="p-content-list-section__item js-navigation-link">
             <a href="/careers/finance" class="p-link--soft">Finance</a>
@@ -84,8 +74,7 @@
         <option value="/careers/sales">Sales</option>
         <option value="/careers/marketing">Marketing</option>
         <option value="/careers/design">Design</option>
-        <option value="/careers/project">Project</option>
-        <option value="/careers/management">Management</option>
+        <option value="/careers/project-management">Project Management</option>
         <option value="/careers/finance">Finance</option>
         <option value="/careers/legal">Legal</option>
         <option value="/careers/admin">Admin</option>
@@ -121,45 +110,76 @@
         </div>
       </div>
       {% endif %}
-      <div class="p-strip is-shallow u-extra-space">
-        <div class="tab-content" id="overview" style="padding: 0;">
-          {% block overview %}{% endblock %}
+
+      {% block overview %}{% endblock %}
+
+      <div class="p-strip is-shallow u-extra-space tab-content u-hide" id="available-roles">
+        <div class="row u-align--right">
+          <div class="col-12">
+            <form action="" method="get" class="p-form p-form--inline">
+              <div class="p-form__group">
+                <label for="full-name-inline" aria-label="Filter the resources by type" class="p-form__label">Filter by</label>
+                <select class="js-submit-on-change p-form__control" name="content" aria-label="Filter by content type">
+                  <option value="">All</option>
+                  <option value="">Home based</option>
+                  <option value="">Office based</option>
+                  <option value="">Management/option>
+                  <option value="">Senior roles</option>
+                  <option value="">Full-time</option>
+                  <option value="">Part-time</option>
+                </select>
+                <label for="full-name-inline" aria-label="Filter the resources by type" class="p-form__label">Sort by</label>
+                <select class="js-submit-on-change p-form__control" name="content" aria-label="Filter by content type">
+                  <option value="">Date</option>
+                  <option value="">Home based</option>
+                </select>
+              </div>
+            </form>
+          </div>
         </div>
-        <div class="tab-content u-hide" id="available-roles" style="padding: 0;">
-          {% block available_roles %}{% endblock %}
+        <div class="row">
+          <div class="col-12">
+            <hr />
+          </div>
         </div>
-        <div class="tab-content u-hide" id="send-cv" style="padding: 0;">
-          <div class="row">
-            <div class="col-12">
-              <h2>Can't find the ideal role for you?</h2>
-              <p>Don't worry if you can't find the a role that fits you, send us your CV and we'll keep it on file to match any future roles to your skills to see if we can get a great match.</p>
-              <form>
-                <fieldset style="border: none;">
-                  <p class="required-legend u-align-text--right ">Required</p>
-                  <label for="list-input-1" class="is-required u-no-padding--top">First name</label>
-                  <input placeholder="" id="list-input-1" type="text">
-                  <label for="list-input-2" class="is-required">Last name</label>
-                  <input placeholder="" id="list-input-2" type="text">
-                  <label for="list-input-3" class="is-required">Email address</label>
-                  <input placeholder="" id="list-input-3" type="text">
-                  <label for="list-input-4">Phone</label>
-                  <input placeholder="" id="list-input-3" type="text">
-                  <label for="exampleSelect">Country</label>
-                  <select name="countrySelect" id="countrySelect">
-                    <option value="" disabled="disabled" selected="">Select...</option>
-                    <option value="1">Cosmic Cuttlefish</option>
-                    <option value="2">Bionic Beaver</option>
-                    <option value="3">Xenial Xerus</option>
-                  </select>
-                  <label for="exampleInputFile">Upload CV</label>
-                  <input type="file" id="exampleInputFile">
-                  <textarea id="textarea" rows="3">Tell us what type of role you are looking for</textarea>
-                  <input type="checkbox" id="CheckMe">
-                  <label for="CheckMe">I agree to receive information about Canonical’s products and services.</label>
-                  <button type="submit">Send now</button>
-                </fieldset>
-              </form>
-            </div>
+        <div class="row">
+          <div class="col-12">
+          
+          </div>
+        </div>
+      </div>
+
+      <div class="p-strip is-shallow u-extra-space tab-content u-hide" id="send-cv">
+        <div class="row">
+          <div class="col-12">
+            <h2>Can't find the ideal role for you?</h2>
+            <p>Don't worry if you can't find the a role that fits you, send us your CV and we'll keep it on file to match any future roles to your skills to see if we can get a great match.</p>
+            <form>
+              <fieldset style="border: none;">
+                <p class="required-legend u-align-text--right ">Required</p>
+                <label for="list-input-1" class="is-required u-no-padding--top">First name</label>
+                <input placeholder="" id="list-input-1" type="text">
+                <label for="list-input-2" class="is-required">Last name</label>
+                <input placeholder="" id="list-input-2" type="text">
+                <label for="list-input-3" class="is-required">Email address</label>
+                <input placeholder="" id="list-input-3" type="text">
+                <label for="list-input-4">Phone</label>
+                <input placeholder="" id="list-input-3" type="text">
+                <label for="exampleSelect">Country</label>
+                <select name="countrySelect" id="countrySelect">
+                  <option value="" disabled="disabled" selected="">Select...</option>
+                  <option value="1">Cosmic Cuttlefish</option>
+                  <option value="2">Bionic Beaver</option>
+                  <option value="3">Xenial Xerus</option>
+                </select>
+                <label for="exampleInputFile">Upload CV</label>
+                <input type="file" id="exampleInputFile">
+                <textarea id="textarea" rows="3">Tell us what type of role you are looking for</textarea>
+                <input type="checkbox" id="CheckMe">
+                <label for="CheckMe">I agree to receive information about Canonical’s products and services.</label>
+                <button type="submit">Send now</button>
+              </fieldset>
+            </form>
           </div>
         </div>
       </div>

--- a/templates/careers/careers_base.html
+++ b/templates/careers/careers_base.html
@@ -76,28 +76,30 @@
       </div>
     </div>
     <div class="col-3 u-hide--medium u-hide--large">
-      <select name="menu">
-        <option value="engineering">Engineering</option>
-        <option value="tech-ops">Tech-ops</option>
-        <option value="commercial-ops">Commercial-ops</option>
-        <option value="sales">Sales</option>
-        <option value="marketing">Marketing</option>
-        <option value="design">Design</option>
-        <option value="project">Project</option>
-        <option value="management">Management</option>
-        <option value="finance">Finance</option>
-        <option value="legal">Legal</option>
-        <option value="admin">Admin</option>
-        <option value="hr">HR</option>
-        <option value="lifestyle">Lifestyle</option>
-        <option value="ethics">Ethics</option>
-        <option value="travel">Travel</option>
-        <option value="progression">Progression</option>
-        <option value="diversity">Diversity</option>
-        <option value="all">ALL</option>
+      <select name="menu" onchange="location.href=this.value">
+        <option disabled="disabled" value="" selected="">Select a career...</option>
+        <option value="/careers/engineering">Engineering</option>
+        <option value="/careers/tech-ops">Tech-ops</option>
+        <option value="/careers/commercial-ops">Commercial-ops</option>
+        <option value="/careers/sales">Sales</option>
+        <option value="/careers/marketing">Marketing</option>
+        <option value="/careers/design">Design</option>
+        <option value="/careers/project">Project</option>
+        <option value="/careers/management">Management</option>
+        <option value="/careers/finance">Finance</option>
+        <option value="/careers/legal">Legal</option>
+        <option value="/careers/admin">Admin</option>
+        <option value="/careers/hr">HR</option>
+        <option value="/careers/lifestyle">Lifestyle</option>
+        <option value="/careers/ethics">Ethics</option>
+        <option value="/careers/travel">Travel</option>
+        <option value="/careers/progression">Progression</option>
+        <option value="/careers/diversity">Diversity</option>
+        <option value="/careers/all">ALL</option>
       </select>
     </div>
     <div class="col-8 col-start-large-5">
+      {% if (request.path != "/careers/lifestyle" and request.path != "/careers/ethics" and request.path != "/careers/travel" and request.path != "/careers/progression" and request.path != "/careers/diversity") %}
       <div class="row">
         <div class="col-12">
           <nav class="p-tabs">
@@ -118,6 +120,7 @@
           </nav>
         </div>
       </div>
+      {% endif %}
       <div class="p-strip is-shallow u-extra-space">
         <div class="tab-content" id="overview" style="padding: 0;">
           {% block overview %}{% endblock %}
@@ -129,8 +132,7 @@
           <div class="row">
             <div class="col-12">
               <h2>Can't find the ideal role for you?</h2>
-              <p>Don't worry if you can't find the a role that fits you, send us your CV and we'll keep it on file to
-                match any future roles to your skills to see if we can get a great match.</p>
+              <p>Don't worry if you can't find the a role that fits you, send us your CV and we'll keep it on file to match any future roles to your skills to see if we can get a great match.</p>
               <form>
                 <fieldset style="border: none;">
                   <p class="required-legend u-align-text--right ">Required</p>

--- a/templates/careers/commercial-ops.html
+++ b/templates/careers/commercial-ops.html
@@ -3,3 +3,5 @@
 {% block title %}<h1>Commercial-ops</h1>{% endblock %}
 
 {% block overview %}
+
+{% endblock %}

--- a/templates/careers/commercial-ops.html
+++ b/templates/careers/commercial-ops.html
@@ -1,8 +1,6 @@
 {% extends '/careers/careers_base.html' %}
 
-{% block title %}
-  <h1>Commercial-ops</h1>
-{% endblock %}
+{% block title %}<h1>Commercial-ops</h1>{% endblock %}
 
 {% block overview %}
 

--- a/templates/careers/commercial-ops.html
+++ b/templates/careers/commercial-ops.html
@@ -3,13 +3,3 @@
 {% block title %}<h1>Commercial-ops</h1>{% endblock %}
 
 {% block overview %}
-
-{% endblock %}
-
-{% block available_roles %}
-
-{% endblock %}
-
-{% block send_cv %}
-
-{% endblock %}

--- a/templates/careers/commercial-ops.html
+++ b/templates/careers/commercial-ops.html
@@ -1,7 +1,36 @@
 {% extends '/careers/careers_base.html' %}
 
-{% block title %}<h1>Commercial-ops</h1>{% endblock %}
+{% block hero %}
+  <section class="p-strip--image is-dark is-deep u-no-padding--top u-no-padding--bottom u-extra-space">
+    <div class="p-strip--suru-background">
+      <div class="row">
+        <div class="col-6">
+          <h1>Commercial-ops</h1>
+        </div>
+      </div>
+    </div>
+  </section>
+{% endblock %}
 
 {% block overview %}
+  <div class="p-strip is-shallow u-extra-space tab-content" id="overview">
+    <div class="row">
+      <div class="col-12">
 
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-12">
+        <hr />
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-12">
+        <p class="p-muted-heading">
+          <span style="text-transform: capitalize">Europe&nbsp;&#124;&nbsp;Middle East&nbsp;&#124;&nbsp;Africa&nbsp;&#124;&nbsp;Americas&nbsp;&#124;&nbsp;APAC</span>
+        </p>
+        <a href="#">Apply now&nbsp;&rsaquo;</a>
+      </div>
+    </div>
+  </div>
 {% endblock %}

--- a/templates/careers/design.html
+++ b/templates/careers/design.html
@@ -1,8 +1,6 @@
 {% extends '/careers/careers_base.html' %}
 
-{% block title %}
-  <h1>Design</h1>
-{% endblock %}
+{% block title %}<h1>Design</h1>{% endblock %}
 
 {% block overview %}
   <div class="row">

--- a/templates/careers/design.html
+++ b/templates/careers/design.html
@@ -1,70 +1,47 @@
 {% extends '/careers/careers_base.html' %}
 
-{% block title %}<h1>Design</h1>{% endblock %}
+{% block hero %}
+  <section class="p-strip--image is-dark is-deep u-no-padding--top u-no-padding--bottom u-extra-space">
+    <div class="p-strip--suru-background">
+      <div class="row">
+        <div class="col-6">
+          <h1>Design</h1>
+        </div>
+      </div>
+    </div>
+  </section>
+{% endblock %}
 
 {% block overview %}
-  <div class="row">
-    <div class="col-12">
-      <p><strong>Canonical and Ubuntu are central to modern tech - from cloud to the internet of things, from the web to mobile back-ends, from development to production. We count on our design teams to bring together deep domain knowledge with great instincts, teamwork and rigorous process, to shape our products for a very demanding audience.</strong>
-      </p>
-      <p>
-        Our customers are sophisticated technical specialists across a very wide range of industries and geographies, focused on cutting edge software development and operations. Canonical delivers Ubuntu and a range of tools - for engineers, admins and enterprises - to help businesses move to an open source stack.
-      </p>
-      <p>
-        Our opportunity is to shape the enterprise infrastructure and application operations landscape. Every layer of the stack is important - from bare metal data center operations, to virtualisation infrastructure and cloud, to the desktop, to systems management, to serverless and embedded connected devices. Our designers work on a range of products, using common visual and web frameworks to create consistency of experience across a very wide range of capabilities.
-      </p>
-      <p>
-        Our team are centered in Europe, covering global distributed development engineering teams, so designers need to be effective working collaboratively in a digital space. We travel to engineering sprints and summits to collaborate with global teams on products and website.
-      </p>
+  <div class="p-strip is-shallow u-extra-space tab-content" id="overview">
+    <div class="row">
+      <div class="col-12">
+        <p><strong>Canonical and Ubuntu are central to modern tech - from cloud to the internet of things, from the web to mobile back-ends, from development to production. We count on our design teams to bring together deep domain knowledge with great instincts, teamwork and rigorous process, to shape our products for a very demanding audience.</strong>
+        </p>
+        <p>
+          Our customers are sophisticated technical specialists across a very wide range of industries and geographies, focused on cutting edge software development and operations. Canonical delivers Ubuntu and a range of tools - for engineers, admins and enterprises - to help businesses move to an open source stack.
+        </p>
+        <p>
+          Our opportunity is to shape the enterprise infrastructure and application operations landscape. Every layer of the stack is important - from bare metal data center operations, to virtualisation infrastructure and cloud, to the desktop, to systems management, to serverless and embedded connected devices. Our designers work on a range of products, using common visual and web frameworks to create consistency of experience across a very wide range of capabilities.
+        </p>
+        <p>
+          Our team are centered in Europe, covering global distributed development engineering teams, so designers need to be effective working collaboratively in a digital space. We travel to engineering sprints and summits to collaborate with global teams on products and website.
+        </p>
+      </div>
     </div>
-  </div>
-  <div class="row">
-    <div class="col-12">
-      <hr />
+    <div class="row">
+      <div class="col-12">
+        <hr />
+      </div>
     </div>
-  </div>
-  <div class="row">
-    <div class="col-12">
-      <p class="p-muted-heading">
-        <span>Emea</span>&nbsp;&#124;&nbsp;<span style="text-transform: capitalize">Americas</span>
-      </p>
-      <a href="#">Apply now&nbsp;&rsaquo;</a>
+    <div class="row">
+      <div class="col-12">
+        <p class="p-muted-heading">
+          <span>Emea</span>&nbsp;&#124;&nbsp;<span style="text-transform: capitalize">Americas</span>
+        </p>
+        <a href="#">Apply now&nbsp;&rsaquo;</a>
+      </div>
     </div>
   </div>
 {% endblock %}
 
-{% block available_roles %}
-  <div class="row">
-    <div class="col-12 u-align--right">
-      <form action="" method="get" class="p-form p-form--inline">
-        <div class="p-form__group">
-          <label for="full-name-inline" aria-label="Filter the resources by type" class="p-form__label">Filter by</label>
-          <select class="js-submit-on-change p-form__control" name="content" aria-label="Filter by content type">
-            <option value="">All</option>
-            <option value="">Home based</option>
-            <option value="">Office based</option>
-            <option value="">Management/option>
-            <option value="">Senior roles</option>
-            <option value="">Full-time</option>
-            <option value="">Part-time</option>
-          </select>
-          <label for="full-name-inline" aria-label="Filter the resources by type" class="p-form__label">Sort by</label>
-          <select class="js-submit-on-change p-form__control" name="content" aria-label="Filter by content type">
-            <option value="">Date</option>
-            <option value="">Home based</option>
-          </select>
-        </div>
-      </form>
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-12">
-      <hr />
-    </div>
-  </div>
-  <div class="row">
-    <div class="col-12">
-          
-    </div>
-  </div>
-{% endblock %}

--- a/templates/careers/diversity.html
+++ b/templates/careers/diversity.html
@@ -1,0 +1,29 @@
+{% extends '/careers/careers_base.html' %}
+
+{% block title %}<h1>Diversity</h1>{% endblock %}
+
+{% block meta_description %}Canonical proactively promotes leaders who represent new kinds of diversity, to grow the confidence of colleagues from every walk of life. We seek to create an environment that is welcoming to outstanding technology and business professionals committed to teamwork and open source.{% endblock %}
+
+{% block overview %}
+  <div class="row">
+    <div class="col-12">
+      <p>
+        <strong>We believe that talent is evenly distributed around the world. No matter where you were born, or what you look like, or how you like to dress, we think you might have the brilliance and the work ethic and the passion for open source that would make you a Canonical candidate.</strong>
+      </p>
+      <p>
+        The diversity in our company is part of our strength. What unifies us isn’t our background or our culture, it’s our vision of the future and our dedication to delivering the best of the future for our customers and our colleagues. We are unified in our pursuit of company and personal excellence in our chosen fields, we are unified in our commitment to teamwork, and we have a common vision of open source as the platform that best empowers innovators in a modern digital society. 
+      </p>
+      <p>
+        We believe in affirmative action, because we know it builds confidence in new team members when they can relate to people with similar backgrounds in their workplace. But we also expect people to look beyond the obvious and relate to intrinsic motivation and quality of work, not superficial qualities.
+      </p>
+    </div>
+  </div>
+{% endblock %}
+
+{% block available_roles %}
+
+{% endblock %}
+
+{% block send_cv %}
+
+{% endblock %}

--- a/templates/careers/diversity.html
+++ b/templates/careers/diversity.html
@@ -19,11 +19,3 @@
     </div>
   </div>
 {% endblock %}
-
-{% block available_roles %}
-
-{% endblock %}
-
-{% block send_cv %}
-
-{% endblock %}

--- a/templates/careers/diversity.html
+++ b/templates/careers/diversity.html
@@ -1,8 +1,18 @@
 {% extends '/careers/careers_base.html' %}
 
-{% block title %}<h1>Diversity</h1>{% endblock %}
-
 {% block meta_description %}Canonical proactively promotes leaders who represent new kinds of diversity, to grow the confidence of colleagues from every walk of life. We seek to create an environment that is welcoming to outstanding technology and business professionals committed to teamwork and open source.{% endblock %}
+
+{% block hero %}
+  <section class="p-strip--image is-dark is-deep u-no-padding--top u-no-padding--bottom u-extra-space">
+    <div class="p-strip--suru-background">
+      <div class="row">
+        <div class="col-6">
+          <h1>Diversity</h1>
+        </div>
+      </div>
+    </div>
+  </section>
+{% endblock %}
 
 {% block overview %}
   <div class="row">

--- a/templates/careers/engineering.html
+++ b/templates/careers/engineering.html
@@ -1,10 +1,20 @@
 {% extends '/careers/careers_base.html' %}
 
-{% block title %}<h1>Engineering</h1>{% endblock %}
+{% block hero %}
+  <section class="p-strip--image is-dark is-deep u-no-padding--top u-no-padding--bottom u-extra-space">
+    <div class="p-strip--suru-background">
+      <div class="row">
+        <div class="col-6">
+          <h1>Engineering</h1>
+        </div>
+      </div>
+    </div>
+  </section>
+{% endblock %}
 
 {% block overview %}
-  <div class="row">
-    <div class="col-12">
+  <div class="p-strip is-shallow u-extra-space tab-content" id="overview">
+    <div class="u-fixed-width">
       <p>
         <strong>Open source is transforming the entire stack. This is your chance to be right at the center of that revolution, to shape the platforms and tools that millions use to invent our global technology future. From bare metal to cloud to high performance computing, from AI and big data to the web and connected devices, open source is the key ingredient for success. Canonical offers the opportunity to work across the entire spectrum.</strong>
       </p>
@@ -24,14 +34,10 @@
         Engineering is a calling - it’s a way of thinking, not just a job. You know you will fit in at Canonical if you have consistently sought out the opportunity to write code to solve problems, from the moment you first had access to a PC. You’ll know you  fit in if you have consistently taken on the most difficult mental challenges you could, and shone brightly amongst your peers in doing so. Join us to take that to the next level - the problems we solve enable the world’s fiercest innovators and protect the world’s most critical systems. Canonical is where software engineers make a difference - to every industry and every society.
       </p>
     </div>
-  </div>
-  <div class="row">
-    <div class="col-12">
+    <div class="u-fixed-width">
       <hr />
     </div>
-  </div>
-  <div class="row">
-    <div class="col-12">
+    <div class="u-fixed-width">
       <p class="p-muted-heading">
         <span style="text-transform: capitalize">Europe&nbsp;&#124;&nbsp;Middle East&nbsp;&#124;&nbsp;Africa&nbsp;&#124;&nbsp;Americas&nbsp;&#124;&nbsp;APAC</span>
       </p>

--- a/templates/careers/engineering.html
+++ b/templates/careers/engineering.html
@@ -1,11 +1,43 @@
 {% extends '/careers/careers_base.html' %}
 
-{% block title %}
-  <h1>Engineering</h1>
-{% endblock %}
+{% block title %}<h1>Engineering</h1>{% endblock %}
 
 {% block overview %}
-
+  <div class="row">
+    <div class="col-12">
+      <p>
+        <strong>Open source is transforming the entire stack. This is your chance to be right at the center of that revolution, to shape the platforms and tools that millions use to invent our global technology future. From bare metal to cloud to high performance computing, from AI and big data to the web and connected devices, open source is the key ingredient for success. Canonical offers the opportunity to work across the entire spectrum.</strong>
+      </p>
+      <p>
+        We publish Ubuntu, the leanest and most efficient open source platform. We care about developer access to the very best of open source, and make it easy to innovate and publish on the cloud, on the desktop, and on smart connected devices for the internet of things. We work across the full range of open source - from the kernel, to applications, from deep system services to the GUI and the web. We care about security, correctness, reliability, performance and efficiency. If you share those values and you have a track record of exceptional software development, this is the place for you.
+      </p>
+      <p>
+        With the flexibility to work from anywhere in the world as long as you are an outstanding and reliable team member, Canonical offers engineering career paths that include technical mastery, leadership, or management. We don’t prescribe your journey - explore different kinds of career development and choose the path that suits you best. We do expect world-leading software quality and personal dedication to the challenges you take on.
+      </p>
+      <p>
+        Engineering at Canonical ranges from deep single-product specialization, to diverse customer-centric field integration, delivery and development, and high-pressure rapid-response to critical situations in our techops team. The right career for you will depend on your interests and aptitudes. If you love the idea of travel and seeing the world, our field engineers work on-site with the world’s best companies to transform their open infrastructure. If you love saving the day, our techops teams fight fires shoulder to shoulder, from security incident response to deep problem analysis and repair. If you love operations, we take a code-first approach to infrastructure and application operations that is raising the bar for the entire industry.
+      </p>
+      <p>
+        We see all of these as engineering roles and we encourage people to build a career that spans diverse aspects of software development and operations. Regardless of your starting point, as long as you are performing well you have the option to progress in any of those roles, or to gain experience in management or technical leadership.
+      </p>
+      <p>
+        Engineering is a calling - it’s a way of thinking, not just a job. You know you will fit in at Canonical if you have consistently sought out the opportunity to write code to solve problems, from the moment you first had access to a PC. You’ll know you  fit in if you have consistently taken on the most difficult mental challenges you could, and shone brightly amongst your peers in doing so. Join us to take that to the next level - the problems we solve enable the world’s fiercest innovators and protect the world’s most critical systems. Canonical is where software engineers make a difference - to every industry and every society.
+      </p>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12">
+      <hr />
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12">
+      <p class="p-muted-heading">
+        <span style="text-transform: capitalize">Europe&nbsp;&#124;&nbsp;Middle East&nbsp;&#124;&nbsp;Africa&nbsp;&#124;&nbsp;Americas&nbsp;&#124;&nbsp;APAC</span>
+      </p>
+      <a href="#">Apply now&nbsp;&rsaquo;</a>
+    </div>
+  </div>
 {% endblock %}
 
 {% block available_roles %}

--- a/templates/careers/engineering.html
+++ b/templates/careers/engineering.html
@@ -14,34 +14,40 @@
 
 {% block overview %}
   <div class="p-strip is-shallow u-extra-space tab-content" id="overview">
-    <div class="u-fixed-width">
-      <p>
-        <strong>Open source is transforming the entire stack. This is your chance to be right at the center of that revolution, to shape the platforms and tools that millions use to invent our global technology future. From bare metal to cloud to high performance computing, from AI and big data to the web and connected devices, open source is the key ingredient for success. Canonical offers the opportunity to work across the entire spectrum.</strong>
-      </p>
-      <p>
-        We publish Ubuntu, the leanest and most efficient open source platform. We care about developer access to the very best of open source, and make it easy to innovate and publish on the cloud, on the desktop, and on smart connected devices for the internet of things. We work across the full range of open source - from the kernel, to applications, from deep system services to the GUI and the web. We care about security, correctness, reliability, performance and efficiency. If you share those values and you have a track record of exceptional software development, this is the place for you.
-      </p>
-      <p>
-        With the flexibility to work from anywhere in the world as long as you are an outstanding and reliable team member, Canonical offers engineering career paths that include technical mastery, leadership, or management. We don’t prescribe your journey - explore different kinds of career development and choose the path that suits you best. We do expect world-leading software quality and personal dedication to the challenges you take on.
-      </p>
-      <p>
-        Engineering at Canonical ranges from deep single-product specialization, to diverse customer-centric field integration, delivery and development, and high-pressure rapid-response to critical situations in our techops team. The right career for you will depend on your interests and aptitudes. If you love the idea of travel and seeing the world, our field engineers work on-site with the world’s best companies to transform their open infrastructure. If you love saving the day, our techops teams fight fires shoulder to shoulder, from security incident response to deep problem analysis and repair. If you love operations, we take a code-first approach to infrastructure and application operations that is raising the bar for the entire industry.
-      </p>
-      <p>
-        We see all of these as engineering roles and we encourage people to build a career that spans diverse aspects of software development and operations. Regardless of your starting point, as long as you are performing well you have the option to progress in any of those roles, or to gain experience in management or technical leadership.
-      </p>
-      <p>
-        Engineering is a calling - it’s a way of thinking, not just a job. You know you will fit in at Canonical if you have consistently sought out the opportunity to write code to solve problems, from the moment you first had access to a PC. You’ll know you  fit in if you have consistently taken on the most difficult mental challenges you could, and shone brightly amongst your peers in doing so. Join us to take that to the next level - the problems we solve enable the world’s fiercest innovators and protect the world’s most critical systems. Canonical is where software engineers make a difference - to every industry and every society.
-      </p>
+    <div class="row">
+      <div class="col-12">
+        <p>
+          <strong>Open source is transforming the entire stack. This is your chance to be right at the center of that revolution, to shape the platforms and tools that millions use to invent our global technology future. From bare metal to cloud to high performance computing, from AI and big data to the web and connected devices, open source is the key ingredient for success. Canonical offers the opportunity to work across the entire spectrum.</strong>
+        </p>
+        <p>
+          We publish Ubuntu, the leanest and most efficient open source platform. We care about developer access to the very best of open source, and make it easy to innovate and publish on the cloud, on the desktop, and on smart connected devices for the internet of things. We work across the full range of open source - from the kernel, to applications, from deep system services to the GUI and the web. We care about security, correctness, reliability, performance and efficiency. If you share those values and you have a track record of exceptional software development, this is the place for you.
+        </p>
+        <p>
+          With the flexibility to work from anywhere in the world as long as you are an outstanding and reliable team member, Canonical offers engineering career paths that include technical mastery, leadership, or management. We don’t prescribe your journey - explore different kinds of career development and choose the path that suits you best. We do expect world-leading software quality and personal dedication to the challenges you take on.
+        </p>
+        <p>
+          Engineering at Canonical ranges from deep single-product specialization, to diverse customer-centric field integration, delivery and development, and high-pressure rapid-response to critical situations in our techops team. The right career for you will depend on your interests and aptitudes. If you love the idea of travel and seeing the world, our field engineers work on-site with the world’s best companies to transform their open infrastructure. If you love saving the day, our techops teams fight fires shoulder to shoulder, from security incident response to deep problem analysis and repair. If you love operations, we take a code-first approach to infrastructure and application operations that is raising the bar for the entire industry.
+        </p>
+        <p>
+          We see all of these as engineering roles and we encourage people to build a career that spans diverse aspects of software development and operations. Regardless of your starting point, as long as you are performing well you have the option to progress in any of those roles, or to gain experience in management or technical leadership.
+        </p>
+        <p>
+          Engineering is a calling - it’s a way of thinking, not just a job. You know you will fit in at Canonical if you have consistently sought out the opportunity to write code to solve problems, from the moment you first had access to a PC. You’ll know you  fit in if you have consistently taken on the most difficult mental challenges you could, and shone brightly amongst your peers in doing so. Join us to take that to the next level - the problems we solve enable the world’s fiercest innovators and protect the world’s most critical systems. Canonical is where software engineers make a difference - to every industry and every society.
+        </p>
+      </div>
     </div>
-    <div class="u-fixed-width">
-      <hr />
+    <div class="row">
+      <div class="col-12">
+        <hr />
+      </div>
     </div>
-    <div class="u-fixed-width">
-      <p class="p-muted-heading">
-        <span style="text-transform: capitalize">Europe&nbsp;&#124;&nbsp;Middle East&nbsp;&#124;&nbsp;Africa&nbsp;&#124;&nbsp;Americas&nbsp;&#124;&nbsp;APAC</span>
-      </p>
-      <a href="#">Apply now&nbsp;&rsaquo;</a>
+    <div class="row">
+      <div class="col-12">
+        <p class="p-muted-heading">
+          <span style="text-transform: capitalize">Europe&nbsp;&#124;&nbsp;Middle East&nbsp;&#124;&nbsp;Africa&nbsp;&#124;&nbsp;Americas&nbsp;&#124;&nbsp;APAC</span>
+        </p>
+        <a href="#">Apply now&nbsp;&rsaquo;</a>
+      </div>
     </div>
   </div>
 {% endblock %}

--- a/templates/careers/engineering.html
+++ b/templates/careers/engineering.html
@@ -39,11 +39,3 @@
     </div>
   </div>
 {% endblock %}
-
-{% block available_roles %}
-
-{% endblock %}
-
-{% block send_cv %}
-
-{% endblock %}

--- a/templates/careers/ethics.html
+++ b/templates/careers/ethics.html
@@ -1,0 +1,26 @@
+{% extends '/careers/careers_base.html' %}
+
+{% block title %}<h1>Ethics</h1>{% endblock %}
+
+{% block meta_description %}Trust in Canonical’s Ubuntu and other products is well-earned and critical to our future. We have a very high expectation of ethical behaviour at the company and in particular among leaders of any sort.{% endblock %}
+
+{% block overview %}
+  <div class="row">
+    <div class="col-12">
+      <p>
+        <strong>Trust is our most precious asset. We take our responsible for the most critical elements of every piece of open infrastructure in the software-defined world very seriously, and we are committed to quality in every aspect of our product and services. When people deploy Ubuntu, they trust Canonical to ensure that it is secure and robust, that it represents the best balance of possibility and pragmatism, and that it is the best way for them to benefit from and participate in the open source movement.</strong>
+      </p>
+      <p>
+        From time to time we know everybody has tough choices to make. We support our leads in doing things properly, even if that means taking extra time. We expect a high level of productivity but we expect much of that effort to go into quality. Most importantly, we have an uncompromising approach to ethics and do not tolerate ambiguity when it comes to the interests of our customers. Ethical failures are grounds for dismissal from the team.
+      </p>
+    </div>
+  </div>
+{% endblock %}
+
+{% block available_roles %}
+
+{% endblock %}
+
+{% block send_cv %}
+
+{% endblock %}

--- a/templates/careers/ethics.html
+++ b/templates/careers/ethics.html
@@ -18,7 +18,10 @@
   <div class="row">
     <div class="col-12">
       <p>
-        <strong>Trust is our most precious asset. We take our responsible for the most critical elements of every piece of open infrastructure in the software-defined world very seriously, and we are committed to quality in every aspect of our product and services. When people deploy Ubuntu, they trust Canonical to ensure that it is secure and robust, that it represents the best balance of possibility and pragmatism, and that it is the best way for them to benefit from and participate in the open source movement.</strong>
+        <strong>Trust is our most precious asset.</strong>
+      </p>
+      <p>
+        We take our responsible for the most critical elements of every piece of open infrastructure in the software-defined world very seriously, and we are committed to quality in every aspect of our product and services. When people deploy Ubuntu, they trust Canonical to ensure that it is secure and robust, that it represents the best balance of possibility and pragmatism, and that it is the best way for them to benefit from and participate in the open source movement.
       </p>
       <p>
         From time to time we know everybody has tough choices to make. We support our leads in doing things properly, even if that means taking extra time. We expect a high level of productivity but we expect much of that effort to go into quality. Most importantly, we have an uncompromising approach to ethics and do not tolerate ambiguity when it comes to the interests of our customers. Ethical failures are grounds for dismissal from the team.

--- a/templates/careers/ethics.html
+++ b/templates/careers/ethics.html
@@ -1,8 +1,18 @@
 {% extends '/careers/careers_base.html' %}
 
-{% block title %}<h1>Ethics</h1>{% endblock %}
-
 {% block meta_description %}Trust in Canonical’s Ubuntu and other products is well-earned and critical to our future. We have a very high expectation of ethical behaviour at the company and in particular among leaders of any sort.{% endblock %}
+
+{% block hero %}
+  <section class="p-strip--image is-dark is-deep u-no-padding--top u-no-padding--bottom u-extra-space">
+    <div class="p-strip--suru-background">
+      <div class="row">
+        <div class="col-6">
+          <h1>Ethics</h1>
+        </div>
+      </div>
+    </div>
+  </section>
+{% endblock %}
 
 {% block overview %}
   <div class="row">

--- a/templates/careers/ethics.html
+++ b/templates/careers/ethics.html
@@ -16,11 +16,3 @@
     </div>
   </div>
 {% endblock %}
-
-{% block available_roles %}
-
-{% endblock %}
-
-{% block send_cv %}
-
-{% endblock %}

--- a/templates/careers/finance.html
+++ b/templates/careers/finance.html
@@ -1,8 +1,6 @@
 {% extends '/careers/careers_base.html' %}
 
-{% block title %}
-  <h1>Finance</h1>
-{% endblock %}
+{% block title %}<h1>Finance</h1>{% endblock %}
 
 {% block overview %}
 

--- a/templates/careers/finance.html
+++ b/templates/careers/finance.html
@@ -5,11 +5,3 @@
 {% block overview %}
 
 {% endblock %}
-
-{% block available_roles %}
-
-{% endblock %}
-
-{% block send_cv %}
-
-{% endblock %}

--- a/templates/careers/hr.html
+++ b/templates/careers/hr.html
@@ -1,31 +1,43 @@
 {% extends '/careers/careers_base.html' %}
 
-{% block title %}<h1>HR</h1>{% endblock %}
+{% block hero %}
+  <section class="p-strip--image is-dark is-deep u-no-padding--top u-no-padding--bottom u-extra-space">
+    <div class="p-strip--suru-background">
+      <div class="row">
+        <div class="col-6">
+          <h1>HR</h1>
+        </div>
+      </div>
+    </div>
+  </section>
+{% endblock %}
 
 {% block overview %}
-  <div class="row">
-    <div class="col-12">
-      <p><strong>Canonical provides a unique window into the world of 21st-century digital business. We work with smart individuals from a wide range of professional backgrounds in more than 40 countries worldwide, bringing together distinct and diverse perspectives to contribute to the advancement of state-of-the-art technical infrastructure. Our team is united by a passion for open engineering and a commitment to crisp, reliable execution which enables us to exceed our customers’ expectations when it comes to next-generation open source technology.</strong>
-      </p>
-      <p>
-        Our set-up provides a unique challenge for our HR team, who ensure that we operate consistently on a global basis and are compliant with regional and national regulations. If you are interested in finding, coaching, and developing the best talent, Canonical encourages our management team to hire the best person for the job, no matter who they are or where they are located. If you are fascinated by the technical and legal aspects of HR, Canonical will give you the chance to work with teams in multiple jurisdictions, from Asia to the Americas and so many places in between.
-      </p>
-      <p>
-        We pride ourselves on exceptional quality of work and our HR team embody and build that quality within Canonical. Our HR team is central to the development and growth of that capacity and competence. Our commitment to the team is to seek out potential colleagues with the right mix of interests, aptitudes and attitudes, to coach and develop them through a varied career ensuring that they have the right opportunities to learn and the right mix of challenges to suit their interests. Our commitment to the business is to ensure that we operate consistently on a global basis, mindful of the details of regional and national regulations. We are also committed to offering our HR and talent professionals the coaching, learning opportunities, and challenges that will enable them to create a varied and successful career.
-      </p>
+  <div class="p-strip is-shallow u-extra-space tab-content" id="overview">
+    <div class="row">
+      <div class="col-12">
+        <p><strong>Canonical provides a unique window into the world of 21st-century digital business. We work with smart individuals from a wide range of professional backgrounds in more than 40 countries worldwide, bringing together distinct and diverse perspectives to contribute to the advancement of state-of-the-art technical infrastructure. Our team is united by a passion for open engineering and a commitment to crisp, reliable execution which enables us to exceed our customers’ expectations when it comes to next-generation open source technology.</strong>
+        </p>
+        <p>
+          Our set-up provides a unique challenge for our HR team, who ensure that we operate consistently on a global basis and are compliant with regional and national regulations. If you are interested in finding, coaching, and developing the best talent, Canonical encourages our management team to hire the best person for the job, no matter who they are or where they are located. If you are fascinated by the technical and legal aspects of HR, Canonical will give you the chance to work with teams in multiple jurisdictions, from Asia to the Americas and so many places in between.
+        </p>
+        <p>
+          We pride ourselves on exceptional quality of work and our HR team embody and build that quality within Canonical. Our HR team is central to the development and growth of that capacity and competence. Our commitment to the team is to seek out potential colleagues with the right mix of interests, aptitudes and attitudes, to coach and develop them through a varied career ensuring that they have the right opportunities to learn and the right mix of challenges to suit their interests. Our commitment to the business is to ensure that we operate consistently on a global basis, mindful of the details of regional and national regulations. We are also committed to offering our HR and talent professionals the coaching, learning opportunities, and challenges that will enable them to create a varied and successful career.
+        </p>
+      </div>
     </div>
-  </div>
-  <div class="row">
-    <div class="col-12">
-      <hr />
+    <div class="row">
+      <div class="col-12">
+        <hr />
+      </div>
     </div>
-  </div>
-  <div class="row">
-    <div class="col-12">
-      <p class="p-muted-heading">
-        <span style="text-transform: capitalize">Europe&nbsp;&#124;&nbsp;Americas</span>
-      </p>
-      <a href="#">Apply now&nbsp;&rsaquo;</a>
+    <div class="row">
+      <div class="col-12">
+        <p class="p-muted-heading">
+          <span style="text-transform: capitalize">Europe&nbsp;&#124;&nbsp;Americas</span>
+        </p>
+        <a href="#">Apply now&nbsp;&rsaquo;</a>
+      </div>
     </div>
   </div>
 {% endblock %}

--- a/templates/careers/hr.html
+++ b/templates/careers/hr.html
@@ -1,11 +1,33 @@
 {% extends '/careers/careers_base.html' %}
 
-{% block title %}
-  <h1>HR</h1>
-{% endblock %}
+{% block title %}<h1>HR</h1>{% endblock %}
 
 {% block overview %}
-
+  <div class="row">
+    <div class="col-12">
+      <p><strong>Canonical provides a unique window into the world of 21st-century digital business. We work with smart individuals from a wide range of professional backgrounds in more than 40 countries worldwide, bringing together distinct and diverse perspectives to contribute to the advancement of state-of-the-art technical infrastructure. Our team is united by a passion for open engineering and a commitment to crisp, reliable execution which enables us to exceed our customers’ expectations when it comes to next-generation open source technology.</strong>
+      </p>
+      <p>
+        Our set-up provides a unique challenge for our HR team, who ensure that we operate consistently on a global basis and are compliant with regional and national regulations. If you are interested in finding, coaching, and developing the best talent, Canonical encourages our management team to hire the best person for the job, no matter who they are or where they are located. If you are fascinated by the technical and legal aspects of HR, Canonical will give you the chance to work with teams in multiple jurisdictions, from Asia to the Americas and so many places in between.
+      </p>
+      <p>
+        We pride ourselves on exceptional quality of work and our HR team embody and build that quality within Canonical. Our HR team is central to the development and growth of that capacity and competence. Our commitment to the team is to seek out potential colleagues with the right mix of interests, aptitudes and attitudes, to coach and develop them through a varied career ensuring that they have the right opportunities to learn and the right mix of challenges to suit their interests. Our commitment to the business is to ensure that we operate consistently on a global basis, mindful of the details of regional and national regulations. We are also committed to offering our HR and talent professionals the coaching, learning opportunities, and challenges that will enable them to create a varied and successful career.
+      </p>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12">
+      <hr />
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12">
+      <p class="p-muted-heading">
+        <span style="text-transform: capitalize">Europe&nbsp;&#124;&nbsp;Americas</span>
+      </p>
+      <a href="#">Apply now&nbsp;&rsaquo;</a>
+    </div>
+  </div>
 {% endblock %}
 
 {% block available_roles %}

--- a/templates/careers/hr.html
+++ b/templates/careers/hr.html
@@ -29,7 +29,3 @@
     </div>
   </div>
 {% endblock %}
-
-{% block available_roles %}
-
-{% endblock %}

--- a/templates/careers/legal.html
+++ b/templates/careers/legal.html
@@ -32,11 +32,3 @@
     </div>
   </div>
 {% endblock %}
-
-{% block available_roles %}
-
-{% endblock %}
-
-{% block send_cv %}
-
-{% endblock %}

--- a/templates/careers/legal.html
+++ b/templates/careers/legal.html
@@ -1,34 +1,46 @@
 {% extends '/careers/careers_base.html' %}
 
-{% block title %}<h1>Legal</h1>{% endblock %}
+{% block hero %}
+  <section class="p-strip--image is-dark is-deep u-no-padding--top u-no-padding--bottom u-extra-space">
+    <div class="p-strip--suru-background">
+      <div class="row">
+        <div class="col-6">
+          <h1>Legal</h1>
+        </div>
+      </div>
+    </div>
+  </section>
+{% endblock %}
 
 {% block overview %}
-  <div class="row">
-    <div class="col-12">
-      <p><strong>Canonical works at the forefront of global digital trends and the legal, licensing and regulatory frameworks that support them. We are a tight-knit team of professionals that enjoy playing a part in the rapid change of the software landscape to open infrastructure and applications, while supporting a fast-moving and global business.</strong>
-      </p>
-      <p>
-        Enabling enterprises, partners and technology providers across the globe to embrace the latest open source technology means efficient contracting that is both commercially sophisticated and technically interesting. We shape multinational agreements between many of the very largest organisations in a wide range of industries - from telecommunications to retail, financial services to media. And we participate in the world wide process to define and understand the future of collaborative engineering, as open source licenses explore new ways to support the creation of open software by companies and individual contributors.
-      </p>
-      <p>
-        Our goal is to reflect the simplest, cleanest and most understandable contractual framework to our counterparts, that represents current best practice and the latest approaches to software production, consumption and distribution. We pride ourselves on the combination of rigour and business enablement - we support complex deals in a way that protects all parties and minimises friction.
-      </p>
-      <p>
-        Experience at Canonical offers rapid growth in understanding the global legal landscape, both in terms of technology, but also in terms of commercial and corporate contracting. We welcome candidates with an outstanding track record, a commitment to teamwork, and a personal interest in the future of software and the legal frameworks that underpin it.
-      </p>
+  <div class="p-strip is-shallow u-extra-space tab-content" id="overview">
+    <div class="row">
+      <div class="col-12">
+        <p><strong>Canonical works at the forefront of global digital trends and the legal, licensing and regulatory frameworks that support them. We are a tight-knit team of professionals that enjoy playing a part in the rapid change of the software landscape to open infrastructure and applications, while supporting a fast-moving and global business.</strong>
+        </p>
+        <p>
+          Enabling enterprises, partners and technology providers across the globe to embrace the latest open source technology means efficient contracting that is both commercially sophisticated and technically interesting. We shape multinational agreements between many of the very largest organisations in a wide range of industries - from telecommunications to retail, financial services to media. And we participate in the world wide process to define and understand the future of collaborative engineering, as open source licenses explore new ways to support the creation of open software by companies and individual contributors.
+        </p>
+        <p>
+          Our goal is to reflect the simplest, cleanest and most understandable contractual framework to our counterparts, that represents current best practice and the latest approaches to software production, consumption and distribution. We pride ourselves on the combination of rigour and business enablement - we support complex deals in a way that protects all parties and minimises friction.
+        </p>
+        <p>
+          Experience at Canonical offers rapid growth in understanding the global legal landscape, both in terms of technology, but also in terms of commercial and corporate contracting. We welcome candidates with an outstanding track record, a commitment to teamwork, and a personal interest in the future of software and the legal frameworks that underpin it.
+        </p>
+      </div>
     </div>
-  </div>
-  <div class="row">
-    <div class="col-12">
-      <hr />
+    <div class="row">
+      <div class="col-12">
+        <hr />
+      </div>
     </div>
-  </div>
-  <div class="row">
-    <div class="col-12">
-      <p class="p-muted-heading">
-        <span style="text-transform: capitalize">Europe&nbsp;&#124;&nbsp;Americas</span>
-      </p>
-      <a href="#">Apply now&nbsp;&rsaquo;</a>
+    <div class="row">
+      <div class="col-12">
+        <p class="p-muted-heading">
+          <span style="text-transform: capitalize">Europe&nbsp;&#124;&nbsp;Americas</span>
+        </p>
+        <a href="#">Apply now&nbsp;&rsaquo;</a>
+      </div>
     </div>
   </div>
 {% endblock %}

--- a/templates/careers/legal.html
+++ b/templates/careers/legal.html
@@ -1,11 +1,36 @@
 {% extends '/careers/careers_base.html' %}
 
-{% block title %}
-  <h1>Legal</h1>
-{% endblock %}
+{% block title %}<h1>Legal</h1>{% endblock %}
 
 {% block overview %}
-
+  <div class="row">
+    <div class="col-12">
+      <p><strong>Canonical works at the forefront of global digital trends and the legal, licensing and regulatory frameworks that support them. We are a tight-knit team of professionals that enjoy playing a part in the rapid change of the software landscape to open infrastructure and applications, while supporting a fast-moving and global business.</strong>
+      </p>
+      <p>
+        Enabling enterprises, partners and technology providers across the globe to embrace the latest open source technology means efficient contracting that is both commercially sophisticated and technically interesting. We shape multinational agreements between many of the very largest organisations in a wide range of industries - from telecommunications to retail, financial services to media. And we participate in the world wide process to define and understand the future of collaborative engineering, as open source licenses explore new ways to support the creation of open software by companies and individual contributors.
+      </p>
+      <p>
+        Our goal is to reflect the simplest, cleanest and most understandable contractual framework to our counterparts, that represents current best practice and the latest approaches to software production, consumption and distribution. We pride ourselves on the combination of rigour and business enablement - we support complex deals in a way that protects all parties and minimises friction.
+      </p>
+      <p>
+        Experience at Canonical offers rapid growth in understanding the global legal landscape, both in terms of technology, but also in terms of commercial and corporate contracting. We welcome candidates with an outstanding track record, a commitment to teamwork, and a personal interest in the future of software and the legal frameworks that underpin it.
+      </p>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12">
+      <hr />
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12">
+      <p class="p-muted-heading">
+        <span style="text-transform: capitalize">Europe&nbsp;&#124;&nbsp;Americas</span>
+      </p>
+      <a href="#">Apply now&nbsp;&rsaquo;</a>
+    </div>
+  </div>
 {% endblock %}
 
 {% block available_roles %}

--- a/templates/careers/lifestyle.html
+++ b/templates/careers/lifestyle.html
@@ -1,8 +1,18 @@
 {% extends '/careers/careers_base.html' %}
 
-{% block title %}<h1>Lifestyle</h1>{% endblock %}
-
 {% block meta_description %}Canonical offers a truly distributed workplace for exceptional colleagues who are self-motivated, organised. Maintain a home office and experience the top of global technology strategy and engineering. Travel regularly to interesting destinations for team, conference and customer engagements.{% endblock %}
+
+{% block hero %}
+  <section class="p-strip--image is-dark is-deep u-no-padding--top u-no-padding--bottom u-extra-space">
+    <div class="p-strip--suru-background">
+      <div class="row">
+        <div class="col-6">
+          <h1>Lifestyle</h1>
+        </div>
+      </div>
+    </div>
+  </section>
+{% endblock %}
 
 {% block overview %}
   <div class="row">

--- a/templates/careers/lifestyle.html
+++ b/templates/careers/lifestyle.html
@@ -12,6 +12,35 @@
       </div>
     </div>
   </section>
+  <style>
+    .p-strip--suru-background {
+      background-image:
+        linear-gradient(120deg,transparent 40%, rgba(74, 24, 60, 0.4) 50%, rgba(74, 24, 60, 0.4) 100%),
+        linear-gradient(to top right, rgba(74,24,60,0) 0%, rgba(74,24,60,0) 49.9%, rgba(74, 24, 60, 0.4) 50%, rgba(74, 24, 60, 0.4) 100%),
+        linear-gradient(to top left, #fff 0%, #fff 49%, transparent 50%),
+        linear-gradient(to bottom right, rgba(210,180,202,0.05) 0%, rgba(210,180,202,0.05) 49.9%, rgba(210,180,202,0) 50%, rgba(210,180,202,0) 100%),
+        linear-gradient(120deg, #2C001E 4%, #4C193E 54.9%, transparent 55%),
+        url('https://assets.ubuntu.com/v1/883df027-canonical-travel.jpg');
+      background-position: right top, right top, bottom -1px right -1px, top left, top left, center right, right bottom;
+      background-repeat: no-repeat;
+      background-size: 100% 90%, 85% 100%, 105% 25%, 70% 80%, 100% 100%, 65% auto;
+      padding-bottom: 6rem;
+      padding-top: 6rem;
+    }
+
+    @media (max-width: 620px) {
+      .p-strip--suru-background {
+        background-image:
+          linear-gradient(to top right, rgba(74,24,60,0) 0%, rgba(74,24,60,0) 49.9%, rgba(74, 24, 60, 0.4) 50%, rgba(74, 24, 60, 0.4) 100%),
+          linear-gradient(to top left, #fff 0%, #fff 49%, transparent 50%),
+          linear-gradient(to bottom right, rgba(210,180,202,0.05) 0%, rgba(210,180,202,0.05) 49.9%, rgba(210,180,202,0) 50%, rgba(210,180,202,0) 100%),
+          linear-gradient(120deg, #2C001E  4%,  #4C193E 100%);
+        background-position: right top, bottom right, top left, top left, center right;
+        background-repeat: no-repeat;
+        background-size: 100% 100%, 105% 25%, 70% 80%, 100% 100%;
+      }
+    }
+  </style>
 {% endblock %}
 
 {% block overview %}
@@ -22,6 +51,9 @@
       </p>
       <p>
         We’re a technology company. Every role at Canonical is a tech role. We have a high expectation of fluency and competence and passion for technology regardless of your title. The future is already here, as open source, and Canonical’s mission is to deliver it to the world. We are part of the biggest change in technology history - to open source - and we play a critical role in broadening the benefits of open source to ever more people. Every role at the company involves good judgment against the backdrop of the fast-moving technology landscape. We look for people who find that interesting.
+      </p>
+      <p>
+        Second, we’re a fully distributed organisation. Most people work from home, using the latest communications technology to be productive and maintain a who find that interesting.
       </p>
       <p>
         Second, we’re a fully distributed organisation. Most people work from home, using the latest communications technology to be productive and maintain a high level of coordination with colleagues. Digital collaboration is how we enable people to enjoy their home environment AND work with the best in the world in their domain. Zero commute means more time for the things you enjoy, it also means you need to be organized and effective in a distributed workplace. You get tremendous, perhaps unprecedented, flexibility in how you organise your day. At the same time, you have to be productive and a good counterpart to colleagues around the world. You need to be a team player, and you need to deliver what you promise, because teams depend on each other and don’t have daily eyes on one another. We have very little office politics but we do have very high expectations of commitment and independent execution. We also travel more than most companies, because our customers and our teams are global, and we need regular face-time with both.

--- a/templates/careers/lifestyle.html
+++ b/templates/careers/lifestyle.html
@@ -1,0 +1,24 @@
+{% extends '/careers/careers_base.html' %}
+
+{% block title %}<h1>Lifestyle</h1>{% endblock %}
+
+{% block meta_description %}Canonical offers a truly distributed workplace for exceptional colleagues who are self-motivated, organised. Maintain a home office and experience the top of global technology strategy and engineering. Travel regularly to interesting destinations for team, conference and customer engagements.{% endblock %}
+
+{% block overview %}
+  <div class="row">
+    <div class="col-12">
+      <p>
+        <strong>Canonical is unlike any other company in the world. It’s not for everybody, but it is amazing for people who are organized, passionate about technology, and like to travel. People at Canonical say the people at Canonical are amazing. That’s special.</strong>
+      </p>
+      <p>
+        We’re a technology company. Every role at Canonical is a tech role. We have a high expectation of fluency and competence and passion for technology regardless of your title. The future is already here, as open source, and Canonical’s mission is to deliver it to the world. We are part of the biggest change in technology history - to open source - and we play a critical role in broadening the benefits of open source to ever more people. Every role at the company involves good judgment against the backdrop of the fast-moving technology landscape. We look for people who find that interesting.
+      </p>
+      <p>
+        Second, we’re a fully distributed organisation. Most people work from home, using the latest communications technology to be productive and maintain a high level of coordination with colleagues. Digital collaboration is how we enable people to enjoy their home environment AND work with the best in the world in their domain. Zero commute means more time for the things you enjoy, it also means you need to be organized and effective in a distributed workplace. You get tremendous, perhaps unprecedented, flexibility in how you organise your day. At the same time, you have to be productive and a good counterpart to colleagues around the world. You need to be a team player, and you need to deliver what you promise, because teams depend on each other and don’t have daily eyes on one another. We have very little office politics but we do have very high expectations of commitment and independent execution. We also travel more than most companies, because our customers and our teams are global, and we need regular face-time with both.
+      </p>
+      <p>
+        Third, we aspire to lead on the global stage. There’s no other way to describe it than hard - hard work, hard challenges, hard competition. Most of us are avid students of greatness - we are interested in how the latest things work, how the best organizations work, how the smartest companies work, and we aim to hold our own in that crowd. You will need to show that you can compete in deeply challenging intellectual fields. Your colleagues are aiming for the top, and they depend on you to set the same standard in your area of responsibility. That’s tough. It’s also incredibly satisfying, with continuous learning and challenge. You will have exceptional opportunities and exceptional colleagues. They will expect you to be exceptional too.
+      </p>
+    </div>
+  </div>
+{% endblock %}

--- a/templates/careers/management.html
+++ b/templates/careers/management.html
@@ -1,7 +1,0 @@
-{% extends '/careers/careers_base.html' %}
-
-{% block title %}<h1>Management</h1>{% endblock %}
-
-{% block overview %}
-
-{% endblock %}

--- a/templates/careers/management.html
+++ b/templates/careers/management.html
@@ -5,11 +5,3 @@
 {% block overview %}
 
 {% endblock %}
-
-{% block available_roles %}
-
-{% endblock %}
-
-{% block send_cv %}
-
-{% endblock %}

--- a/templates/careers/management.html
+++ b/templates/careers/management.html
@@ -1,8 +1,6 @@
 {% extends '/careers/careers_base.html' %}
 
-{% block title %}
-  <h1>Management</h1>
-{% endblock %}
+{% block title %}<h1>Management</h1>{% endblock %}
 
 {% block overview %}
 

--- a/templates/careers/marketing.html
+++ b/templates/careers/marketing.html
@@ -1,11 +1,43 @@
 {% extends '/careers/careers_base.html' %}
 
-{% block title %}
-  <h1>Marketing</h1>
-{% endblock %}
+{% block title %}<h1>Marketing</h1>{% endblock %}
 
 {% block overview %}
-
+  <div class="row">
+    <div class="col-12">
+      <p>
+        <strong>We deliver the right technology message to a highly competent audience, at exactly the right moment. Success depends on having good instincts for tech trends and topics and a natural inclination to leadership.</strong>
+      </p>
+      <p>
+        The best candidates for marketing at Canonical love technology and words. They are tech-savvy and are comfortable working with data at scale - in spreadsheets, business analytics suites and databases. They love data visualisation and presentation. They are passionate about message and language, and strive to find the best way to share a powerful idea that leads people to act.
+      </p>
+      <p>
+        Canonical has a global following of sophisticated tech readers and decision makers, constantly evaluating the state of the art for open infrastructure and applications. Your mission is to reach them at precisely the right moment with clear information showing that Ubuntu and Canonical’s solutions deliver the very best in quality and economics. It’s a fast-paced, high stakes responsibility that demands a high level of intellect and work ethic.
+      </p>
+      <p>
+        Our team also understands that it’s not just about broadcast, it’s about feedback, measurement, iteration and improvement. We use analytics to understand how the world is consuming our narrative, and technology to sift through mountains of engagement data to spot the opportunities that are ready to explore further. We delight in showing that we can engineer growth in engagement, awareness, consumption and commerce just as effectively as our colleagues in software development engineer reliability and performance in their products. We are growth hackers at heart. As the tools evolve, so do we, which creates a learning environment that celebrates new ideas which can prove their effectiveness. We’re a tiny company in an industry of giants, so we have always punched way above our weight and that’s exactly what we expect from new members of the team too.
+      </p>
+      <p>
+        In marketing you are a representative of Canonical and you are an advocate of our brands and products. We all work together across the full portfolio - you are expected to understand the big picture of how Canonical’s products fit together, there are no siloes. These are not behind-the-scenes roles, they are public leadership roles. We expect our team to be just as comfortable delivering our message online as they are face to face at meetups, meetings, conferences, partner workshops, or press events. From the analyst community to the tech press, from the CIO to the graduate engineer, from prospects to existing customers, we think Ubuntu should be the starting point for technology transformation around open source, and our marketing team are the amplifier for our message.
+      </p>
+      <p>
+        This team is all about having the confidence in our ideas and our quality to put us squarely into the frame for companies thinking afresh about their biggest technology questions. Join us if you are passionate about digital marketing and technology products.
+      </p>
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12">
+      <hr />
+    </div>
+  </div>
+  <div class="row">
+    <div class="col-12">
+      <p class="p-muted-heading">
+        <span>Emea</span>&nbsp;&#124;&nbsp;<span style="text-transform: capitalize">Americas</span>
+      </p>
+      <a href="#">Apply now&nbsp;&rsaquo;</a>
+    </div>
+  </div>
 {% endblock %}
 
 {% block available_roles %}

--- a/templates/careers/marketing.html
+++ b/templates/careers/marketing.html
@@ -1,41 +1,53 @@
 {% extends '/careers/careers_base.html' %}
 
-{% block title %}<h1>Marketing</h1>{% endblock %}
+{% block hero %}
+  <section class="p-strip--image is-dark is-deep u-no-padding--top u-no-padding--bottom u-extra-space">
+    <div class="p-strip--suru-background">
+      <div class="row">
+        <div class="col-6">
+          <h1>Marketing</h1>
+        </div>
+      </div>
+    </div>
+  </section>
+{% endblock %}
 
 {% block overview %}
-  <div class="row">
-    <div class="col-12">
-      <p>
-        <strong>We deliver the right technology message to a highly competent audience, at exactly the right moment. Success depends on having good instincts for tech trends and topics and a natural inclination to leadership.</strong>
-      </p>
-      <p>
-        The best candidates for marketing at Canonical love technology and words. They are tech-savvy and are comfortable working with data at scale - in spreadsheets, business analytics suites and databases. They love data visualisation and presentation. They are passionate about message and language, and strive to find the best way to share a powerful idea that leads people to act.
-      </p>
-      <p>
-        Canonical has a global following of sophisticated tech readers and decision makers, constantly evaluating the state of the art for open infrastructure and applications. Your mission is to reach them at precisely the right moment with clear information showing that Ubuntu and Canonical’s solutions deliver the very best in quality and economics. It’s a fast-paced, high stakes responsibility that demands a high level of intellect and work ethic.
-      </p>
-      <p>
-        Our team also understands that it’s not just about broadcast, it’s about feedback, measurement, iteration and improvement. We use analytics to understand how the world is consuming our narrative, and technology to sift through mountains of engagement data to spot the opportunities that are ready to explore further. We delight in showing that we can engineer growth in engagement, awareness, consumption and commerce just as effectively as our colleagues in software development engineer reliability and performance in their products. We are growth hackers at heart. As the tools evolve, so do we, which creates a learning environment that celebrates new ideas which can prove their effectiveness. We’re a tiny company in an industry of giants, so we have always punched way above our weight and that’s exactly what we expect from new members of the team too.
-      </p>
-      <p>
-        In marketing you are a representative of Canonical and you are an advocate of our brands and products. We all work together across the full portfolio - you are expected to understand the big picture of how Canonical’s products fit together, there are no siloes. These are not behind-the-scenes roles, they are public leadership roles. We expect our team to be just as comfortable delivering our message online as they are face to face at meetups, meetings, conferences, partner workshops, or press events. From the analyst community to the tech press, from the CIO to the graduate engineer, from prospects to existing customers, we think Ubuntu should be the starting point for technology transformation around open source, and our marketing team are the amplifier for our message.
-      </p>
-      <p>
-        This team is all about having the confidence in our ideas and our quality to put us squarely into the frame for companies thinking afresh about their biggest technology questions. Join us if you are passionate about digital marketing and technology products.
-      </p>
+  <div class="p-strip is-shallow u-extra-space tab-content" id="overview">
+    <div class="row">
+      <div class="col-12">
+        <p>
+          <strong>We deliver the right technology message to a highly competent audience, at exactly the right moment. Success depends on having good instincts for tech trends and topics and a natural inclination to leadership.</strong>
+        </p>
+        <p>
+          The best candidates for marketing at Canonical love technology and words. They are tech-savvy and are comfortable working with data at scale - in spreadsheets, business analytics suites and databases. They love data visualisation and presentation. They are passionate about message and language, and strive to find the best way to share a powerful idea that leads people to act.
+        </p>
+        <p>
+          Canonical has a global following of sophisticated tech readers and decision makers, constantly evaluating the state of the art for open infrastructure and applications. Your mission is to reach them at precisely the right moment with clear information showing that Ubuntu and Canonical’s solutions deliver the very best in quality and economics. It’s a fast-paced, high stakes responsibility that demands a high level of intellect and work ethic.
+        </p>
+        <p>
+          Our team also understands that it’s not just about broadcast, it’s about feedback, measurement, iteration and improvement. We use analytics to understand how the world is consuming our narrative, and technology to sift through mountains of engagement data to spot the opportunities that are ready to explore further. We delight in showing that we can engineer growth in engagement, awareness, consumption and commerce just as effectively as our colleagues in software development engineer reliability and performance in their products. We are growth hackers at heart. As the tools evolve, so do we, which creates a learning environment that celebrates new ideas which can prove their effectiveness. We’re a tiny company in an industry of giants, so we have always punched way above our weight and that’s exactly what we expect from new members of the team too.
+        </p>
+        <p>
+          In marketing you are a representative of Canonical and you are an advocate of our brands and products. We all work together across the full portfolio - you are expected to understand the big picture of how Canonical’s products fit together, there are no siloes. These are not behind-the-scenes roles, they are public leadership roles. We expect our team to be just as comfortable delivering our message online as they are face to face at meetups, meetings, conferences, partner workshops, or press events. From the analyst community to the tech press, from the CIO to the graduate engineer, from prospects to existing customers, we think Ubuntu should be the starting point for technology transformation around open source, and our marketing team are the amplifier for our message.
+        </p>
+        <p>
+          This team is all about having the confidence in our ideas and our quality to put us squarely into the frame for companies thinking afresh about their biggest technology questions. Join us if you are passionate about digital marketing and technology products.
+        </p>
+      </div>
     </div>
-  </div>
-  <div class="row">
-    <div class="col-12">
-      <hr />
+    <div class="row">
+      <div class="col-12">
+        <hr />
+      </div>
     </div>
-  </div>
-  <div class="row">
-    <div class="col-12">
-      <p class="p-muted-heading">
-        <span>Emea</span>&nbsp;&#124;&nbsp;<span style="text-transform: capitalize">Americas</span>
-      </p>
-      <a href="#">Apply now&nbsp;&rsaquo;</a>
+    <div class="row">
+      <div class="col-12">
+        <p class="p-muted-heading">
+          <span>Emea</span>&nbsp;&#124;&nbsp;<span style="text-transform: capitalize">Americas</span>
+        </p>
+        <a href="#">Apply now&nbsp;&rsaquo;</a>
+      </div>
     </div>
   </div>
 {% endblock %}

--- a/templates/careers/marketing.html
+++ b/templates/careers/marketing.html
@@ -39,11 +39,3 @@
     </div>
   </div>
 {% endblock %}
-
-{% block available_roles %}
-
-{% endblock %}
-
-{% block send_cv %}
-
-{% endblock %}

--- a/templates/careers/progression.html
+++ b/templates/careers/progression.html
@@ -6,8 +6,9 @@
   <section class="p-strip--image is-dark is-deep u-no-padding--top u-no-padding--bottom u-extra-space">
     <div class="p-strip--suru-background">
       <div class="row">
-        <div class="col-6">
+        <div class="col-6 p-heading-icon--h1">
           <h1>Progression</h1>
+          <img src="https://assets.ubuntu.com/v1/1c95d556-canonical-progression.svg">
         </div>
       </div>
     </div>

--- a/templates/careers/progression.html
+++ b/templates/careers/progression.html
@@ -1,0 +1,26 @@
+{% extends '/careers/careers_base.html' %}
+
+{% block title %}<h1>Progression</h1>{% endblock %}
+
+{% block meta_description %}Canonical prefers internal promotion and encourages high-performing colleagues to pursue diverse roles at the company over the course of their career, to develop a well-rounded perspective.{% endblock %}
+
+{% block overview %}
+  <div class="row">
+    <div class="col-12">
+      <p>
+        <strong>We hire for talent, passion and work ethic. Your career at Canonical can progress in many ways - and we celebrate growth and development in many forms. Management is important and we like to develop those skills in people who enjoy it. We also explicitly encourage team members to find their passion and invest in that, recognising the benefit to your team and the company when you become a more effective team player. We encourage team members to experience diverse roles at Canonical over the course of their career, and we prefer to promote internally to build deep awareness of company culture and practices in senior leadership.</strong>
+      </p>
+      <p>
+        Joining Canonical means joining an intense global mission - to deliver the world’s best open source experience, from platform to application. We touch every aspect of open source technology, and so we offer a wide range of technology and business careers. You might start out as a product developer, then choose to get more travel and focus on customer operations transformation and cloud operations, then take on a role in tech leadership or management. We value people who love to learn - not just how to be a better engineer, but how to be a better speaker, how to be a better designer, better organiser, better partner and better vendor.
+      </p>
+    </div>
+  </div>
+{% endblock %}
+
+{% block available_roles %}
+
+{% endblock %}
+
+{% block send_cv %}
+
+{% endblock %}

--- a/templates/careers/progression.html
+++ b/templates/careers/progression.html
@@ -1,8 +1,18 @@
 {% extends '/careers/careers_base.html' %}
 
-{% block title %}<h1>Progression</h1>{% endblock %}
-
 {% block meta_description %}Canonical prefers internal promotion and encourages high-performing colleagues to pursue diverse roles at the company over the course of their career, to develop a well-rounded perspective.{% endblock %}
+
+{% block hero %}
+  <section class="p-strip--image is-dark is-deep u-no-padding--top u-no-padding--bottom u-extra-space">
+    <div class="p-strip--suru-background">
+      <div class="row">
+        <div class="col-6">
+          <h1>Progression</h1>
+        </div>
+      </div>
+    </div>
+  </section>
+{% endblock %}
 
 {% block overview %}
   <div class="row">

--- a/templates/careers/progression.html
+++ b/templates/careers/progression.html
@@ -16,11 +16,3 @@
     </div>
   </div>
 {% endblock %}
-
-{% block available_roles %}
-
-{% endblock %}
-
-{% block send_cv %}
-
-{% endblock %}

--- a/templates/careers/progression.html
+++ b/templates/careers/progression.html
@@ -18,7 +18,10 @@
   <div class="row">
     <div class="col-12">
       <p>
-        <strong>We hire for talent, passion and work ethic. Your career at Canonical can progress in many ways - and we celebrate growth and development in many forms. Management is important and we like to develop those skills in people who enjoy it. We also explicitly encourage team members to find their passion and invest in that, recognising the benefit to your team and the company when you become a more effective team player. We encourage team members to experience diverse roles at Canonical over the course of their career, and we prefer to promote internally to build deep awareness of company culture and practices in senior leadership.</strong>
+        <strong>We hire for talent, passion and work ethic.</strong>
+      </p>
+      <p>
+        Your career at Canonical can progress in many ways - and we celebrate growth and development in many forms. Management is important and we like to develop those skills in people who enjoy it. We also explicitly encourage team members to find their passion and invest in that, recognising the benefit to your team and the company when you become a more effective team player. We encourage team members to experience diverse roles at Canonical over the course of their career, and we prefer to promote internally to build deep awareness of company culture and practices in senior leadership.
       </p>
       <p>
         Joining Canonical means joining an intense global mission - to deliver the world’s best open source experience, from platform to application. We touch every aspect of open source technology, and so we offer a wide range of technology and business careers. You might start out as a product developer, then choose to get more travel and focus on customer operations transformation and cloud operations, then take on a role in tech leadership or management. We value people who love to learn - not just how to be a better engineer, but how to be a better speaker, how to be a better designer, better organiser, better partner and better vendor.

--- a/templates/careers/project-management.html
+++ b/templates/careers/project-management.html
@@ -5,7 +5,7 @@
     <div class="p-strip--suru-background">
       <div class="row">
         <div class="col-6">
-          <h1>Finance</h1>
+          <h1>Project Management</h1>
         </div>
       </div>
     </div>

--- a/templates/careers/project.html
+++ b/templates/careers/project.html
@@ -1,8 +1,6 @@
 {% extends '/careers/careers_base.html' %}
 
-{% block title %}
-  <h1>Project</h1>
-{% endblock %}
+{% block title %}<h1>Project</h1>{% endblock %}
 
 {% block overview %}
 

--- a/templates/careers/project.html
+++ b/templates/careers/project.html
@@ -1,7 +1,0 @@
-{% extends '/careers/careers_base.html' %}
-
-{% block title %}<h1>Project</h1>{% endblock %}
-
-{% block overview %}
-
-{% endblock %}

--- a/templates/careers/project.html
+++ b/templates/careers/project.html
@@ -5,11 +5,3 @@
 {% block overview %}
 
 {% endblock %}
-
-{% block available_roles %}
-
-{% endblock %}
-
-{% block send_cv %}
-
-{% endblock %}

--- a/templates/careers/sales.html
+++ b/templates/careers/sales.html
@@ -1,8 +1,6 @@
 {% extends '/careers/careers_base.html' %}
 
-{% block title %}
-  <h1>Sales</h1>
-{% endblock %}
+{% block title %}<h1>Sales</h1>{% endblock %}
 
 {% block overview %}
 

--- a/templates/careers/sales.html
+++ b/templates/careers/sales.html
@@ -1,7 +1,36 @@
 {% extends '/careers/careers_base.html' %}
 
-{% block title %}<h1>Sales</h1>{% endblock %}
+{% block hero %}
+  <section class="p-strip--image is-dark is-deep u-no-padding--top u-no-padding--bottom u-extra-space">
+    <div class="p-strip--suru-background">
+      <div class="row">
+        <div class="col-6">
+          <h1>Sales</h1>
+        </div>
+      </div>
+    </div>
+  </section>
+{% endblock %}
 
 {% block overview %}
+  <div class="p-strip is-shallow u-extra-space tab-content" id="overview">
+    <div class="row">
+      <div class="col-12">
 
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-12">
+        <hr />
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-12">
+        <p class="p-muted-heading">
+          <span style="text-transform: capitalize">Europe&nbsp;&#124;&nbsp;Middle East&nbsp;&#124;&nbsp;Africa&nbsp;&#124;&nbsp;Americas&nbsp;&#124;&nbsp;APAC</span>
+        </p>
+        <a href="#">Apply now&nbsp;&rsaquo;</a>
+      </div>
+    </div>
+  </div>
 {% endblock %}

--- a/templates/careers/sales.html
+++ b/templates/careers/sales.html
@@ -5,11 +5,3 @@
 {% block overview %}
 
 {% endblock %}
-
-{% block available_roles %}
-
-{% endblock %}
-
-{% block send_cv %}
-
-{% endblock %}

--- a/templates/careers/shared/_left-navigation.html
+++ b/templates/careers/shared/_left-navigation.html
@@ -1,0 +1,88 @@
+<div class="row">
+  <div class="col-3 u-hide--small">
+    <div class="p-content-list">
+      <ul class="p-content-list-section" style="font-size: 1.1rem;">
+        <li class="p-content-list-section__item js-navigation-link">
+          <a href="/careers/engineering" class="p-link--soft">Engineering</a>
+        </li>
+        <li class="p-content-list-section__item js-navigation-link">
+          <a href="/careers/tech-ops" class="p-link--soft">Tech-ops</a>
+        </li>
+        <li class="p-content-list-section__item js-navigation-link">
+          <a href="/careers/commercial-ops" class="p-link--soft">Commercial-ops</a>
+        </li>
+        <li class="p-content-list-section__item js-navigation-link">
+          <a href="/careers/sales" class="p-link--soft">Sales</a>
+        </li>
+        <li class="p-content-list-section__item js-navigation-link">
+          <a href="/careers/marketing" class="p-link--soft">Marketing</a>
+        </li>
+        <li class="p-content-list-section__item js-navigation-link">
+          <a href="/careers/design" class="p-link--soft">Design</a>
+        </li>
+        <li class="p-content-list-section__item js-navigation-link">
+          <a href="/careers/project" class="p-link--soft">Project</a>
+        </li>
+        <li class="p-content-list-section__item js-navigation-link">
+          <a href="/careers/management" class="p-link--soft">Management</a>
+        </li>
+        <li class="p-content-list-section__item js-navigation-link">
+          <a href="/careers/finance" class="p-link--soft">Finance</a>
+        </li>
+        <li class="p-content-list-section__item js-navigation-link">
+          <a href="/careers/legal" class="p-link--soft">Legal</a>
+        </li>
+        <li class="p-content-list-section__item js-navigation-link">
+          <a href="/careers/admin" class="p-link--soft">Admin</a>
+        </li>
+        <li class="p-content-list-section__item js-navigation-link">
+          <a href="/careers/hr" class="p-link--soft">HR</a>
+        </li>
+      </ul>
+      <ul class="p-content-list-section">
+        <li class="p-content-list-section__item js-navigation-link">
+          <a href="/careers/lifestyle" class="p-link--soft">Lifestyle</a>
+        </li>
+        <li class="p-content-list-section__item js-navigation-link">
+          <a href="/careers/ethics" class="p-link--soft">Ethics</a>
+        </li>
+        <li class="p-content-list-section__item js-navigation-link">
+          <a href="/careers/travel" class="p-link--soft">Travel</a>
+        </li>
+        <li class="p-content-list-section__item js-navigation-link">
+          <a href="/careers/progression" class="p-link--soft">Progression</a>
+        </li>
+        <li class="p-content-list-section__item js-navigation-link">
+          <a href="/careers/diversity" class="p-link--soft">Diversity</a>
+        </li>
+      </ul>
+      <ul class="p-content-list-section">
+        <li class="p-content-list-section__item js-navigation-link">
+          <a href="/careers/all" class="p-link--soft">All roles</a>
+        </li>
+      </ul>
+    </div>
+  </div>
+  <div class="col-3 u-hide--medium u-hide--large">
+    <select name="menu">
+      <option value="engineering">Engineering</option>
+      <option value="tech-ops">Tech-ops</option>
+      <option value="commercial-ops">Commercial-ops</option>
+      <option value="sales">Sales</option>
+      <option value="marketing">Marketing</option>
+      <option value="design">Design</option>
+      <option value="project">Project</option>
+      <option value="management">Management</option>
+      <option value="finance">Finance</option>
+      <option value="legal">Legal</option>
+      <option value="admin">Admin</option>
+      <option value="hr">HR</option>
+      <option value="lifestyle">Lifestyle</option>
+      <option value="ethics">Ethics</option>
+      <option value="travel">Travel</option>
+      <option value="progression">Progression</option>
+      <option value="diversity">Diversity</option>
+      <option value="all">ALL</option>
+    </select>
+  </div>
+  

--- a/templates/careers/tech-ops.html
+++ b/templates/careers/tech-ops.html
@@ -1,7 +1,36 @@
 {% extends '/careers/careers_base.html' %}
 
-{% block title %}<h1>Tech-ops</h1>{% endblock %}
+{% block hero %}
+  <section class="p-strip--image is-dark is-deep u-no-padding--top u-no-padding--bottom u-extra-space">
+    <div class="p-strip--suru-background">
+      <div class="row">
+        <div class="col-6">
+          <h1>Tech-ops</h1>
+        </div>
+      </div>
+    </div>
+  </section>
+{% endblock %}
 
 {% block overview %}
+  <div class="p-strip is-shallow u-extra-space tab-content" id="overview">
+    <div class="row">
+      <div class="col-12">
 
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-12">
+        <hr />
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-12">
+        <p class="p-muted-heading">
+          <span style="text-transform: capitalize">Europe&nbsp;&#124;&nbsp;Middle East&nbsp;&#124;&nbsp;Africa&nbsp;&#124;&nbsp;Americas&nbsp;&#124;&nbsp;APAC</span>
+        </p>
+        <a href="#">Apply now&nbsp;&rsaquo;</a>
+      </div>
+    </div>
+  </div>
 {% endblock %}

--- a/templates/careers/tech-ops.html
+++ b/templates/careers/tech-ops.html
@@ -1,8 +1,6 @@
 {% extends '/careers/careers_base.html' %}
 
-{% block title %}
-  <h1>Tech-ops</h1>
-{% endblock %}
+{% block title %}<h1>Tech-ops</h1>{% endblock %}
 
 {% block overview %}
 

--- a/templates/careers/tech-ops.html
+++ b/templates/careers/tech-ops.html
@@ -5,11 +5,3 @@
 {% block overview %}
 
 {% endblock %}
-
-{% block available_roles %}
-
-{% endblock %}
-
-{% block send_cv %}
-
-{% endblock %}

--- a/templates/careers/travel.html
+++ b/templates/careers/travel.html
@@ -25,11 +25,3 @@
     </div>
   </div>
 {% endblock %}
-
-{% block available_roles %}
-
-{% endblock %}
-
-{% block send_cv %}
-
-{% endblock %}

--- a/templates/careers/travel.html
+++ b/templates/careers/travel.html
@@ -1,0 +1,35 @@
+{% extends '/careers/careers_base.html' %}
+
+{% block title %}<h1>Travel</h1>{% endblock %}
+
+{% block meta_description %}Travel is central to Canonical’s global, distributed workplace. All teams participate in regular team and cross-team events. We spread locations across time zones and look for interesting and diverse cultural places. Many employees return to these destinations with friends and family.{% endblock %}
+
+{% block overview %}
+  <div class="row">
+    <div class="col-12">
+      <p>
+        <strong>Less commuting, more real travel.</strong>
+      </p>
+      <p>
+        Canonical is uniquely global - we hire the best open source team globally, regardless of nationality or language, creed or colour, and we serve the global market for technology in open infrastructure and open applications.
+      </p>
+      <p>
+        We do optimise team structure for time zone overlap - collaboration takes time and inspiration needs time to develop fully - but leadership at Canonical means building cross-team relationships and we do that through regular global summits which bring diverse teams or their leaders together. We aim to balance these events around the world to minimize the total travel and jet lag, and we try to discover great places to explore and appreciate in the process. Team events have taken place in Annecy, Vancouver, Brugge, New York, Budapest, Orlando, Cape Town, Warsaw, Seoul, Paris, Portland, Lyon, London, Toronto and many more.
+      </p>
+      <p>
+        Our customers are transforming their deepest and most important infrastructure to benefit from open source and modern dev/ops insights, and they trust us to advise them and lead them to best practice. That also takes time on site, to whiteboard and to work shoulder to shoulder in their development halls and data centers. Many teams at Canonical travel for that deep customer presence.
+      </p>
+      <p>
+        Travel isn’t for everybody but if you are excited to see the world then Canonical is a great place to be. We expect everybody at Canonical to be willing to travel for up to two weeks at a time, four times a year, but in some roles the travel expectation is higher. There are multiple career paths at Canonical in technical, management and commercial spheres, and not all of them are travel centric, but our culture celebrates both global talent and face-time, so travel is part of the deal. We love it when people like our destinations so much they bring family and friends there later.
+      </p>
+    </div>
+  </div>
+{% endblock %}
+
+{% block available_roles %}
+
+{% endblock %}
+
+{% block send_cv %}
+
+{% endblock %}

--- a/templates/careers/travel.html
+++ b/templates/careers/travel.html
@@ -12,6 +12,34 @@
       </div>
     </div>
   </section>
+  <style>
+    .p-strip--suru-background {
+      background-image:
+        linear-gradient(to top right, rgba(74,24,60,0) 0%, rgba(74,24,60,0) 49.9%, rgba(74, 24, 60, 0.4) 50%, rgba(74, 24, 60, 0.4) 100%),
+        linear-gradient(to top left, #fff 0%, #fff 49%, transparent 50%),
+        linear-gradient(to bottom right, rgba(210,180,202,0.05) 0%, rgba(210,180,202,0.05) 49.9%, rgba(210,180,202,0) 50%, rgba(210,180,202,0) 100%),
+        linear-gradient(120deg, #2C001E  4%, #4C193E 54.9%, transparent 55%),
+        url('https://assets.ubuntu.com/v1/883df027-canonical-travel.jpg');
+      background-position: right top, bottom -1px right -1px, top left, top left, center right, right bottom;
+      background-repeat: no-repeat;
+      background-size: 85% 100%, 105% 25%, 70% 80%, 100% 100%, 65% auto;
+      padding-bottom: 6rem;
+      padding-top: 6rem;
+    }
+
+    @media (max-width: 620px) {
+      .p-strip--suru-background {
+        background-image:
+          linear-gradient(to top right, rgba(74,24,60,0) 0%, rgba(74,24,60,0) 49.9%, rgba(74, 24, 60, 0.4) 50%, rgba(74, 24, 60, 0.4) 100%),
+          linear-gradient(to top left, #fff 0%, #fff 49%, transparent 50%),
+          linear-gradient(to bottom right, rgba(210,180,202,0.05) 0%, rgba(210,180,202,0.05) 49.9%, rgba(210,180,202,0) 50%, rgba(210,180,202,0) 100%),
+          linear-gradient(120deg, #2C001E  4%, #4C193E 100%);
+        background-position: right top, bottom right, top left, top left, center right;
+        background-repeat: no-repeat;
+        background-size: 100% 100%, 105% 25%, 70% 80%, 100% 100%;
+      }
+    }
+  </style>
 {% endblock %}
 
 {% block overview %}
@@ -20,12 +48,26 @@
       <p>
         <strong>Less commuting, more real travel.</strong>
       </p>
+    </div>
+  </div>
+  <div class="row u-sv3">
+    <div class="col-4">
       <p>
         Canonical is uniquely global - we hire the best open source team globally, regardless of nationality or language, creed or colour, and we serve the global market for technology in open infrastructure and open applications.
       </p>
       <p>
         We do optimise team structure for time zone overlap - collaboration takes time and inspiration needs time to develop fully - but leadership at Canonical means building cross-team relationships and we do that through regular global summits which bring diverse teams or their leaders together. We aim to balance these events around the world to minimize the total travel and jet lag, and we try to discover great places to explore and appreciate in the process. Team events have taken place in Annecy, Vancouver, Brugge, New York, Budapest, Orlando, Cape Town, Warsaw, Seoul, Paris, Portland, Lyon, London, Toronto and many more.
       </p>
+    </div>
+    <div class="col-4">
+      <img src="https://assets.ubuntu.com/v1/1e10b1d8-canonical-travel-city.jpg" alt="">
+    </div>
+  </div>
+  <div class="row u-extra-space">
+    <div class="col-3 u-hide--small">
+      <img src="https://assets.ubuntu.com/v1/95444386-canonical-travel-city-2.jpg" alt="">
+    </div>
+    <div class="col-5">
       <p>
         Our customers are transforming their deepest and most important infrastructure to benefit from open source and modern dev/ops insights, and they trust us to advise them and lead them to best practice. That also takes time on site, to whiteboard and to work shoulder to shoulder in their development halls and data centers. Many teams at Canonical travel for that deep customer presence.
       </p>

--- a/templates/careers/travel.html
+++ b/templates/careers/travel.html
@@ -1,8 +1,18 @@
 {% extends '/careers/careers_base.html' %}
 
-{% block title %}<h1>Travel</h1>{% endblock %}
-
 {% block meta_description %}Travel is central to Canonical’s global, distributed workplace. All teams participate in regular team and cross-team events. We spread locations across time zones and look for interesting and diverse cultural places. Many employees return to these destinations with friends and family.{% endblock %}
+
+{% block hero %}
+  <section class="p-strip--image is-dark is-deep u-no-padding--top u-no-padding--bottom u-extra-space">
+    <div class="p-strip--suru-background">
+      <div class="row">
+        <div class="col-6">
+          <h1>Travel</h1>
+        </div>
+      </div>
+    </div>
+  </section>
+{% endblock %}
 
 {% block overview %}
   <div class="row">


### PR DESCRIPTION
## Done
- Add content to the following careers pages:
- [x] `/careers/admin`
- [x] `/careers/engineering`
- [x] `/careers/marketing`
- [x] `/careers/travel`
- [x] `/careers/ethics`
- [x] `/careers/hr`
- [x] `/careers/legal`
- [x] `/careers/lifestyle`
- [x] `/careers/progression`
- [x] `/careers/diversity`
- Fix drop-down navigation on mobile version for all careers pages

## QA
- Go to [/careers/design](http://0.0.0.0:8002/careers/design) and navigate to all pages from left navigation menu. Compare the overview tab for the pages mentioned above to the content from [google drive](https://drive.google.com/drive/u/1/folders/1eppuIK_ETt7zIyrqDE6VDtDkjYlPJD4T)
- Make sure the drop-down navigation menu on mobile is functional

## Issue

Fixes https://github.com/canonical-web-and-design/web-squad/issues/1566
