### PR TITLE
Add ids to the navigation tabs on careers pages

### DIFF
--- a/templates/careers/careers_base.html
+++ b/templates/careers/careers_base.html
@@ -56,8 +56,22 @@
 <script defer src="/static/js/apply-for-jobs.js"></script>
 <script defer src="/static/js/file-validation.js"></script>
 <script>
+  var urlHash = window.location.hash;
   var tabLinks = document.querySelectorAll(".p-tabs__link");
+  if (urlHash) {
+    document.querySelectorAll(".tab-content").forEach(function (tab) {
+      tab.classList.add("u-hide");
+    });
+  }
   tabLinks.forEach(function (tabLink) {
+    if (urlHash) {
+      if (`#${tabLink.getAttribute("aria-controls")}` === urlHash) {
+        tabLink.setAttribute("aria-selected", true);
+        document.getElementById(tabLink.getAttribute("aria-controls")).classList.remove("u-hide");
+      } else {
+        tabLink.setAttribute("aria-selected", false);
+      }
+    }
     tabLink.addEventListener("click", function (e) {
       e.preventDefault();
       tabLinks.forEach(function (tab) {
@@ -69,8 +83,23 @@
         tab.classList.add("u-hide");
       });
       document.getElementById(control).classList.remove("u-hide");
+      window.location.hash = `#${control}`;
     });
   });
+
+  window.onhashchange = function() { 
+    urlHash = window.location.hash;
+    tabLinks.forEach(function (tabLink) {
+      if (`#${tabLink.getAttribute("aria-controls")}` === urlHash) {
+        tabLink.setAttribute("aria-selected", true);
+        document.getElementById(tabLink.getAttribute("aria-controls")).classList.remove("u-hide");
+      } else {
+        tabLink.setAttribute("aria-selected", false);
+        document.getElementById(tabLink.getAttribute("aria-controls")).classList.add("u-hide");
+      }
+    });
+  }
+
   var path = window.location.pathname.split("/").pop();
   navigationLinks = document.querySelectorAll(".js-navigation-link");
   navigationLinks.forEach(function (link) {


### PR DESCRIPTION
## Done
- Add `id`s to the navigation tabs on `/careers/{department}` pages


## QA
- Run the website locally using `./run`
- Go to [/careers/sales#available-roles](http://0.0.0.0:8002/careers/sales#available-roles) and change click on `Send your CV`. Check if the url hash is changing
- Change the url to `/careers/sales#overview` and see if the content is changing accordingly 
- Go to [/careers/hr](http://0.0.0.0:8002/careers/hr) and check if you see the overview section


## Issue
Fixes https://github.com/canonical-web-and-design/web-squad/issues/1731
