### PR TITLE
Add ids to products, partners & careers sections

### DIFF
--- a/static/js/careers-game.js
+++ b/static/js/careers-game.js
@@ -155,7 +155,7 @@
       if (selectedSkills[i]) {
         const card = document.createElement("div");
         card.classList.add("col-2", "col-medium-3");
-        card.innerHTML = `<div class="p-card--game-selected" data-skill=${selectedSkills[i].skill} data-card=${selectedSkills[i].card}><button class="js-remove-button"><i class="p-icon--close"></i></button><h4 class="p-card--game-selected__title">${selectedSkills[i].name}</h4><div class="p-card--game-selected__content"><p>${selectedSkills[i].description}</p></div></div>`
+        card.innerHTML = `<div class="p-card--game-selected" data-skill=${selectedSkills[i].skill} data-card=${selectedSkills[i].card}><button class="js-button--remove"><i class="p-icon--close"></i></button><h4 class="p-card--game-selected__title">${selectedSkills[i].name}</h4><div class="p-card--game-selected__content"><p>${selectedSkills[i].description}</p></div></div>`
         cardTree.appendChild(card);
       } else {
         const card = document.createElement("div");
@@ -167,7 +167,7 @@
     }
     container.insertBefore(cardTree, container.firstChild);
     // Add click event listener to skill remove buttons
