### PR TITLE
Create available roles elements

### DIFF
--- a/static/sass/_pattern_strip.scss
+++ b/static/sass/_pattern_strip.scss
@@ -49,7 +49,7 @@
       linear-gradient(to top right, rgba(74,24,60,0) 0%, rgba(74,24,60,0) 49.9%, rgba(74,24,60,0.34) 50%, rgba(74,24,60,0.34) 100%),
       linear-gradient(to top left, #fff 0%, #fff 49%, transparent 50%),
       linear-gradient(230deg, #E95420 0%, #772953 33%, #2C001E 72%);
-    background-position: left top, right top, right bottom -0.3px;
+    background-position: left top, right top, right 101%;
     background-repeat: no-repeat;
     background-size: 70% 80%, 70% 100%, 110% 20%, 100% 100%;
     padding-bottom: 6rem;

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -70,6 +70,28 @@ $color-brand: #7c355d;
   }
 }
 
-.js-partner-link:hover .p{
+.js-partner-link:hover .p {
   border-right: 3px solid $color-tabs-active-bar;
+}
+
+[type="checkbox"] + label.p-checkbox-label--h2 {
+  $offset-top--h2-large: 1.2rem;
+  $offset-top--h2-small: 0.8rem;
+  $tick-offset: 0.1875rem;
+
+  &::before {
+    top: $offset-top--h2-small;
+
+    @media (min-width: $breakpoint-heading-threshold) {
+      top: $offset-top--h2-large;
+    }
+  }
+
+  &::after {
+    top: $offset-top--h2-small + $tick-offset;
+
+    @media (min-width: $breakpoint-heading-threshold) {
+      top: $offset-top--h2-large + $tick-offset;
+    }
+  }
 }

--- a/templates/careers/careers_base.html
+++ b/templates/careers/careers_base.html
@@ -87,7 +87,7 @@
         <option value="/careers/all">ALL</option>
       </select>
     </div>
-    <div class="col-8 col-start-large-5">
+    <div class="col-9 col-start-large-5">
       {% if (request.path != "/careers/lifestyle" and request.path != "/careers/ethics" and request.path != "/careers/travel" and request.path != "/careers/progression" and request.path != "/careers/diversity") %}
       <div class="row">
         <div class="col-12">
@@ -114,8 +114,11 @@
       {% block overview %}{% endblock %}
 
       <div class="p-strip is-shallow u-extra-space tab-content u-hide" id="available-roles">
-        <div class="row u-align--right">
-          <div class="col-12">
+        <div class="row u-vertically-center">
+          <div class="col-3">
+            <small class="p-form-help-text u-sv2">Select the role(s) you are interested in and apply once to them all.</small>
+          </div>
+          <div class="col-6">
             <form action="" method="get" class="p-form p-form--inline">
               <div class="p-form__group">
                 <label for="full-name-inline" aria-label="Filter the resources by type" class="p-form__label">Filter by</label>
@@ -123,7 +126,7 @@
                   <option value="">All</option>
                   <option value="">Home based</option>
                   <option value="">Office based</option>
-                  <option value="">Management/option>
+                  <option value="">Management</option>
                   <option value="">Senior roles</option>
                   <option value="">Full-time</option>
                   <option value="">Part-time</option>

--- a/templates/careers/careers_base.html
+++ b/templates/careers/careers_base.html
@@ -146,7 +146,28 @@
         </div>
         <div class="row">
           <div class="col-12">
-          
+            <form action="">
+              <ul class="p-list--divided">
+                <li class="p-list__item">
+                  <small class="u-sv1" style="padding-left: 2rem;">Anywhere - Home based</small>
+                  <input type="checkbox" name="roles" id="example1" value="1234" />
+                  <label class="p-checkbox-label--h2" for="example1">
+                    <h2><a class="p-link--soft" href="#">Robotics Developer Advocate&nbsp;&rsaquo;</a></h2>
+                    <p class="u-sv3">{{ "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras lorem felis, elementum sit amet maximus quis, consequat elementum tortor. Sed molestie imperdiet pretium."|truncate(130)}}</p>
+                  </label>
+                </li>
+                <li class="p-list__item">
+                  <small class="u-sv1" style="padding-left: 2rem;">Anywhere - Home based</small>
+                  <input type="checkbox" name="roles" id="example2" value="2345" />
+                  <label class="p-checkbox-label--h2" for="example2">
+                    <h2><a class="p-link--soft" href="#">Front End Developer&nbsp;&rsaquo;</a></h2>
+                    <p>{{ "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras lorem felis, elementum sit amet maximus quis, consequat elementum tortor. Sed molestie imperdiet pretium."|truncate(130)}}</p>
+                  </label>
+                </li>
+              </ul>
+              <hr />
+              <button type="submit">Apply now</button>
+            </form>
           </div>
         </div>
       </div>

--- a/templates/careers/careers_base.html
+++ b/templates/careers/careers_base.html
@@ -128,6 +128,8 @@
                   <option value="">Full-time</option>
                   <option value="">Part-time</option>
                 </select>
+              </div>
+              <div class="p-form__group">
                 <label for="full-name-inline" aria-label="Filter the resources by type" class="p-form__label">Sort by</label>
                 <select class="js-submit-on-change p-form__control" name="content" aria-label="Filter by content type">
                   <option value="">Date</option>

--- a/templates/careers/careers_base.html
+++ b/templates/careers/careers_base.html
@@ -152,7 +152,7 @@
             <form action="">
               <ul class="p-list--divided">
                 <li class="p-list__item">
-                  <small class="u-sv1" style="padding-left: 2rem;">Anywhere - Home based</small>
+                  <p class="u-no-margin--bottom u-sv1"><small style="padding-left: 2rem;">Anywhere - Home based</small></p>
                   <input type="checkbox" name="roles" id="example1" value="1234" />
                   <label class="p-checkbox-label--h2 u-no-padding--top" for="example1">
                     <h2 class="u-no-margin--bottom u-sv1"><a class="p-link--soft" href="#">Robotics Developer Advocate&nbsp;&rsaquo;</a></h2>
@@ -160,7 +160,7 @@
                   </label>
                 </li>
                 <li class="p-list__item">
-                  <small class="u-sv1" style="padding-left: 2rem;">Anywhere - Home based</small>
+                  <p class="u-no-margin--bottom u-sv1"><small style="padding-left: 2rem;">Anywhere - Home based</small></p>
                   <input type="checkbox" name="roles" id="example2" value="2345" />
                   <label class="p-checkbox-label--h2 u-no-padding--top" for="example2">
                     <h2 class="u-no-margin--bottom u-sv1"><a class="p-link--soft" href="#">Front End Developer&nbsp;&rsaquo;</a></h2>

--- a/templates/careers/careers_base.html
+++ b/templates/careers/careers_base.html
@@ -151,16 +151,16 @@
                 <li class="p-list__item">
                   <small class="u-sv1" style="padding-left: 2rem;">Anywhere - Home based</small>
                   <input type="checkbox" name="roles" id="example1" value="1234" />
-                  <label class="p-checkbox-label--h2" for="example1">
-                    <h2><a class="p-link--soft" href="#">Robotics Developer Advocate&nbsp;&rsaquo;</a></h2>
+                  <label class="p-checkbox-label--h2 u-no-padding--top" for="example1">
+                    <h2 class="u-no-margin--bottom u-sv1"><a class="p-link--soft" href="#">Robotics Developer Advocate&nbsp;&rsaquo;</a></h2>
                     <p class="u-sv3">{{ "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras lorem felis, elementum sit amet maximus quis, consequat elementum tortor. Sed molestie imperdiet pretium."|truncate(130)}}</p>
                   </label>
                 </li>
                 <li class="p-list__item">
                   <small class="u-sv1" style="padding-left: 2rem;">Anywhere - Home based</small>
                   <input type="checkbox" name="roles" id="example2" value="2345" />
-                  <label class="p-checkbox-label--h2" for="example2">
-                    <h2><a class="p-link--soft" href="#">Front End Developer&nbsp;&rsaquo;</a></h2>
+                  <label class="p-checkbox-label--h2 u-no-padding--top" for="example2">
+                    <h2 class="u-no-margin--bottom u-sv1"><a class="p-link--soft" href="#">Front End Developer&nbsp;&rsaquo;</a></h2>
                     <p>{{ "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras lorem felis, elementum sit amet maximus quis, consequat elementum tortor. Sed molestie imperdiet pretium."|truncate(130)}}</p>
                   </label>
                 </li>


### PR DESCRIPTION
# Done
- adjusted spacing between filter inputs on career pages
- built available role list element (with dummy data)

# QA
- Check out this branch
- Run `./run`
- Visit http://0.0.0.0:8002/careers/design
- Click 'Available roles'
- See that there is a proper amount of space between the "Filter by" and "Sort by" elements
- See that the available role items match the [design](https://images.zenhubusercontent.com/5cb4608f97df763a9090bdec/49839913-0355-4344-a84d-759c2e822d45)

Fixes https://github.com/canonical-web-and-design/web-squad/issues/1538