### PR TITLE
82 update careers finance

### DIFF
--- a/templates/careers/admin.html
+++ b/templates/careers/admin.html
@@ -37,7 +37,7 @@
         <p class="p-muted-heading">
           <span style="text-transform: capitalize">Austin&nbsp;&#124;&nbsp;Beijing&nbsp;&#124;&nbsp;Boston&nbsp;&#124;&nbsp;London&nbsp;&#124;&nbsp;Taipei</span>
         </p>
-        <a href="#">Apply now&nbsp;&rsaquo;</a>
+        <a href="#available-roles">Apply now&nbsp;&rsaquo;</a>
       </div>
     </div>
   </div>

--- a/templates/careers/all.html
+++ b/templates/careers/all.html
@@ -41,7 +41,7 @@
         <p class="p-muted-heading">
           <span style="text-transform: capitalize">Austin&nbsp;&#124;&nbsp;Beijing&nbsp;&#124;&nbsp;Boston&nbsp;&#124;&nbsp;London&nbsp;&#124;&nbsp;Taipei</span>
         </p>
-        <a href="#">Apply now&nbsp;&rsaquo;</a>
+        <a href="#available-roles">Apply now&nbsp;&rsaquo;</a>
       </div>
     </div>
   </div>

--- a/templates/careers/commercial-ops.html
+++ b/templates/careers/commercial-ops.html
@@ -29,7 +29,7 @@
         <p class="p-muted-heading">
           <span style="text-transform: capitalize">Europe&nbsp;&#124;&nbsp;Middle East&nbsp;&#124;&nbsp;Africa&nbsp;&#124;&nbsp;Americas&nbsp;&#124;&nbsp;APAC</span>
         </p>
-        <a href="#">Apply now&nbsp;&rsaquo;</a>
+        <a href="#available-roles">Apply now&nbsp;&rsaquo;</a>
       </div>
     </div>
   </div>

--- a/templates/careers/design.html
+++ b/templates/careers/design.html
@@ -47,7 +47,7 @@
         <p class="p-muted-heading">
           <span>Emea</span>&nbsp;&#124;&nbsp;<span style="text-transform: capitalize">Americas</span>
         </p>
-        <a href="/careers/design#available-roles">Apply now&nbsp;&rsaquo;</a>
+        <a href="#available-roles">Apply now&nbsp;&rsaquo;</a>
       </div>
     </div>
   </div>

--- a/templates/careers/engineering.html
+++ b/templates/careers/engineering.html
@@ -1,5 +1,7 @@
 {% extends '/careers/careers_base.html' %}
 
+{% block meta_copydoc %}https://docs.google.com/document/d/14gNX9sCgQUM1H0Hfl46R3Wvw0E91XjsuyStMV4KvKME{% endblock meta_copydoc %}
+
 {% block hero %}
   <section class="p-strip--image is-dark is-deep u-no-padding--top u-no-padding--bottom u-extra-space">
     <div class="p-strip--suru-background">
@@ -29,10 +31,7 @@
           Engineering at Canonical ranges from deep single-product specialization, to diverse customer-centric field integration, delivery and development, and high-pressure rapid-response to critical situations in our techops team. The right career for you will depend on your interests and aptitudes. If you love the idea of travel and seeing the world, our field engineers work on-site with the world’s best companies to transform their open infrastructure. If you love saving the day, our techops teams fight fires shoulder to shoulder, from security incident response to deep problem analysis and repair. If you love operations, we take a code-first approach to infrastructure and application operations that is raising the bar for the entire industry.
         </p>
         <p>
-          We see all of these as engineering roles and we encourage people to build a career that spans diverse aspects of software development and operations. Regardless of your starting point, as long as you are performing well you have the option to progress in any of those roles, or to gain experience in management or technical leadership.
-        </p>
-        <p>
-          Engineering is a calling - it’s a way of thinking, not just a job. You know you will fit in at Canonical if you have consistently sought out the opportunity to write code to solve problems, from the moment you first had access to a PC. You’ll know you  fit in if you have consistently taken on the most difficult mental challenges you could, and shone brightly amongst your peers in doing so. Join us to take that to the next level - the problems we solve enable the world’s fiercest innovators and protect the world’s most critical systems. Canonical is where software engineers make a difference - to every industry and every society.
+          We see all of these as engineering roles and we encourage people to build a career that spans diverse aspects of software development and operations. Regardless of your starting point, you have the option to progress in any of those roles, or to gain experience in management or technical leadership.
         </p>
       </div>
     </div>
@@ -46,7 +45,7 @@
         <p class="p-muted-heading">
           <span style="text-transform: capitalize">Europe&nbsp;&#124;&nbsp;Middle East&nbsp;&#124;&nbsp;Africa&nbsp;&#124;&nbsp;Americas&nbsp;&#124;&nbsp;APAC</span>
         </p>
-        <a href="#">Apply now&nbsp;&rsaquo;</a>
+        <a href="#available-roles">Apply now&nbsp;&rsaquo;</a>
       </div>
     </div>
   </div>

--- a/templates/careers/finance.html
+++ b/templates/careers/finance.html
@@ -1,5 +1,7 @@
 {% extends '/careers/careers_base.html' %}
 
+{% block meta_copydoc %}https://docs.google.com/document/d/1R4i26Ov-ccfrXm8uSdSRApxgXDH3HwZVY8qWQqPpIjg{% endblock meta_copydoc %}
+
 {% block hero %}
   <section class="p-strip--image is-dark is-deep u-no-padding--top u-no-padding--bottom u-extra-space">
     <div class="p-strip--suru-background">
