### PR TITLE
Update /careers/design page

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description"
       content="{% block meta_description %}Canonical produces Ubuntu, provides commercial services for Ubuntu’s users, and works with hardware manufacturers, software vendors and cloud partners to certify Ubuntu.{% endblock %}" />
-    <meta name="copydoc" content="{% block meta_copydoc %}https://drive.google.com/drive/u/1/folders/0B8feV0jqaac3TmExU3NDcHhFTGc{% endblock %}">
+    <meta name="copydoc" content="{% block meta_copydoc %}https://drive.google.com/drive/folders/0B8feV0jqaac3TmExU3NDcHhFTGc{% endblock %}">
     <meta name="author" content="Canonical Ltd" />
 
     <link rel="shortcut icon" href="https://assets.ubuntu.com/v1/0843d517-favicon.ico" type="image/x-icon" />

--- a/templates/base.html
+++ b/templates/base.html
@@ -7,9 +7,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description"
       content="{% block meta_description %}Canonical produces Ubuntu, provides commercial services for Ubuntu’s users, and works with hardware manufacturers, software vendors and cloud partners to certify Ubuntu.{% endblock %}" />
+    <meta name="copydoc" content="{% block meta_copydoc %}https://drive.google.com/drive/u/1/folders/0B8feV0jqaac3TmExU3NDcHhFTGc{% endblock %}">
     <meta name="author" content="Canonical Ltd" />
-
-    <script src="/static/js/navigation.js" defer></script>
 
     <link rel="shortcut icon" href="https://assets.ubuntu.com/v1/0843d517-favicon.ico" type="image/x-icon" />
     <link rel="apple-touch-icon-precomposed" sizes="144x144"
@@ -34,6 +33,8 @@
     <link rel="preload" as="font" type="font/woff2" href="https://assets.ubuntu.com/v1/fff37993-Ubuntu-R_W.woff2"
       crossorigin>
 
+    <script src="/static/js/navigation.js" defer></script>
+    
     <link rel="stylesheet" type="text/css" media="screen" href="/static/css/styles.css" />
   </head>
 

--- a/templates/careers/all.html
+++ b/templates/careers/all.html
@@ -2,6 +2,8 @@
 
 {% block meta_description %}Canonical publishes Ubuntu, provides commercial services and solutions for Ubuntu, and works with hardware manufacturers, software vendors and public.{% endblock %}
 
+{% block meta_copydoc %}https://docs.google.com/document/d/1adoe3jR-_O3EC4LECotKiPo2SsC_Ht5YPTR0wr-BhH0{% endblock meta_copydoc %}
+
 {% block hero %}
   <section class="p-strip--image is-dark is-deep u-no-padding--top u-no-padding--bottom u-extra-space">
     <div class="p-strip--suru-background">

--- a/templates/careers/design.html
+++ b/templates/careers/design.html
@@ -1,5 +1,7 @@
 {% extends '/careers/careers_base.html' %}
 
+{% block meta_copydoc %}https://docs.google.com/document/d/1V8SzuqyJEqXAXf_FrobdNn5-OLzTvKWcRlfBXjI9oBo{% endblock meta_copydoc %}
+
 {% block hero %}
   <section class="p-strip--image is-dark is-deep u-no-padding--top u-no-padding--bottom u-extra-space">
     <div class="p-strip--suru-background">
@@ -16,16 +18,22 @@
   <div class="p-strip is-shallow u-extra-space tab-content" id="overview">
     <div class="row">
       <div class="col-12">
-        <p><strong>Canonical and Ubuntu are central to modern tech - from cloud to the internet of things, from the web to mobile back-ends, from development to production. We count on our design teams to bring together deep domain knowledge with great instincts, teamwork and rigorous process, to shape our products for a very demanding audience.</strong>
+        <p><strong>Canonical and Ubuntu are central to modern tech &ndash; from cloud to the internet of things, from the web to mobile back-ends, from development to production.</strong>
         </p>
         <p>
-          Our customers are sophisticated technical specialists across a very wide range of industries and geographies, focused on cutting edge software development and operations. Canonical delivers Ubuntu and a range of tools - for engineers, admins and enterprises - to help businesses move to an open source stack.
+          The design team at Canonical crafts the user-experiences of  sophisticated technical specialists across a wide range of industries and geographies. Canonical delivers Ubuntu, and a range of tools &ndash; for engineers, admins and enterprises &ndash; to help businesses move to an open source stack.
         </p>
         <p>
