### PR TITLE
Fix commercial-ops and admin link in the nav

### DIFF
--- a/templates/careers/_secondary-navigation.html
+++ b/templates/careers/_secondary-navigation.html
@@ -13,7 +13,7 @@
           <a class="breadcrumbs__link {% if request.path|get_secondary_nav_path == 'admin' %}p-link--active{% else %}p-link--soft{% endif %}" href="/careers/admin">Admin</a>
         </li>
         <li class="breadcrumbs__item">
-          <a class="breadcrumbs__link {% if request.path|get_secondary_nav_path == 'commerical-ops' %}p-link--active{% else %}p-link--soft{% endif %}" href="/careers/commerical-ops">Commerical ops</a>
+          <a class="breadcrumbs__link {% if request.path|get_secondary_nav_path == 'commercial-ops' %}p-link--active{% else %}p-link--soft{% endif %}" href="/careers/commercial-ops">Commercial-ops</a>
         </li>
         <li class="breadcrumbs__item">
           <a class="breadcrumbs__link {% if request.path|get_secondary_nav_path == 'design' %}p-link--active{% else %}p-link--soft{% endif %}" href="/careers/design">Design</a>
@@ -43,13 +43,13 @@
           <a class="breadcrumbs__link {% if request.path|get_secondary_nav_path == 'progression' %}p-link--active{% else %}p-link--soft{% endif %}" href="/careers/progression">Progression</a>
         </li>
         <li class="breadcrumbs__item">
-          <a class="breadcrumbs__link {% if request.path|get_secondary_nav_path == 'project-management' %}p-link--active{% else %}p-link--soft{% endif %}" href="/careers/project-management">Project management</a>
+          <a class="breadcrumbs__link {% if request.path|get_secondary_nav_path == 'project-management' %}p-link--active{% else %}p-link--soft{% endif %}" href="/careers/project-management">Project Management</a>
         </li>
         <li class="breadcrumbs__item">
           <a class="breadcrumbs__link {% if request.path|get_secondary_nav_path == 'sales' %}p-link--active{% else %}p-link--soft{% endif %}" href="/careers/sales">Sales</a>
         </li>
         <li class="breadcrumbs__item">
-          <a class="breadcrumbs__link {% if request.path|get_secondary_nav_path == 'tech-ops' %}p-link--active{% else %}p-link--soft{% endif %}" href="/careers/tech-ops">Tech ops</a>
+          <a class="breadcrumbs__link {% if request.path|get_secondary_nav_path == 'tech-ops' %}p-link--active{% else %}p-link--soft{% endif %}" href="/careers/tech-ops">Tech-ops</a>
         </li>
         <li class="breadcrumbs__item">
           <a class="breadcrumbs__link {% if request.path|get_secondary_nav_path == 'travel' %}p-link--active{% else %}p-link--soft{% endif %}" href="/careers/travel">Travel</a>

--- a/templates/careers/index.html
+++ b/templates/careers/index.html
@@ -66,7 +66,7 @@
         <a href="/careers/legal">More&nbsp;&rsaquo;</a>
       </div>
       <div class="col-4 p-card--strip-thin">
-        <h4 class="p-card--strip-thin__title">Administration</h4>
+        <h4 class="p-card--strip-thin__title">Admin</h4>
         <p class="p-card--strip-thin__content">Canonical is a completely new kind of organisation - almost entirely distributed, we are a global team of technology leaders who collaborate online to enable the transformation of enterprise software to open source&mldr;
         </p>
         <a href="/careers/admin">More&nbsp;&rsaquo;</a>

--- a/templates/partial/_navigation-careers.html
+++ b/templates/partial/_navigation-careers.html
@@ -41,13 +41,13 @@
         <div class="col-3">
           <h4 class="p-heading--four is-dense p-muted-heading" style="padding-top: .5rem; margin-bottom: 1.5rem;">Explore opportunities in</h4>
           <ul class="p-list">
-            <li class="p-list__item"><a href="/careers/tech-ops">Tech ops&nbsp;&rsaquo;</a></li>
-            <li class="p-list__item"><a href="/careers/commerical-ops">Commerical ops&nbsp;&rsaquo;</a></li>
+            <li class="p-list__item"><a href="/careers/tech-ops">Tech-ops&nbsp;&rsaquo;</a></li>
+            <li class="p-list__item"><a href="/careers/commercial-ops">Commercial-ops&nbsp;&rsaquo;</a></li>
             <li class="p-list__item"><a href="/careers/design">Design&nbsp;&rsaquo;</a></li>
             <li class="p-list__item"><a href="/careers/finance">Finance&nbsp;&rsaquo;</a></li>
             <li class="p-list__item"><a href="/careers/project-management">Project Management&nbsp;&rsaquo;</a></li>
             <li class="p-list__item"><a href="/careers/legal">Legal&nbsp;&rsaquo;</a></li>
-            <li class="p-list__item"><a href="/careers/administration">Administration&nbsp;&rsaquo;</a></li>
+            <li class="p-list__item"><a href="/careers/admin">Admin&nbsp;&rsaquo;</a></li>
             <li class="p-list__item"><a href="/careers/hr">HR&nbsp;&rsaquo;</a></li>
           </ul>
           <div class="u-hide u-show--small">


### PR DESCRIPTION
## Done

- Fix `commercial-sop` and `admin` link in the navigation
- Make all navs consistent in terms of naming

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Click on `careers` at the top and then on `commercial-ops` and after `admin`. See that the navigation works.


## Issue / Card

Fixes #75 #76 
