### PR TITLE
81 update careers engineering

### DIFF
--- a/templates/careers/design.html
+++ b/templates/careers/design.html
@@ -47,7 +47,7 @@
         <p class="p-muted-heading">
           <span>Emea</span>&nbsp;&#124;&nbsp;<span style="text-transform: capitalize">Americas</span>
         </p>
-        <a href="/careers/design#available-roles">Apply now&nbsp;&rsaquo;</a>
+        <a href="#available-roles">Apply now&nbsp;&rsaquo;</a>
       </div>
     </div>
   </div>

--- a/templates/careers/engineering.html
+++ b/templates/careers/engineering.html
@@ -1,5 +1,7 @@
 {% extends '/careers/careers_base.html' %}
 
+{% block meta_copydoc %}https://docs.google.com/document/d/14gNX9sCgQUM1H0Hfl46R3Wvw0E91XjsuyStMV4KvKME{% endblock meta_copydoc %}
+
 {% block hero %}
   <section class="p-strip--image is-dark is-deep u-no-padding--top u-no-padding--bottom u-extra-space">
     <div class="p-strip--suru-background">
@@ -29,10 +31,7 @@
           Engineering at Canonical ranges from deep single-product specialization, to diverse customer-centric field integration, delivery and development, and high-pressure rapid-response to critical situations in our techops team. The right career for you will depend on your interests and aptitudes. If you love the idea of travel and seeing the world, our field engineers work on-site with the world’s best companies to transform their open infrastructure. If you love saving the day, our techops teams fight fires shoulder to shoulder, from security incident response to deep problem analysis and repair. If you love operations, we take a code-first approach to infrastructure and application operations that is raising the bar for the entire industry.
         </p>
         <p>
-          We see all of these as engineering roles and we encourage people to build a career that spans diverse aspects of software development and operations. Regardless of your starting point, as long as you are performing well you have the option to progress in any of those roles, or to gain experience in management or technical leadership.
-        </p>
-        <p>
-          Engineering is a calling - it’s a way of thinking, not just a job. You know you will fit in at Canonical if you have consistently sought out the opportunity to write code to solve problems, from the moment you first had access to a PC. You’ll know you  fit in if you have consistently taken on the most difficult mental challenges you could, and shone brightly amongst your peers in doing so. Join us to take that to the next level - the problems we solve enable the world’s fiercest innovators and protect the world’s most critical systems. Canonical is where software engineers make a difference - to every industry and every society.
+          We see all of these as engineering roles and we encourage people to build a career that spans diverse aspects of software development and operations. Regardless of your starting point, you have the option to progress in any of those roles, or to gain experience in management or technical leadership.
         </p>
       </div>
     </div>
@@ -46,7 +45,7 @@
         <p class="p-muted-heading">
           <span style="text-transform: capitalize">Europe&nbsp;&#124;&nbsp;Middle East&nbsp;&#124;&nbsp;Africa&nbsp;&#124;&nbsp;Americas&nbsp;&#124;&nbsp;APAC</span>
         </p>
-        <a href="#">Apply now&nbsp;&rsaquo;</a>
+        <a href="#available-roles">Apply now&nbsp;&rsaquo;</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Done

- Update `/careers/engineering` page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/careers/engineering
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to [copy doc](https://docs.google.com/document/d/14gNX9sCgQUM1H0Hfl46R3Wvw0E91XjsuyStMV4KvKME)


## Issue / Card

Fixes #81 
