### PR TITLE
Remove partners from the navigation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+## Done
+
+[List of work items including drive-bys]
+
+## QA
+
+- Check out this feature branch
+- Run the site using the command `./run serve`
+- View the site locally in your web browser at: http://0.0.0.0:8002/
+- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
+- [List additional steps to QA the new features or prove the bug has been resolved]
+
+
+## Issue / Card
+
+Fixes #
+
+## Screenshots
+
+[if relevant, include a screenshot]

--- a/templates/partial/_navigation.html
+++ b/templates/partial/_navigation.html
@@ -22,13 +22,6 @@
           <a class="p-navigation__link-anchor" href="#products-nav-content" onfocus="fetchDropdown('/partial/_navigation-products', 'products-nav-content');">Products</a>
           {% endif %}
         </li>
-        <li class="p-navigation__dropdown-link {% if request.path|get_nav_path == 'partners' %}is-selected{% endif %}" role="menuitem" id="partners-nav" onmouseover="fetchDropdown('/partial/_navigation-partners', 'partners-nav-content'); this.onmouseover = null;">
-          {% if request.path|get_nav_path == 'partners' %}
-          <a class="p-navigation__link-anchor" href="/partners">Partners</a>
-          {% else %}
-          <a class="p-navigation__link-anchor" href="#partners-nav-content" onfocus="fetchDropdown('/partial/_navigation-partners', 'partners-nav-content');">Partners</a>
-          {% endif %}
-        </li>
         <li class="p-navigation__dropdown-link {% if request.path|get_nav_path == 'careers' %}is-selected{% endif %}" role="menuitem" id="careers-nav" onmouseover="fetchDropdown('/partial/_navigation-careers', 'careers-nav-content'); this.onmouseover = null;">
           {% if request.path|get_nav_path == 'careers' %}
           <a class="p-navigation__link-anchor" href="/careers">Careers</a>
@@ -57,7 +50,7 @@
 <div class="dropdown-window-overlay fade-animation"></div>
 <div class="dropdown-window slide-animation">
   <div class="u-hide" id="products-nav-content"></div>
-  <div class="u-hide" id="partners-nav-content">  </div>
+  <div class="u-hide" id="partners-nav-content"></div>
   <div class="u-hide" id="careers-nav-content"></div>
 </div>
 


### PR DESCRIPTION
## Done
- Remove partners` from the navigation
- Add GitHub PR template

## QA
- Run the website locally using `./run`
- Go to http://0.0.0.0:8002 and check you only have 'products' and 'careers' in the navigation bar

## Issue
Fixes #74