-          Our opportunity is to shape the enterprise infrastructure and application operations landscape. Every layer of the stack is important - from bare metal data center operations, to virtualisation infrastructure and cloud, to the desktop, to systems management, to serverless and embedded connected devices. Our designers work on a range of products, using common visual and web frameworks to create consistency of experience across a very wide range of capabilities.
+          Your opportunity is to shape the user experience across the enterprise infrastructure and application operations landscape. There are challenges at every layer of the stack &ndash; from bare metal data center operations, to virtualisation infrastructure and cloud, to the desktop, to systems management, to serverless and embedded connected devices.
         </p>
         <p>
-          Our team are centered in Europe, covering global distributed development engineering teams, so designers need to be effective working collaboratively in a digital space. We travel to engineering sprints and summits to collaborate with global teams on products and website.
+          Canonical designers work on a range of products, using common visual and web frameworks to create consistency of experience across a very wide range of capabilities.
+        </p>
+        <p>
+          Our team, centered in Europe, has  specialists in visual and ux design, and front and back end development. We collaborate, as product design squads, with global distributed development engineering teams. Designers need to be effective working collaboratively in a digital space. We travel to engineering sprints and summits for face to face time.
+        </p>
+        <p>
+          We count on our team to bring together deep design-thinking, technical domain knowledge, with great instincts, through a rigorous process &ndash; to shape products for a very demanding audience. You’ll fit in if you have equal appetites for design, innovation and technology.
         </p>
       </div>
     </div>
@@ -39,7 +47,7 @@
         <p class="p-muted-heading">
           <span>Emea</span>&nbsp;&#124;&nbsp;<span style="text-transform: capitalize">Americas</span>
         </p>
-        <a href="#">Apply now&nbsp;&rsaquo;</a>
+        <a href="/careers/design#available-roles">Apply now&nbsp;&rsaquo;</a>
       </div>
     </div>
   </div>

--- a/templates/partial/_careers-available-roles.html
+++ b/templates/partial/_careers-available-roles.html
@@ -36,11 +36,9 @@
       </div>
     </div>
   </div>
-  <div class="u-fixed-width p-notification u-no-margin--bottom js-filter__no-results u-hide">
-    <p class="p-notification__response">
-      Sorry, there are no open positions matching your criteria.
-    </p>
-  </div>
+  <h4 class="js-filter__no-results u-hide">
+    Sorry, there are no open positions matching your criteria.
+  </h4>
   <div class="js-filter-jobs-container">
     <div class="row">
       <div class="col-8">
@@ -65,10 +63,8 @@
     </div>
   </div>
   {% else %}
-  <div class="u-fixed-width p-notification u-no-margin--bottom">
-    <p class="p-notification__response">
-      Sorry, there are no open positions at this time.
-    </p>
-  </div>
+    <h3>We don&apos;t have any open positions right now.
+    </h3>
+    <p>If you&apos;d like <a href="#send-cv">send us your CV</a> and we&apos;ll send you an email any time a position opens up.</p>
   {% endif %}
 </div>

--- a/templates/partial/_careers-available-roles.html
+++ b/templates/partial/_careers-available-roles.html
@@ -36,9 +36,9 @@
       </div>
     </div>
   </div>
-  <h4 class="js-filter__no-results u-hide">
+  <h2 class="p-heading--four js-filter__no-results u-hide">
     Sorry, there are no open positions matching your criteria.
-  </h4>
+  </h2>
   <div class="js-filter-jobs-container">
     <div class="row">
       <div class="col-8">
@@ -63,8 +63,8 @@
     </div>
   </div>
   {% else %}
-    <h3>We don&apos;t have any open positions right now.
-    </h3>
+    <h2 class="p-heading--three">We don&apos;t have any open positions right now.
+    </h2>
     <p>If you&apos;d like <a href="#send-cv">send us your CV</a> and we&apos;ll send you an email any time a position opens up.</p>
   {% endif %}
 </div>


### PR DESCRIPTION
## Done

- Update '/careers/design' page
- Add `meta_copydoc` to `/careers/all` and `/careers/design`

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/careers/design
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to [copy doc](https://docs.google.com/document/d/1zpAVnQ1qE-oAmZoxTpfOPFu12zbotBqrD_To9ry0oAQ/edit#)


## Issue / Card

Fixes #80 
