### PR TITLE
Update the careers overview page content

### DIFF
--- a/templates/careers/index.html
+++ b/templates/careers/index.html
@@ -1,5 +1,9 @@
 {% extends 'base.html' %}
 
+{% block meta_copydoc %}https://docs.google.com/document/d/1pNyOXfR07FiBr6TmEMRdB7NZUB5SeBz6COuSxO3ylC0{% endblock meta_copydoc %}
+
+{% block meta_description %}Canonical publishes Ubuntu, provides commercial services and solutions for Ubuntu, and works with hardware manufacturers, software vendors and public clouds to certify Ubuntu.{% endblock %}
+
 {% block content %}
   <section class="p-strip--image is-dark is-deep u-no-padding--top u-no-padding--bottom u-extra-space">
     <div class="p-strip--suru-background">
@@ -18,7 +22,7 @@
     </div>
     <div class="row u-sv3">
       <div class="col-8">
-        <p>Lorem ipsum dolor sit, amet consectetur adipisicing elit. Nisi provident quos aspernatur quisquam, dolor dignissimos tempora ipsa maxime porro ratione molestiae consequuntur ea? Illum laudantium vitae voluptates odit error perspiciatis.</p>
+        <p>Life at Canonical is anything but corporate. As a company that exists to support Ubuntu, one of today’s most important open source projects. We are changing the world on a daily basis. It’s a collaborative environment, but one in which every member of the team takes personal responsibility for everything they produce.</p>
       </div>
       <div class="col-4 u-vertically-center">
         <p><a href="/careers/start" class="p-button--positive">Explore a career at Canonical</a></p>
@@ -27,34 +31,29 @@
     <div class="row u-equal-height">
       <div class="col-6 p-card--strip-thin">
         <h2 class="p-card--strip-thin__title">Engineering</h2>
-        <p class="p-card--strip-thin__content">Open source is transforming the entire stack. This is your chance to be right at the center of that revolution, to shape the platforms and tools that millions use to invent our global technology future. From bare metal to cloud to high performance computing, from AI and big data to the web and connected devices, open source is the key ingredient for success&mldr;
-        </p>
+        <p class="p-card--strip-thin__content">Open source is transforming the entire stack. This is your chance to be right at the center of that revolution, to shape the platforms and tools that millions use to invent our global technology future. From bare metal to cloud to high performance computing, from AI and big data to the web and connected devices, open source is the key ingredient for success&hellip;</p>
         <a href="/careers/engineering">More&nbsp;&rsaquo;</a>
       </div>
       <div class="col-6 p-card--strip-thin">
         <h2 class="p-card--strip-thin__title">Tech-ops</h2>
-        <p class="p-card--strip-thin__content">Getting it done right is the best feeling in the world. Whether it’s running complex technical infrastructure or challenging projects, your consistent focus on data, organisation and teamwork means you’re a force for good in the battle against entropy. Time zones are easy and technical customers are your favourite&mldr;
-        </p>
+        <p class="p-card--strip-thin__content">Getting it done right is the best feeling in the world. Whether it’s running complex technical infrastructure or challenging projects, your consistent focus on data, organisation and teamwork means you’re a force for good in the battle against entropy. Time zones are easy and technical customers are your favourite&hellip;</p>
         <a href="/careers/tech-ops">More&nbsp;&rsaquo;</a>
       </div>
     </div>
     <div class="row u-equal-height">
       <div class="col-4 p-card--strip-thin">
         <h4 class="p-card--strip-thin__title">Project Management</h4>
-        <p class="p-card--strip-thin__content">Lorem ipsum dolor sit amet consectetur adipisicing elit. Repudiandae quisquam error laboriosam! Obcaecati earum, quasi mollitia rem corporis ratione autem delectus eos, nemo molestiae sequi eum qui tempora, ipsam dolor&mldr;
-        </p>
+        <p class="p-card--strip-thin__content">Project Managers at Canonical are engaged during all phases of the project, from pre-sales support, to delivery to handoff of complete projects to support or managed services.  Project managers create, manage, and maintain project specific schedules ensuring projects are delivered within time/resources/scope expectations&hellip;</p>
         <a href="/careers/project-management">More&nbsp;&rsaquo;</a>
       </div>
       <div class="col-4 p-card--strip-thin">
         <h4 class="p-card--strip-thin__title">Commercial-ops</h4>
-        <p class="p-card--strip-thin__content">Lorem ipsum dolor sit amet consectetur adipisicing elit. Maiores alias ipsam voluptate accusamus nisi dicta aut, dolorum quae aperiam libero, vitae distinctio quisquam ratione illo ut? Animi maiores soluta facere.&mldr;
-        </p>
+        <p class="p-card--strip-thin__content">Excellence in operations enables Canonical to scale efficiently. Our core operations - from IT to commercial operations or logistics - is central to the idea that we can be an effective global distributed company serving advanced customers in every geography. We celebrate relentless improvement. We look for people who are passionate about tools and efficiency&hellip;</p>
         <a href="/careers/commercial-ops">More&nbsp;&rsaquo;</a>
       </div>
       <div class="col-4 p-card--strip-thin">
         <h4 class="p-card--strip-thin__title">Sales</h4>
-        <p class="p-card--strip-thin__content">You build long term relationships and you always promote the approach that is in the customers best interests. You are interested in the state of the art, you love to represent a company that knows how to transform customer operations&mldr;
-        </p>
+        <p class="p-card--strip-thin__content">You build long term relationships and you always promote the approach that is in the customers best interests. You are interested in the state of the art, you love to represent a company that knows how to transform customer operations&hellip;</p>
         <a href="/careers/sales">More&nbsp;&rsaquo;</a>
       </div>
     </div>


### PR DESCRIPTION
## Done
Update the careers overview page content

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/careers
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check it matches the [copydoc](https://docs.google.com/document/d/1pNyOXfR07FiBr6TmEMRdB7NZUB5SeBz6COuSxO3ylC0/edit#)

## Issue / Card
Fixes https://github.com/canonical-web-and-design/canonical.com/issues/78