@@ -16,7 +18,22 @@
   <div class="p-strip is-shallow u-extra-space tab-content" id="overview">
     <div class="row">
       <div class="col-12">
-
+        <p><strong>Finance at Canonical isn’t just about numbers. It’s about connecting with people across the business, helping them to understand the value they bring, as well as promoting the commercial focus that will grow our brand.</strong></p>
+        <p>
+          We fuel growth by devising innovative solutions to complex problems in forecasting, accounting, compliance, and project management. From advising all teams across the business to managing day-to-day data, you’ll help keep our business on track to meet (or, better yet, exceed) our goals.
+        </p>
+        <p>
+          With significant growth and a stated path to public markets, industry&ndash;leading analysis is essential. As part of this we:
+        </p>
+        <ul class="p-list">
+          <li class="p-list__item is-ticked">Translate complex data into actionable insights that drive strategic company decisions, whether modelling business scenarios or tracking performance metrics.</li>
+          <li class="p-list__item is-ticked">Manage large-scale projects. Develop and implement insightful strategies that address and solve our complex business needs.</li>
+          <li class="p-list__item is-ticked">Protect Canonical by partnering with our business and engineering teams to identify and address risks related to product launches and other initiatives.</li>
+          <li class="p-list__item is-ticked">Balance our legal and compliance requirements with our company values and the dynamic needs of our users, along with developing efficient systems to ensure Canonical keeps up with regulations.</li>
+        </ul>
+        <p>
+          The finance team at Canonical offers rapid growth in understanding both industry best practice with analytical excellence. We welcome candidates with an outstanding track record, a commitment to teamwork, and a personal interest in the future of software and the financial frameworks that underpin it.
+        </p>
       </div>
     </div>
     <div class="row">
@@ -29,7 +46,7 @@
         <p class="p-muted-heading">
           <span style="text-transform: capitalize">Europe&nbsp;&#124;&nbsp;Middle East&nbsp;&#124;&nbsp;Africa&nbsp;&#124;&nbsp;Americas&nbsp;&#124;&nbsp;APAC</span>
         </p>
-        <a href="#">Apply now&nbsp;&rsaquo;</a>
+        <a href="#available-roles">Apply now&nbsp;&rsaquo;</a>
       </div>
     </div>
   </div>

--- a/templates/careers/hr.html
+++ b/templates/careers/hr.html
@@ -36,7 +36,7 @@
         <p class="p-muted-heading">
           <span style="text-transform: capitalize">Europe&nbsp;&#124;&nbsp;Americas</span>
         </p>
-        <a href="#">Apply now&nbsp;&rsaquo;</a>
+        <a href="#available-roles">Apply now&nbsp;&rsaquo;</a>
       </div>
     </div>
   </div>

--- a/templates/careers/legal.html
+++ b/templates/careers/legal.html
@@ -39,7 +39,7 @@
         <p class="p-muted-heading">
           <span style="text-transform: capitalize">Europe&nbsp;&#124;&nbsp;Americas</span>
         </p>
-        <a href="#">Apply now&nbsp;&rsaquo;</a>
+        <a href="#available-roles">Apply now&nbsp;&rsaquo;</a>
       </div>
     </div>
   </div>

--- a/templates/careers/marketing.html
+++ b/templates/careers/marketing.html
@@ -46,7 +46,7 @@
         <p class="p-muted-heading">
           <span>Emea</span>&nbsp;&#124;&nbsp;<span style="text-transform: capitalize">Americas</span>
         </p>
-        <a href="#">Apply now&nbsp;&rsaquo;</a>
+        <a href="#available-roles">Apply now&nbsp;&rsaquo;</a>
       </div>
     </div>
   </div>

--- a/templates/careers/project-management.html
+++ b/templates/careers/project-management.html
@@ -34,7 +34,7 @@
         <p class="p-muted-heading">
           <span style="text-transform: capitalize">Europe&nbsp;&#124;&nbsp;Americas</span>
         </p>
-        <a href="#">Apply now&nbsp;&rsaquo;</a>
+        <a href="#available-roles">Apply now&nbsp;&rsaquo;</a>
       </div>
     </div>
   </div>

--- a/templates/careers/sales.html
+++ b/templates/careers/sales.html
@@ -29,7 +29,7 @@
         <p class="p-muted-heading">
           <span style="text-transform: capitalize">Europe&nbsp;&#124;&nbsp;Middle East&nbsp;&#124;&nbsp;Africa&nbsp;&#124;&nbsp;Americas&nbsp;&#124;&nbsp;APAC</span>
         </p>
-        <a href="#">Apply now&nbsp;&rsaquo;</a>
+        <a href="#available-roles">Apply now&nbsp;&rsaquo;</a>
       </div>
     </div>
   </div>

--- a/templates/careers/tech-ops.html
+++ b/templates/careers/tech-ops.html
@@ -29,7 +29,7 @@
         <p class="p-muted-heading">
           <span style="text-transform: capitalize">Europe&nbsp;&#124;&nbsp;Middle East&nbsp;&#124;&nbsp;Africa&nbsp;&#124;&nbsp;Americas&nbsp;&#124;&nbsp;APAC</span>
         </p>
-        <a href="#">Apply now&nbsp;&rsaquo;</a>
+        <a href="#available-roles">Apply now&nbsp;&rsaquo;</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Done

- Update `/careers/finance` page
- Change `Apply now` link on all careers pages

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/careers/finance
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to [copy doc](https://docs.google.com/document/d/1R4i26Ov-ccfrXm8uSdSRApxgXDH3HwZVY8qWQqPpIjg)


## Issue / Card

Fixes #82 