-    await document.querySelectorAll(".js-remove-button").forEach(button => {
+    await document.querySelectorAll(".js-button--remove").forEach(button => {
       button.addEventListener("click", function (event) {
         removeSelectedSkill(event);
       });

--- a/static/js/dynamic-image-load.js
+++ b/static/js/dynamic-image-load.js
@@ -30,14 +30,14 @@
     activePartner = el.parentElement;
     activePartner.classList.add("is-active");
     partners.forEach(function (partner) {
-      if ((partner.classList.value.split(" ")[2] === "loaded") && (el.innerHTML.toLowerCase().replace(" ","-"))) {
+      if ((partner.classList.value.split(" ")[2] === "loaded") && (el.innerHTML.toLowerCase().replace(/ /g,"-"))) {
         Array.from(partner.children).forEach(function (image) {
           image.firstElementChild.dataset.src = image.firstElementChild.src;
           image.firstElementChild.removeAttribute("src");
         });
         partner.classList.remove('loaded');
       }
-      if (partner.dataset.partner === el.innerHTML.toLowerCase().replace(" ","-")) {
+      if (partner.dataset.partner === el.innerHTML.toLowerCase().replace(/ /g,"-")) {
         Array.from(partner.children).forEach(function (image) {
           image.firstElementChild.src = image.firstElementChild.dataset.src;
           image.firstElementChild.removeAttribute("data-src");

--- a/static/js/navigation.js
+++ b/static/js/navigation.js
@@ -94,9 +94,9 @@ function closeMainMenu() {
 
 var origin = window.location.href;
 
-addGANavEvents('#products', 'canonical.com-nav-products');
-addGANavEvents('#partners', 'canonical.com-nav-partners');
-addGANavEvents('#careers', 'canonical.com-nav-careers');
+addGANavEvents('#products-nav', 'canonical.com-nav-products');
+addGANavEvents('#partners-nav', 'canonical.com-nav-partners');
+addGANavEvents('#careers-nav', 'canonical.com-nav-careers');
 
 function addGANavEvents(target, category){
   var t = document.querySelector(target);

--- a/static/sass/_pattern_buttons.scss
+++ b/static/sass/_pattern_buttons.scss
@@ -61,16 +61,30 @@
     }
   }
 
-  .js-remove-button {
+  .js-button--remove {
     @extend %vf-button-base;
 
     border: none;
     border-radius: 50%;
-    height: 1.5rem;
+    height: 2rem;
     position: absolute;
     right: 0.5rem;
     top: 0.5rem;
-    width: 1rem;
+    width: auto;
+    
+    &>.p-icon--close {
+      height: map-get($line-heights, default-text); // so height matches that of text inside buttons
+      margin-left: -#{$sph-inner--small};
+      top: -1px;
+
+      &:only-child {
+        margin-right: -#{$sph-inner--small};
+      }
+
+      + * {
+        margin-left: $sph-inner--small;
+      }
+    }
 
     &:hover {
       background-color: $color-negative;
@@ -82,9 +96,6 @@
 
     i {
       @include vf-icon-close($color-mid-dark);
-      width: 0.7rem;
-      top: -0.22rem;
-      margin-left: -0.31rem;
     }
   }
 }

--- a/static/sass/_pattern_cards.scss
+++ b/static/sass/_pattern_cards.scss
@@ -83,7 +83,7 @@
     background-color: $color-brand;
     color: $color-x-light;
     min-height: 10rem;
-    margin-bottom: $spv-outer--scaleable;
+    margin-bottom: $spv-inner--large;
     position: relative;
 
     &:hover {

--- a/templates/careers/results.html
+++ b/templates/careers/results.html
@@ -110,7 +110,7 @@ Travel regularly to interesting destinations for team, conference and customer e
               <input type="checkbox" name="roles" id="{{ job.id }}" />
               <label class="p-checkbox-label--h2 u-no-padding--top" for="{{ job.id }}">
                 <h2 class="u-no-margin--bottom u-sv1"><a class="p-link--soft"
-                    href="{{request.path}}/{{ job.id }}">{{ job.title }}&nbsp;&rsaquo;</a></h2>
+                    href="/careers/{{ job.id }}">{{ job.title }}&nbsp;&rsaquo;</a></h2>
                 <p class="u-sv3">
                   {{ "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras lorem felis, elementum sit amet maximus quis, consequat elementum tortor. Sed molestie imperdiet pretium."|truncate(130)}}
                 </p>

--- a/templates/index.html
+++ b/templates/index.html
@@ -19,7 +19,7 @@
     </div>
   </div>
 
-  <div class="p-strip is-slanted--top-left" style="margin-bottom: 6rem;">
+  <div id="products" class="p-strip is-slanted--top-left" style="margin-bottom: 6rem;">
     <div class="row u-sv3">
       <div class="col-12 u-align--center u-sv3" data-animation="u-animation--slide-from-bottom">
         <h4 class="p-muted-heading" style="max-width: none; text-transform: capitalize;">Best enterprise security. Best datacentre automation. Best developer experience. Best app store. Best devices.</h4>
@@ -227,7 +227,7 @@
     </div>
   </div>
 
-  <div class="p-strip is-slanted--top-right" style="margin-bottom: 9rem;">
+  <div id="partners" class="p-strip is-slanted--top-right" style="margin-bottom: 9rem;">
     <div class="row">
       <div class="col-3 u-hide--small">
         <div class="p-content-list">
@@ -304,7 +304,7 @@
     </div>
   </div>
 
-  <div class="p-strip--suru is-dark is-slanted--top-left">
+  <div id="careers" class="p-strip--suru is-dark is-slanted--top-left">
     <div class="row">
       <div class="col-4">
         <div class="p-heading-highlight--bottom">

--- a/templates/partial/_navigation.html
+++ b/templates/partial/_navigation.html
@@ -15,25 +15,25 @@
         <a href="#main-content">Jump to main content</a>
       </span>
       <ul class="p-navigation__links u-hide js-show-nav" >
-        <li class="p-navigation__dropdown-link {% if request.path|get_nav_path == 'products' %}is-selected{% endif %}" role="menuitem" id="products" onmouseover="fetchDropdown('/partial/_navigation-products', 'products-content'); this.onmouseover = null;">
+        <li class="p-navigation__dropdown-link {% if request.path|get_nav_path == 'products' %}is-selected{% endif %}" role="menuitem" id="products-nav" onmouseover="fetchDropdown('/partial/_navigation-products', 'products-nav-content'); this.onmouseover = null;">
           {% if request.path|get_nav_path == 'products' %}
           <a class="p-navigation__link-anchor" href="/products">Products</a>
           {% else %}
-          <a class="p-navigation__link-anchor" href="#products-content" onfocus="fetchDropdown('/partial/_navigation-products', 'products-content');">Products</a>
+          <a class="p-navigation__link-anchor" href="#products-nav-content" onfocus="fetchDropdown('/partial/_navigation-products', 'products-nav-content');">Products</a>
           {% endif %}
         </li>
-        <li class="p-navigation__dropdown-link {% if request.path|get_nav_path == 'partners' %}is-selected{% endif %}" role="menuitem" id="partners" onmouseover="fetchDropdown('/partial/_navigation-partners', 'partners-content'); this.onmouseover = null;">
+        <li class="p-navigation__dropdown-link {% if request.path|get_nav_path == 'partners' %}is-selected{% endif %}" role="menuitem" id="partners-nav" onmouseover="fetchDropdown('/partial/_navigation-partners', 'partners-nav-content'); this.onmouseover = null;">
           {% if request.path|get_nav_path == 'partners' %}
           <a class="p-navigation__link-anchor" href="/partners">Partners</a>
           {% else %}
-          <a class="p-navigation__link-anchor" href="#partners-content" onfocus="fetchDropdown('/partial/_navigation-partners', 'partners-content');">Partners</a>
+          <a class="p-navigation__link-anchor" href="#partners-nav-content" onfocus="fetchDropdown('/partial/_navigation-partners', 'partners-nav-content');">Partners</a>
           {% endif %}
         </li>
-        <li class="p-navigation__dropdown-link {% if request.path|get_nav_path == 'careers' %}is-selected{% endif %}" role="menuitem" id="careers" onmouseover="fetchDropdown('/partial/_navigation-careers', 'careers-content'); this.onmouseover = null;">
+        <li class="p-navigation__dropdown-link {% if request.path|get_nav_path == 'careers' %}is-selected{% endif %}" role="menuitem" id="careers-nav" onmouseover="fetchDropdown('/partial/_navigation-careers', 'careers-nav-content'); this.onmouseover = null;">
           {% if request.path|get_nav_path == 'careers' %}
           <a class="p-navigation__link-anchor" href="/careers">Careers</a>
           {% else %}
-          <a class="p-navigation__link-anchor" href="#careers-content" onfocus="fetchDropdown('/partial/_navigation-careers', 'careers-content');">Careers</a>
+          <a class="p-navigation__link-anchor" href="#careers-nav-content" onfocus="fetchDropdown('/partial/_navigation-careers', 'careers-nav-content');">Careers</a>
           {% endif %}
         </li>
       </ul>
@@ -56,9 +56,9 @@
 </header>
 <div class="dropdown-window-overlay fade-animation"></div>
 <div class="dropdown-window slide-animation">
-  <div class="u-hide" id="products-content"></div>
-  <div class="u-hide" id="partners-content">  </div>
-  <div class="u-hide" id="careers-content"></div>
+  <div class="u-hide" id="products-nav-content"></div>
+  <div class="u-hide" id="partners-nav-content">  </div>
+  <div class="u-hide" id="careers-nav-content"></div>
 </div>
 
 <script>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -129,11 +129,6 @@ def job_details(job_id):
     return flask.render_template("/careers/job-detail.html", job=job)
 
 
-@app.route("/careers/<department>/<job_id>", methods=["POST"])
-def submit_job(department, job_id):
-    return flask.render_template("/careers/jobs/index.html")
-
-
 # Partners
 @app.route("/partners/find-a-partner")
 def find_a_partner():


### PR DESCRIPTION
## Done
- Add ids to `products`, `partners` & `careers` section on the home page
- Change close button style on `/careers/start`


## QA
- Run the website locally using `./run`
- Go to [http://0.0.0.0:8002](http://0.0.0.0:8002) and check if adding `#products`, `#partners` or `#careers` to the url takes you to the right section on the page
- Go to [/careers/start](http://0.0.0.0:8002/careers/start), select a card and click `That's me` button. Check if the close button looks round and nice.

## Issue
Fixes https://github.com/canonical-web-and-design/web-squad/issues/1845

## Screenshots
![image](https://user-images.githubusercontent.com/40214246/67167034-20ef4200-f38d-11e9-9ef9-eaa8b4601324.png)
