### PR TITLE
86 update careers techops

### DIFF
--- a/templates/careers/admin.html
+++ b/templates/careers/admin.html
@@ -14,31 +14,19 @@
 
 {% block overview_tab %}
   <div class="p-strip is-shallow u-extra-space tab-content" id="overview">
-    <div class="row">
-      <div class="col-12">
-        <p>
-          <strong>Canonical is a completely new kind of organisation - almost entirely distributed, we are a global team of technology leaders who collaborate online to enable the transformation of enterprise software to open source. We have a few office locations, but almost everybody works from home. Teams get together every few months at locations around the world to plan and coordinate their projects.</strong>
-        </p>
-        <p>
-          All of this means that administration is central to the effective running of the company. Hundreds of distributed team members count on effective processes to support their travel and operations. Our admin team run events, control expenses, manage travel and coordinate meetings. We are trusted to hold the global team accountable to the company policies. We ensure that the business operates smoothly and we have a significant impact on the quality of the experience that people have at the company.
-        </p>
-        <p>
-          We are a multi-skilled and multi-cultural team. We encourage new members of the team to develop skills across the entire range of admin challenges so that we can help one another as needed and bring our joint insights to bear on continuous improvement. Our team is largely based in offices in Austin, Boston, London, Taipei and Beijing, but we offer some flexibility to work from home. We often run company events around the world in person, so you need the latitude to be in a completely different timezone for up to two weeks at a time, three or four times a year.
-        </p>
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-12">
-        <hr />
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-12">
-        <p class="p-muted-heading">
-          <span style="text-transform: capitalize">Austin&nbsp;&#124;&nbsp;Beijing&nbsp;&#124;&nbsp;Boston&nbsp;&#124;&nbsp;London&nbsp;&#124;&nbsp;Taipei</span>
-        </p>
-        <a href="#available-roles">Apply now&nbsp;&rsaquo;</a>
-      </div>
-    </div>
+    <p>
+      <strong>Canonical is a completely new kind of organisation - almost entirely distributed, we are a global team of technology leaders who collaborate online to enable the transformation of enterprise software to open source. We have a few office locations, but almost everybody works from home. Teams get together every few months at locations around the world to plan and coordinate their projects.</strong>
+    </p>
+    <p>
+      All of this means that administration is central to the effective running of the company. Hundreds of distributed team members count on effective processes to support their travel and operations. Our admin team run events, control expenses, manage travel and coordinate meetings. We are trusted to hold the global team accountable to the company policies. We ensure that the business operates smoothly and we have a significant impact on the quality of the experience that people have at the company.
+    </p>
+    <p>
+      We are a multi-skilled and multi-cultural team. We encourage new members of the team to develop skills across the entire range of admin challenges so that we can help one another as needed and bring our joint insights to bear on continuous improvement. Our team is largely based in offices in Austin, Boston, London, Taipei and Beijing, but we offer some flexibility to work from home. We often run company events around the world in person, so you need the latitude to be in a completely different timezone for up to two weeks at a time, three or four times a year.
+    </p>
+    <hr />
+    <p class="p-muted-heading">
+      <span style="text-transform: capitalize">Austin&nbsp;&#124;&nbsp;Beijing&nbsp;&#124;&nbsp;Boston&nbsp;&#124;&nbsp;London&nbsp;&#124;&nbsp;Taipei</span>
+    </p>
+    <a href="#available-roles">Apply now&nbsp;&rsaquo;</a>
   </div>
 {% endblock %}

--- a/templates/careers/all.html
+++ b/templates/careers/all.html
@@ -18,31 +18,19 @@
 
 {% block overview_tab %}
   <div class="p-strip is-shallow u-extra-space tab-content" id="overview">
-    <div class="row">
-      <div class="col-12">
-        <p>
-          <strong>Canonical is a completely new kind of organisation &ndash; almost entirely distributed, we are a global team of technology leaders who collaborate online to enable the transformation of enterprise software to open source. We have a few office locations, but almost everybody works from home. Teams get together every few months at locations around the world to plan and coordinate their projects.</strong>
-        </p>
-        <p>
-          All of this means that administration is central to the effective running of the company. Hundreds of distributed team members count on effective processes to support their travel and operations. Our admin team run events, control expenses, manage travel and coordinate meetings. We are trusted to hold the global team accountable to the company policies. We ensure that the business operates smoothly and we have a significant impact on the quality of the experience that people have at the company.
-        </p>
-        <p>
-          We are a multi-skilled and multi-cultural team. We encourage new members of the team to develop skills across the entire range of admin challenges so that we can help one another as needed and bring our joint insights to bear on continuous improvement. Our team is largely based in offices in Austin, Boston, London, Taipei and Beijing, but we offer some flexibility to work from home. We often run company events around the world in person, so you need the latitude to be in a completely different timezone for up to two weeks at a time, three or four times a year.
-        </p>
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-12">
-        <hr />
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-12">
-        <p class="p-muted-heading">
-          <span style="text-transform: capitalize">Austin&nbsp;&#124;&nbsp;Beijing&nbsp;&#124;&nbsp;Boston&nbsp;&#124;&nbsp;London&nbsp;&#124;&nbsp;Taipei</span>
-        </p>
-        <a href="#available-roles">Apply now&nbsp;&rsaquo;</a>
-      </div>
-    </div>
+    <p>
+      <strong>Canonical is a completely new kind of organisation &ndash; almost entirely distributed, we are a global team of technology leaders who collaborate online to enable the transformation of enterprise software to open source. We have a few office locations, but almost everybody works from home. Teams get together every few months at locations around the world to plan and coordinate their projects.</strong>
+    </p>
+    <p>
+      All of this means that administration is central to the effective running of the company. Hundreds of distributed team members count on effective processes to support their travel and operations. Our admin team run events, control expenses, manage travel and coordinate meetings. We are trusted to hold the global team accountable to the company policies. We ensure that the business operates smoothly and we have a significant impact on the quality of the experience that people have at the company.
+    </p>
+    <p>
+      We are a multi-skilled and multi-cultural team. We encourage new members of the team to develop skills across the entire range of admin challenges so that we can help one another as needed and bring our joint insights to bear on continuous improvement. Our team is largely based in offices in Austin, Boston, London, Taipei and Beijing, but we offer some flexibility to work from home. We often run company events around the world in person, so you need the latitude to be in a completely different timezone for up to two weeks at a time, three or four times a year.
+    </p>
+    <hr />
+    <p class="p-muted-heading">
+      <span style="text-transform: capitalize">Austin&nbsp;&#124;&nbsp;Beijing&nbsp;&#124;&nbsp;Boston&nbsp;&#124;&nbsp;London&nbsp;&#124;&nbsp;Taipei</span>
+    </p>
+    <a href="#available-roles">Apply now&nbsp;&rsaquo;</a>
   </div>
 {% endblock %}

--- a/templates/careers/commercial-ops.html
+++ b/templates/careers/commercial-ops.html
@@ -14,23 +14,10 @@
 
 {% block overview_tab %}
   <div class="p-strip is-shallow u-extra-space tab-content" id="overview">
-    <div class="row">
-      <div class="col-12">
-
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-12">
-        <hr />
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-12">
-        <p class="p-muted-heading">
-          <span style="text-transform: capitalize">Europe&nbsp;&#124;&nbsp;Middle East&nbsp;&#124;&nbsp;Africa&nbsp;&#124;&nbsp;Americas&nbsp;&#124;&nbsp;APAC</span>
-        </p>
-        <a href="#available-roles">Apply now&nbsp;&rsaquo;</a>
-      </div>
-    </div>
+    <hr />
+    <p class="p-muted-heading">
+      <span style="text-transform: capitalize">Europe&nbsp;&#124;&nbsp;Middle East&nbsp;&#124;&nbsp;Africa&nbsp;&#124;&nbsp;Americas&nbsp;&#124;&nbsp;APAC</span>
+    </p>
+    <a href="#available-roles">Apply now&nbsp;&rsaquo;</a>
   </div>
 {% endblock %}

--- a/templates/careers/design.html
+++ b/templates/careers/design.html
@@ -1,5 +1,7 @@
 {% extends '/careers/careers_base.html' %}
 
+{% block meta_description %}Canonical publishes Ubuntu and provides commercial services and solutions for Ubuntu. The design team works on web applications for enterprise, cloud services and operating system for IoT and embedded devices focusing on current design thinking, technology and innovation.{% endblock %}
+
 {% block meta_copydoc %}https://docs.google.com/document/d/1V8SzuqyJEqXAXf_FrobdNn5-OLzTvKWcRlfBXjI9oBo{% endblock meta_copydoc %}
 
 {% block hero %}
@@ -16,40 +18,28 @@
 
 {% block overview_tab %}
   <div class="p-strip is-shallow u-extra-space tab-content" id="overview">
-    <div class="row">
-      <div class="col-12">
-        <p><strong>Canonical and Ubuntu are central to modern tech &ndash; from cloud to the internet of things, from the web to mobile back-ends, from development to production.</strong>
-        </p>
-        <p>
-          The design team at Canonical crafts the user-experiences of  sophisticated technical specialists across a wide range of industries and geographies. Canonical delivers Ubuntu, and a range of tools &ndash; for engineers, admins and enterprises &ndash; to help businesses move to an open source stack.
-        </p>
-        <p>
-          Your opportunity is to shape the user experience across the enterprise infrastructure and application operations landscape. There are challenges at every layer of the stack &ndash; from bare metal data center operations, to virtualisation infrastructure and cloud, to the desktop, to systems management, to serverless and embedded connected devices.
-        </p>
-        <p>
-          Canonical designers work on a range of products, using common visual and web frameworks to create consistency of experience across a very wide range of capabilities.
-        </p>
-        <p>
-          Our team, centered in Europe, has  specialists in visual and ux design, and front and back end development. We collaborate, as product design squads, with global distributed development engineering teams. Designers need to be effective working collaboratively in a digital space. We travel to engineering sprints and summits for face to face time.
-        </p>
-        <p>
-          We count on our team to bring together deep design-thinking, technical domain knowledge, with great instincts, through a rigorous process &ndash; to shape products for a very demanding audience. You’ll fit in if you have equal appetites for design, innovation and technology.
-        </p>
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-12">
-        <hr />
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-12">
-        <p class="p-muted-heading">
-          <span>Emea</span>&nbsp;&#124;&nbsp;<span style="text-transform: capitalize">Americas</span>
-        </p>
-        <a href="#available-roles">Apply now&nbsp;&rsaquo;</a>
-      </div>
-    </div>
+    <p><strong>Canonical and Ubuntu are central to modern tech &ndash; from cloud to the internet of things, from the web to mobile back-ends, from development to production.</strong>
+    </p>
+    <p>
+      The design team at Canonical crafts the user-experiences of  sophisticated technical specialists across a wide range of industries and geographies. Canonical delivers Ubuntu, and a range of tools &ndash; for engineers, admins and enterprises &ndash; to help businesses move to an open source stack.
+    </p>
+    <p>
+      Your opportunity is to shape the user experience across the enterprise infrastructure and application operations landscape. There are challenges at every layer of the stack &ndash; from bare metal data center operations, to virtualisation infrastructure and cloud, to the desktop, to systems management, to serverless and embedded connected devices.
+    </p>
+    <p>
+      Canonical designers work on a range of products, using common visual and web frameworks to create consistency of experience across a very wide range of capabilities.
+    </p>
+    <p>
+      Our team, centered in Europe, has  specialists in visual and ux design, and front and back end development. We collaborate, as product design squads, with global distributed development engineering teams. Designers need to be effective working collaboratively in a digital space. We travel to engineering sprints and summits for face to face time.
+    </p>
+    <p>
+      We count on our team to bring together deep design-thinking, technical domain knowledge, with great instincts, through a rigorous process &ndash; to shape products for a very demanding audience. You’ll fit in if you have equal appetites for design, innovation and technology.
+    </p>
+    <hr />
+    <p class="p-muted-heading">
+      <span>Emea</span>&nbsp;&#124;&nbsp;<span style="text-transform: capitalize">Americas</span>
+    </p>
+    <a href="#available-roles">Apply now&nbsp;&rsaquo;</a>
   </div>
 {% endblock %}
 

--- a/templates/careers/diversity.html
+++ b/templates/careers/diversity.html
@@ -2,6 +2,8 @@
 
 {% block meta_description %}Canonical proactively promotes leaders who represent new kinds of diversity, to grow the confidence of colleagues from every walk of life. We seek to create an environment that is welcoming to outstanding technology and business professionals committed to teamwork and open source.{% endblock %}
 
+{% block meta_copydoc %}https://docs.google.com/document/d/1L8z8Np75JN2wJa72iVrv-eRFzGiqiGW4HZiD8muPOAQ{% endblock meta_copydoc %}
+
 {% block hero %}
   <section class="p-strip--image is-dark is-deep u-no-padding--top u-no-padding--bottom u-extra-space">
     <div class="p-strip--suru-background">
@@ -15,17 +17,13 @@
 {% endblock %}
 
 {% block overview %}
-  <div class="row">
-    <div class="col-12">
-      <p>
-        <strong>We believe that talent is evenly distributed around the world. No matter where you were born, or what you look like, or how you like to dress, we think you might have the brilliance and the work ethic and the passion for open source that would make you a Canonical candidate.</strong>
-      </p>
-      <p>
-        The diversity in our company is part of our strength. What unifies us isn’t our background or our culture, it’s our vision of the future and our dedication to delivering the best of the future for our customers and our colleagues. We are unified in our pursuit of company and personal excellence in our chosen fields, we are unified in our commitment to teamwork, and we have a common vision of open source as the platform that best empowers innovators in a modern digital society. 
-      </p>
-      <p>
-        We believe in affirmative action, because we know it builds confidence in new team members when they can relate to people with similar backgrounds in their workplace. But we also expect people to look beyond the obvious and relate to intrinsic motivation and quality of work, not superficial qualities.
-      </p>
-    </div>
-  </div>
+  <p>
+    <strong>We believe that talent is evenly distributed around the world. No matter where you were born, or what you look like, or how you like to dress, we think you might have the brilliance and the work ethic and the passion for open source that would make you a Canonical candidate.</strong>
+  </p>
+  <p>
+    The diversity in our company is part of our strength. What unifies us isn’t our background or our culture, it’s our vision of the future and our dedication to delivering the best of the future for our customers and our colleagues. We are unified in our pursuit of company and personal excellence in our chosen fields, we are unified in our commitment to teamwork, and we have a common vision of open source as the platform that best empowers innovators in a modern digital society. 
+  </p>
+  <p>
+    We believe in affirmative action, because we know it builds confidence in new team members when they can relate to people with similar backgrounds in their workplace. But we also expect people to look beyond the obvious and relate to intrinsic motivation and quality of work, not superficial qualities.
+  </p>
 {% endblock %}

--- a/templates/careers/engineering.html
+++ b/templates/careers/engineering.html
@@ -16,37 +16,25 @@
 
 {% block overview_tab %}
   <div class="p-strip is-shallow u-extra-space tab-content" id="overview">
-    <div class="row">
-      <div class="col-12">
-        <p>
-          <strong>Open source is transforming the entire stack. This is your chance to be right at the center of that revolution, to shape the platforms and tools that millions use to invent our global technology future. From bare metal to cloud to high performance computing, from AI and big data to the web and connected devices, open source is the key ingredient for success. Canonical offers the opportunity to work across the entire spectrum.</strong>
-        </p>
-        <p>
-          We publish Ubuntu, the leanest and most efficient open source platform. We care about developer access to the very best of open source, and make it easy to innovate and publish on the cloud, on the desktop, and on smart connected devices for the internet of things. We work across the full range of open source - from the kernel, to applications, from deep system services to the GUI and the web. We care about security, correctness, reliability, performance and efficiency. If you share those values and you have a track record of exceptional software development, this is the place for you.
-        </p>
-        <p>
-          With the flexibility to work from anywhere in the world as long as you are an outstanding and reliable team member, Canonical offers engineering career paths that include technical mastery, leadership, or management. We don’t prescribe your journey - explore different kinds of career development and choose the path that suits you best. We do expect world-leading software quality and personal dedication to the challenges you take on.
-        </p>
-        <p>
-          Engineering at Canonical ranges from deep single-product specialization, to diverse customer-centric field integration, delivery and development, and high-pressure rapid-response to critical situations in our techops team. The right career for you will depend on your interests and aptitudes. If you love the idea of travel and seeing the world, our field engineers work on-site with the world’s best companies to transform their open infrastructure. If you love saving the day, our techops teams fight fires shoulder to shoulder, from security incident response to deep problem analysis and repair. If you love operations, we take a code-first approach to infrastructure and application operations that is raising the bar for the entire industry.
-        </p>
-        <p>
-          We see all of these as engineering roles and we encourage people to build a career that spans diverse aspects of software development and operations. Regardless of your starting point, you have the option to progress in any of those roles, or to gain experience in management or technical leadership.
-        </p>
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-12">
-        <hr />
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-12">
-        <p class="p-muted-heading">
-          <span style="text-transform: capitalize">Europe&nbsp;&#124;&nbsp;Middle East&nbsp;&#124;&nbsp;Africa&nbsp;&#124;&nbsp;Americas&nbsp;&#124;&nbsp;APAC</span>
-        </p>
-        <a href="#available-roles">Apply now&nbsp;&rsaquo;</a>
-      </div>
-    </div>
+    <p>
+      <strong>Open source is transforming the entire stack. This is your chance to be right at the center of that revolution, to shape the platforms and tools that millions use to invent our global technology future. From bare metal to cloud to high performance computing, from AI and big data to the web and connected devices, open source is the key ingredient for success. Canonical offers the opportunity to work across the entire spectrum.</strong>
+    </p>
+    <p>
+      We publish Ubuntu, the leanest and most efficient open source platform. We care about developer access to the very best of open source, and make it easy to innovate and publish on the cloud, on the desktop, and on smart connected devices for the internet of things. We work across the full range of open source - from the kernel, to applications, from deep system services to the GUI and the web. We care about security, correctness, reliability, performance and efficiency. If you share those values and you have a track record of exceptional software development, this is the place for you.
+    </p>
+    <p>
+      With the flexibility to work from anywhere in the world as long as you are an outstanding and reliable team member, Canonical offers engineering career paths that include technical mastery, leadership, or management. We don’t prescribe your journey - explore different kinds of career development and choose the path that suits you best. We do expect world-leading software quality and personal dedication to the challenges you take on.
+    </p>
+    <p>
+      Engineering at Canonical ranges from deep single-product specialization, to diverse customer-centric field integration, delivery and development, and high-pressure rapid-response to critical situations in our techops team. The right career for you will depend on your interests and aptitudes. If you love the idea of travel and seeing the world, our field engineers work on-site with the world’s best companies to transform their open infrastructure. If you love saving the day, our techops teams fight fires shoulder to shoulder, from security incident response to deep problem analysis and repair. If you love operations, we take a code-first approach to infrastructure and application operations that is raising the bar for the entire industry.
+    </p>
+    <p>
+      We see all of these as engineering roles and we encourage people to build a career that spans diverse aspects of software development and operations. Regardless of your starting point, you have the option to progress in any of those roles, or to gain experience in management or technical leadership.
+    </p>
+    <hr />
+    <p class="p-muted-heading">
+      <span style="text-transform: capitalize">Europe&nbsp;&#124;&nbsp;Middle East&nbsp;&#124;&nbsp;Africa&nbsp;&#124;&nbsp;Americas&nbsp;&#124;&nbsp;APAC</span>
+    </p>
+    <a href="#available-roles">Apply now&nbsp;&rsaquo;</a>
   </div>
 {% endblock %}

--- a/templates/careers/ethics.html
+++ b/templates/careers/ethics.html
@@ -2,6 +2,8 @@
 
 {% block meta_description %}Trust in Canonical’s Ubuntu and other products is well-earned and critical to our future. We have a very high expectation of ethical behaviour at the company and in particular among leaders of any sort.{% endblock %}
 
+{% block meta_copydoc %}https://docs.google.com/document/d/1K2pY9lFlKvdL3jZ6Ih5sgritIP23z_KQS3DVMlZxbqw{% endblock meta_copydoc %}
+
 {% block hero %}
   <section class="p-strip--image is-dark is-deep u-no-padding--top u-no-padding--bottom u-extra-space">
     <div class="p-strip--suru-background">
@@ -15,17 +17,13 @@
 {% endblock %}
 
 {% block overview %}
-  <div class="row">
-    <div class="col-12">
-      <p>
-        <strong>Trust is our most precious asset.</strong>
-      </p>
-      <p>
-        We take our responsible for the most critical elements of every piece of open infrastructure in the software-defined world very seriously, and we are committed to quality in every aspect of our product and services. When people deploy Ubuntu, they trust Canonical to ensure that it is secure and robust, that it represents the best balance of possibility and pragmatism, and that it is the best way for them to benefit from and participate in the open source movement.
-      </p>
-      <p>
-        From time to time we know everybody has tough choices to make. We support our leads in doing things properly, even if that means taking extra time. We expect a high level of productivity but we expect much of that effort to go into quality. Most importantly, we have an uncompromising approach to ethics and do not tolerate ambiguity when it comes to the interests of our customers. Ethical failures are grounds for dismissal from the team.
-      </p>
-    </div>
-  </div>
+  <p>
+    <strong>Trust is our most precious asset.</strong>
+  </p>
+  <p>
+    We take our responsible for the most critical elements of every piece of open infrastructure in the software-defined world very seriously, and we are committed to quality in every aspect of our product and services. When people deploy Ubuntu, they trust Canonical to ensure that it is secure and robust, that it represents the best balance of possibility and pragmatism, and that it is the best way for them to benefit from and participate in the open source movement.
+  </p>
+  <p>
+    From time to time we know everybody has tough choices to make. We support our leads in doing things properly, even if that means taking extra time. We expect a high level of productivity but we expect much of that effort to go into quality. Most importantly, we have an uncompromising approach to ethics and do not tolerate ambiguity when it comes to the interests of our customers. Ethical failures are grounds for dismissal from the team.
+  </p>
 {% endblock %}

--- a/templates/careers/finance.html
+++ b/templates/careers/finance.html
@@ -16,38 +16,26 @@
 
 {% block overview_tab %}
   <div class="p-strip is-shallow u-extra-space tab-content" id="overview">
-    <div class="row">
-      <div class="col-12">
-        <p><strong>Finance at Canonical isn’t just about numbers. It’s about connecting with people across the business, helping them to understand the value they bring, as well as promoting the commercial focus that will grow our brand.</strong></p>
-        <p>
-          We fuel growth by devising innovative solutions to complex problems in forecasting, accounting, compliance, and project management. From advising all teams across the business to managing day-to-day data, you’ll help keep our business on track to meet (or, better yet, exceed) our goals.
-        </p>
-        <p>
-          With significant growth and a stated path to public markets, industry&ndash;leading analysis is essential. As part of this we:
-        </p>
-        <ul class="p-list">
-          <li class="p-list__item is-ticked">Translate complex data into actionable insights that drive strategic company decisions, whether modelling business scenarios or tracking performance metrics.</li>
-          <li class="p-list__item is-ticked">Manage large-scale projects. Develop and implement insightful strategies that address and solve our complex business needs.</li>
-          <li class="p-list__item is-ticked">Protect Canonical by partnering with our business and engineering teams to identify and address risks related to product launches and other initiatives.</li>
-          <li class="p-list__item is-ticked">Balance our legal and compliance requirements with our company values and the dynamic needs of our users, along with developing efficient systems to ensure Canonical keeps up with regulations.</li>
-        </ul>
-        <p>
-          The finance team at Canonical offers rapid growth in understanding both industry best practice with analytical excellence. We welcome candidates with an outstanding track record, a commitment to teamwork, and a personal interest in the future of software and the financial frameworks that underpin it.
-        </p>
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-12">
-        <hr />
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-12">
-        <p class="p-muted-heading">
-          <span style="text-transform: capitalize">Europe&nbsp;&#124;&nbsp;Middle East&nbsp;&#124;&nbsp;Africa&nbsp;&#124;&nbsp;Americas&nbsp;&#124;&nbsp;APAC</span>
-        </p>
-        <a href="#available-roles">Apply now&nbsp;&rsaquo;</a>
-      </div>
-    </div>
+    <p><strong>Finance at Canonical isn’t just about numbers. It’s about connecting with people across the business, helping them to understand the value they bring, as well as promoting the commercial focus that will grow our brand.</strong></p>
+    <p>
+      We fuel growth by devising innovative solutions to complex problems in forecasting, accounting, compliance, and project management. From advising all teams across the business to managing day-to-day data, you’ll help keep our business on track to meet (or, better yet, exceed) our goals.
+    </p>
+    <p>
+      With significant growth and a stated path to public markets, industry&ndash;leading analysis is essential. As part of this we:
+    </p>
+    <ul class="p-list">
+      <li class="p-list__item is-ticked">Translate complex data into actionable insights that drive strategic company decisions, whether modelling business scenarios or tracking performance metrics.</li>
+      <li class="p-list__item is-ticked">Manage large-scale projects. Develop and implement insightful strategies that address and solve our complex business needs.</li>
+      <li class="p-list__item is-ticked">Protect Canonical by partnering with our business and engineering teams to identify and address risks related to product launches and other initiatives.</li>
+      <li class="p-list__item is-ticked">Balance our legal and compliance requirements with our company values and the dynamic needs of our users, along with developing efficient systems to ensure Canonical keeps up with regulations.</li>
+    </ul>
+    <p>
+      The finance team at Canonical offers rapid growth in understanding both industry best practice with analytical excellence. We welcome candidates with an outstanding track record, a commitment to teamwork, and a personal interest in the future of software and the financial frameworks that underpin it.
+    </p>
+    <hr />
+    <p class="p-muted-heading">
+      <span style="text-transform: capitalize">Europe&nbsp;&#124;&nbsp;Middle East&nbsp;&#124;&nbsp;Africa&nbsp;&#124;&nbsp;Americas&nbsp;&#124;&nbsp;APAC</span>
+    </p>
+    <a href="#available-roles">Apply now&nbsp;&rsaquo;</a>
   </div>
 {% endblock %}

--- a/templates/careers/hr.html
+++ b/templates/careers/hr.html
@@ -16,30 +16,18 @@
 
 {% block overview_tab %}
   <div class="p-strip is-shallow u-extra-space tab-content" id="overview">
-    <div class="row">
-      <div class="col-12">
-        <p><strong>Canonical provides a unique window into the world of 21st&dash;century digital business. We work with smart individuals from a wide range of professional backgrounds in more than 40 countries worldwide, bringing together distinct and diverse perspectives to contribute to the advancement of state&dash;of&dash;the&dash;art technical infrastructure. Our team is united by a passion for open engineering and a commitment to crisp, reliable execution which enables us to exceed our customers&rsquo; expectations when it comes to next&dash;generation open source technology.</strong>
-        </p>
-        <p>
-          Our set&dash;up provides a unique challenge for our HR team, who ensure that we operate consistently on a global basis and are compliant with regional and national regulations. If you are interested in finding, coaching, and developing the best talent, Canonical encourages our management team to hire the best person for the job, no matter who they are or where they are located. If you are fascinated by the technical and legal aspects of HR, Canonical will give you the chance to work with teams in multiple jurisdictions, from Asia to the Americas and so many places in between.
-        </p>
-        <p>
-          We pride ourselves on exceptional quality of work and our HR team embody and build that quality within Canonical. Our HR team is central to the development and growth of that capacity and competence. Our commitment to the team is to seek out potential colleagues with the right mix of interests, aptitudes and attitudes, to coach and develop them through a varied career ensuring that they have the right opportunities to learn and the right mix of challenges to suit their interests. Our commitment to the business is to ensure that we operate consistently on a global basis, mindful of the details of regional and national regulations. We are also committed to offering our HR and talent professionals the coaching, learning opportunities, and challenges that will enable them to create a varied and successful career.
-        </p>
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-12">
-        <hr />
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-12">
-        <p class="p-muted-heading">
-          <span style="text-transform: capitalize">Europe&nbsp;&#124;&nbsp;Americas</span>
-        </p>
-        <a href="#available-roles">Apply now&nbsp;&rsaquo;</a>
-      </div>
-    </div>
+    <p><strong>Canonical provides a unique window into the world of 21st-century digital business. We work with smart individuals from a wide range of professional backgrounds in more than 40 countries worldwide, bringing together distinct and diverse perspectives to contribute to the advancement of state-of-the-art technical infrastructure. Our team is united by a passion for open engineering and a commitment to crisp, reliable execution which enables us to exceed our customers’ expectations when it comes to next-generation open source technology.</strong>
+    </p>
+    <p>
+      Our set-up provides a unique challenge for our HR team, who ensure that we operate consistently on a global basis and are compliant with regional and national regulations. If you are interested in finding, coaching, and developing the best talent, Canonical encourages our management team to hire the best person for the job, no matter who they are or where they are located. If you are fascinated by the technical and legal aspects of HR, Canonical will give you the chance to work with teams in multiple jurisdictions, from Asia to the Americas and so many places in between.
+    </p>
+    <p>
+      We pride ourselves on exceptional quality of work and our HR team embody and build that quality within Canonical. Our HR team is central to the development and growth of that capacity and competence. Our commitment to the team is to seek out potential colleagues with the right mix of interests, aptitudes and attitudes, to coach and develop them through a varied career ensuring that they have the right opportunities to learn and the right mix of challenges to suit their interests. Our commitment to the business is to ensure that we operate consistently on a global basis, mindful of the details of regional and national regulations. We are also committed to offering our HR and talent professionals the coaching, learning opportunities, and challenges that will enable them to create a varied and successful career.
+    </p>
+    <hr />
+    <p class="p-muted-heading">
+      <span style="text-transform: capitalize">Europe&nbsp;&#124;&nbsp;Americas</span>
+    </p>
+    <a href="#available-roles">Apply now&nbsp;&rsaquo;</a>
   </div>
 {% endblock %}

--- a/templates/careers/legal.html
+++ b/templates/careers/legal.html
@@ -1,5 +1,7 @@
 {% extends '/careers/careers_base.html' %}
 
+{% block meta_copydoc %}https://docs.google.com/document/d/1aZSmg1coz5QKm-NLgzU0BwQbqIaGlwDzPGVH3Yju66k{% endblock meta_copydoc %}
+
 {% block hero %}
   <section class="p-strip--image is-dark is-deep u-no-padding--top u-no-padding--bottom u-extra-space">
     <div class="p-strip--suru-background">
@@ -14,33 +16,21 @@
 
 {% block overview_tab %}
   <div class="p-strip is-shallow u-extra-space tab-content" id="overview">
-    <div class="row">
-      <div class="col-12">
-        <p><strong>Canonical works at the forefront of global digital trends and the legal, licensing and regulatory frameworks that support them. We are a tight-knit team of professionals that enjoy playing a part in the rapid change of the software landscape to open infrastructure and applications, while supporting a fast-moving and global business.</strong>
-        </p>
-        <p>
-          Enabling enterprises, partners and technology providers across the globe to embrace the latest open source technology means efficient contracting that is both commercially sophisticated and technically interesting. We shape multinational agreements between many of the very largest organisations in a wide range of industries - from telecommunications to retail, financial services to media. And we participate in the world wide process to define and understand the future of collaborative engineering, as open source licenses explore new ways to support the creation of open software by companies and individual contributors.
-        </p>
-        <p>
-          Our goal is to reflect the simplest, cleanest and most understandable contractual framework to our counterparts, that represents current best practice and the latest approaches to software production, consumption and distribution. We pride ourselves on the combination of rigour and business enablement - we support complex deals in a way that protects all parties and minimises friction.
-        </p>
-        <p>
-          Experience at Canonical offers rapid growth in understanding the global legal landscape, both in terms of technology, but also in terms of commercial and corporate contracting. We welcome candidates with an outstanding track record, a commitment to teamwork, and a personal interest in the future of software and the legal frameworks that underpin it.
-        </p>
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-12">
-        <hr />
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-12">
-        <p class="p-muted-heading">
-          <span style="text-transform: capitalize">Europe&nbsp;&#124;&nbsp;Americas</span>
-        </p>
-        <a href="#available-roles">Apply now&nbsp;&rsaquo;</a>
-      </div>
-    </div>
+    <p><strong>Canonical works at the forefront of global digital trends and the legal, licensing and regulatory frameworks that support them. We are a tight-knit team of professionals that enjoy playing a part in the rapid change of the software landscape to open infrastructure and applications, while supporting a fast-moving and global business.</strong>
+    </p>
+    <p>
+      Enabling enterprises, partners and technology providers across the globe to embrace the latest open source technology means efficient contracting that is both commercially sophisticated and technically interesting. We shape multinational agreements between many of the very largest organisations in a wide range of industries - from telecommunications to retail, financial services to media. And we participate in the world wide process to define and understand the future of collaborative engineering, as open source licenses explore new ways to support the creation of open software by companies and individual contributors.
+    </p>
+    <p>
+      Our goal is to reflect the simplest, cleanest and most understandable contractual framework to our counterparts, that represents current best practice and the latest approaches to software production, consumption and distribution. We pride ourselves on the combination of rigour and business enablement - we support complex deals in a way that protects all parties and minimises friction.
+    </p>
+    <p>
+      Experience at Canonical offers rapid growth in understanding the global legal landscape, both in terms of technology, but also in terms of commercial and corporate contracting. We welcome candidates with an outstanding track record, a commitment to teamwork, and a personal interest in the future of software and the legal frameworks that underpin it.
+    </p>
+    <hr />
+    <p class="p-muted-heading">
+      <span style="text-transform: capitalize">Europe&nbsp;&#124;&nbsp;Americas</span>
+    </p>
+    <a href="#available-roles">Apply now&nbsp;&rsaquo;</a>
   </div>
 {% endblock %}

--- a/templates/careers/lifestyle.html
+++ b/templates/careers/lifestyle.html
@@ -2,6 +2,8 @@
 
 {% block meta_description %}Canonical offers a truly distributed workplace for exceptional colleagues who are self-motivated, organised. Maintain a home office and experience the top of global technology strategy and engineering. Travel regularly to interesting destinations for team, conference and customer engagements.{% endblock %}
 
+{% block meta_copydoc %}https://docs.google.com/document/d/15Ofb6vRUXbQ3evcWmrOu9ymuY37ayg4M_xZ2QXQyIts{% endblock meta_copydoc %}
+
 {% block hero %}
   <section class="p-strip--image is-dark is-deep u-no-padding--top u-no-padding--bottom u-extra-space">
     <div class="p-strip--suru-background">
@@ -15,15 +17,14 @@
   <style>
     .p-strip--suru-background {
       background-image:
-        linear-gradient(120deg,transparent 40%, rgba(74, 24, 60, 0.4) 50%, rgba(74, 24, 60, 0.4) 100%),
         linear-gradient(to top right, rgba(74,24,60,0) 0%, rgba(74,24,60,0) 49.9%, rgba(74, 24, 60, 0.4) 50%, rgba(74, 24, 60, 0.4) 100%),
         linear-gradient(to top left, #fff 0%, #fff 49%, transparent 50%),
         linear-gradient(to bottom right, rgba(210,180,202,0.05) 0%, rgba(210,180,202,0.05) 49.9%, rgba(210,180,202,0) 50%, rgba(210,180,202,0) 100%),
         linear-gradient(120deg, #2C001E 4%, #4C193E 54.9%, transparent 55%),
         url('https://assets.ubuntu.com/v1/883df027-canonical-travel.jpg');
-      background-position: right top, right top, bottom -1px right -1px, top left, top left, center right, right bottom;
+      background-position: right top, bottom -1px right -1px, top left, top left, center right, right bottom;
       background-repeat: no-repeat;
-      background-size: 100% 90%, 85% 100%, 105% 25%, 70% 80%, 100% 100%, 65% auto;
+      background-size: 85% 100%, 105% 25%, 70% 80%, 100% 100%, 65% auto;
       padding-bottom: 6rem;
       padding-top: 6rem;
     }
@@ -44,23 +45,19 @@
 {% endblock %}
 
 {% block overview %}
-  <div class="row">
-    <div class="col-12">
-      <p>
-        <strong>Canonical is unlike any other company in the world. It’s not for everybody, but it is amazing for people who are organized, passionate about technology, and like to travel. People at Canonical say the people at Canonical are amazing. That’s special.</strong>
-      </p>
-      <p>
-        We’re a technology company. Every role at Canonical is a tech role. We have a high expectation of fluency and competence and passion for technology regardless of your title. The future is already here, as open source, and Canonical’s mission is to deliver it to the world. We are part of the biggest change in technology history - to open source - and we play a critical role in broadening the benefits of open source to ever more people. Every role at the company involves good judgment against the backdrop of the fast-moving technology landscape. We look for people who find that interesting.
-      </p>
-      <p>
-        Second, we’re a fully distributed organisation. Most people work from home, using the latest communications technology to be productive and maintain a who find that interesting.
-      </p>
-      <p>
-        Second, we’re a fully distributed organisation. Most people work from home, using the latest communications technology to be productive and maintain a high level of coordination with colleagues. Digital collaboration is how we enable people to enjoy their home environment AND work with the best in the world in their domain. Zero commute means more time for the things you enjoy, it also means you need to be organized and effective in a distributed workplace. You get tremendous, perhaps unprecedented, flexibility in how you organise your day. At the same time, you have to be productive and a good counterpart to colleagues around the world. You need to be a team player, and you need to deliver what you promise, because teams depend on each other and don’t have daily eyes on one another. We have very little office politics but we do have very high expectations of commitment and independent execution. We also travel more than most companies, because our customers and our teams are global, and we need regular face-time with both.
-      </p>
-      <p>
-        Third, we aspire to lead on the global stage. There’s no other way to describe it than hard - hard work, hard challenges, hard competition. Most of us are avid students of greatness - we are interested in how the latest things work, how the best organizations work, how the smartest companies work, and we aim to hold our own in that crowd. You will need to show that you can compete in deeply challenging intellectual fields. Your colleagues are aiming for the top, and they depend on you to set the same standard in your area of responsibility. That’s tough. It’s also incredibly satisfying, with continuous learning and challenge. You will have exceptional opportunities and exceptional colleagues. They will expect you to be exceptional too.
-      </p>
-    </div>
-  </div>
+  <p>
+    <strong>Canonical is unlike any other company in the world. It’s not for everybody, but it is amazing for people who are organized, passionate about technology, and like to travel. People at Canonical say the people at Canonical are amazing. That’s special.</strong>
+  </p>
+  <p>
+    We’re a technology company. Every role at Canonical is a tech role. We have a high expectation of fluency and competence and passion for technology regardless of your title. The future is already here, as open source, and Canonical’s mission is to deliver it to the world. We are part of the biggest change in technology history - to open source - and we play a critical role in broadening the benefits of open source to ever more people. Every role at the company involves good judgment against the backdrop of the fast-moving technology landscape. We look for people who find that interesting.
+  </p>
+  <p>
+    Second, we’re a fully distributed organisation. Most people work from home, using the latest communications technology to be productive and maintain a who find that interesting.
+  </p>
+  <p>
+    Second, we’re a fully distributed organisation. Most people work from home, using the latest communications technology to be productive and maintain a high level of coordination with colleagues. Digital collaboration is how we enable people to enjoy their home environment AND work with the best in the world in their domain. Zero commute means more time for the things you enjoy, it also means you need to be organized and effective in a distributed workplace. You get tremendous, perhaps unprecedented, flexibility in how you organise your day. At the same time, you have to be productive and a good counterpart to colleagues around the world. You need to be a team player, and you need to deliver what you promise, because teams depend on each other and don’t have daily eyes on one another. We have very little office politics but we do have very high expectations of commitment and independent execution. We also travel more than most companies, because our customers and our teams are global, and we need regular face-time with both.
+  </p>
+  <p>
+    Third, we aspire to lead on the global stage. There’s no other way to describe it than hard - hard work, hard challenges, hard competition. Most of us are avid students of greatness - we are interested in how the latest things work, how the best organizations work, how the smartest companies work, and we aim to hold our own in that crowd. You will need to show that you can compete in deeply challenging intellectual fields. Your colleagues are aiming for the top, and they depend on you to set the same standard in your area of responsibility. That’s tough. It’s also incredibly satisfying, with continuous learning and challenge. You will have exceptional opportunities and exceptional colleagues. They will expect you to be exceptional too.
+  </p>
 {% endblock %}

--- a/templates/careers/marketing.html
+++ b/templates/careers/marketing.html
@@ -1,5 +1,7 @@
 {% extends '/careers/careers_base.html' %}
 
+{% block meta_copydoc %}https://docs.google.com/document/d/1e35Ux74NQ5s4XCUqLFnRAukCJca7AvWDZWofHz1Y2go{% endblock meta_copydoc %}
+
 {% block hero %}
   <section class="p-strip--image is-dark is-deep u-no-padding--top u-no-padding--bottom u-extra-space">
     <div class="p-strip--suru-background">
@@ -14,40 +16,28 @@
 
 {% block overview_tab %}
   <div class="p-strip is-shallow u-extra-space tab-content" id="overview">
-    <div class="row">
-      <div class="col-12">
-        <p>
-          <strong>We deliver the right technology message to a highly competent audience, at exactly the right moment. Success depends on having good instincts for tech trends and topics and a natural inclination to leadership.</strong>
-        </p>
-        <p>
-          The best candidates for marketing at Canonical love technology and words. They are tech-savvy and are comfortable working with data at scale - in spreadsheets, business analytics suites and databases. They love data visualisation and presentation. They are passionate about message and language, and strive to find the best way to share a powerful idea that leads people to act.
-        </p>
-        <p>
-          Canonical has a global following of sophisticated tech readers and decision makers, constantly evaluating the state of the art for open infrastructure and applications. Your mission is to reach them at precisely the right moment with clear information showing that Ubuntu and Canonical’s solutions deliver the very best in quality and economics. It’s a fast-paced, high stakes responsibility that demands a high level of intellect and work ethic.
-        </p>
-        <p>
-          Our team also understands that it’s not just about broadcast, it’s about feedback, measurement, iteration and improvement. We use analytics to understand how the world is consuming our narrative, and technology to sift through mountains of engagement data to spot the opportunities that are ready to explore further. We delight in showing that we can engineer growth in engagement, awareness, consumption and commerce just as effectively as our colleagues in software development engineer reliability and performance in their products. We are growth hackers at heart. As the tools evolve, so do we, which creates a learning environment that celebrates new ideas which can prove their effectiveness. We’re a tiny company in an industry of giants, so we have always punched way above our weight and that’s exactly what we expect from new members of the team too.
-        </p>
-        <p>
-          In marketing you are a representative of Canonical and you are an advocate of our brands and products. We all work together across the full portfolio - you are expected to understand the big picture of how Canonical’s products fit together, there are no siloes. These are not behind-the-scenes roles, they are public leadership roles. We expect our team to be just as comfortable delivering our message online as they are face to face at meetups, meetings, conferences, partner workshops, or press events. From the analyst community to the tech press, from the CIO to the graduate engineer, from prospects to existing customers, we think Ubuntu should be the starting point for technology transformation around open source, and our marketing team are the amplifier for our message.
-        </p>
-        <p>
-          This team is all about having the confidence in our ideas and our quality to put us squarely into the frame for companies thinking afresh about their biggest technology questions. Join us if you are passionate about digital marketing and technology products.
-        </p>
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-12">
-        <hr />
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-12">
-        <p class="p-muted-heading">
-          <span>Emea</span>&nbsp;&#124;&nbsp;<span style="text-transform: capitalize">Americas</span>
-        </p>
-        <a href="#available-roles">Apply now&nbsp;&rsaquo;</a>
-      </div>
-    </div>
+    <p>
+      <strong>We deliver the right technology message to a highly competent audience, at exactly the right moment. Success depends on having good instincts for tech trends and topics and a natural inclination to leadership.</strong>
+    </p>
+    <p>
+      The best candidates for marketing at Canonical love technology and words. They are tech-savvy and are comfortable working with data at scale - in spreadsheets, business analytics suites and databases. They love data visualisation and presentation. They are passionate about message and language, and strive to find the best way to share a powerful idea that leads people to act.
+    </p>
+    <p>
+      Canonical has a global following of sophisticated tech readers and decision makers, constantly evaluating the state of the art for open infrastructure and applications. Your mission is to reach them at precisely the right moment with clear information showing that Ubuntu and Canonical’s solutions deliver the very best in quality and economics. It’s a fast-paced, high stakes responsibility that demands a high level of intellect and work ethic.
+    </p>
+    <p>
+      Our team also understands that it’s not just about broadcast, it’s about feedback, measurement, iteration and improvement. We use analytics to understand how the world is consuming our narrative, and technology to sift through mountains of engagement data to spot the opportunities that are ready to explore further. We delight in showing that we can engineer growth in engagement, awareness, consumption and commerce just as effectively as our colleagues in software development engineer reliability and performance in their products. We are growth hackers at heart. As the tools evolve, so do we, which creates a learning environment that celebrates new ideas which can prove their effectiveness. We’re a tiny company in an industry of giants, so we have always punched way above our weight and that’s exactly what we expect from new members of the team too.
+    </p>
+    <p>
+      In marketing you are a representative of Canonical and you are an advocate of our brands and products. We all work together across the full portfolio - you are expected to understand the big picture of how Canonical’s products fit together, there are no siloes. These are not behind-the-scenes roles, they are public leadership roles. We expect our team to be just as comfortable delivering our message online as they are face to face at meetups, meetings, conferences, partner workshops, or press events. From the analyst community to the tech press, from the CIO to the graduate engineer, from prospects to existing customers, we think Ubuntu should be the starting point for technology transformation around open source, and our marketing team are the amplifier for our message.
+    </p>
+    <p>
+      This team is all about having the confidence in our ideas and our quality to put us squarely into the frame for companies thinking afresh about their biggest technology questions. Join us if you are passionate about digital marketing and technology products.
+    </p>
+    <hr />
+    <p class="p-muted-heading">
+      <span>Emea</span>&nbsp;&#124;&nbsp;<span style="text-transform: capitalize">Americas</span>
+    </p>
+    <a href="#available-roles">Apply now&nbsp;&rsaquo;</a>
   </div>
 {% endblock %}

--- a/templates/careers/progression.html
+++ b/templates/careers/progression.html
@@ -2,6 +2,8 @@
 
 {% block meta_description %}Canonical prefers internal promotion and encourages high-performing colleagues to pursue diverse roles at the company over the course of their career, to develop a well-rounded perspective.{% endblock %}
 
+{% block meta_copydoc %}https://docs.google.com/document/d/13lzdbhQ2mmNPuwBdajOubNyRxXAXTt5lRq0iUk5HfuQ{% endblock meta_copydoc %}
+
 {% block hero %}
   <section class="p-strip--image is-dark is-deep u-no-padding--top u-no-padding--bottom u-extra-space">
     <div class="p-strip--suru-background">
@@ -16,17 +18,13 @@
 {% endblock %}
 
 {% block overview %}
-  <div class="row">
-    <div class="col-12">
-      <p>
-        <strong>We hire for talent, passion and work ethic.</strong>
-      </p>
-      <p>
-        Your career at Canonical can progress in many ways - and we celebrate growth and development in many forms. Management is important and we like to develop those skills in people who enjoy it. We also explicitly encourage team members to find their passion and invest in that, recognising the benefit to your team and the company when you become a more effective team player. We encourage team members to experience diverse roles at Canonical over the course of their career, and we prefer to promote internally to build deep awareness of company culture and practices in senior leadership.
-      </p>
-      <p>
-        Joining Canonical means joining an intense global mission - to deliver the world’s best open source experience, from platform to application. We touch every aspect of open source technology, and so we offer a wide range of technology and business careers. You might start out as a product developer, then choose to get more travel and focus on customer operations transformation and cloud operations, then take on a role in tech leadership or management. We value people who love to learn - not just how to be a better engineer, but how to be a better speaker, how to be a better designer, better organiser, better partner and better vendor.
-      </p>
-    </div>
-  </div>
+  <p>
+    <strong>We hire for talent, passion and work ethic.</strong>
+  </p>
+  <p>
+    Your career at Canonical can progress in many ways - and we celebrate growth and development in many forms. Management is important and we like to develop those skills in people who enjoy it. We also explicitly encourage team members to find their passion and invest in that, recognising the benefit to your team and the company when you become a more effective team player. We encourage team members to experience diverse roles at Canonical over the course of their career, and we prefer to promote internally to build deep awareness of company culture and practices in senior leadership.
+  </p>
+  <p>
+    Joining Canonical means joining an intense global mission - to deliver the world’s best open source experience, from platform to application. We touch every aspect of open source technology, and so we offer a wide range of technology and business careers. You might start out as a product developer, then choose to get more travel and focus on customer operations transformation and cloud operations, then take on a role in tech leadership or management. We value people who love to learn - not just how to be a better engineer, but how to be a better speaker, how to be a better designer, better organiser, better partner and better vendor.
+  </p>
 {% endblock %}

--- a/templates/careers/project-management.html
+++ b/templates/careers/project-management.html
@@ -1,5 +1,7 @@
 {% extends '/careers/careers_base.html' %}
 
+{% block meta_description %}Canonical’s Engagement Project Management Office team owns, drives and communicates delivery excellence by providing strong Project process guidelines,  project continuity and data analytics.{% endblock %}
+
 {% block meta_copydoc %}https://docs.google.com/document/d/1IMXbRXvmvSKe_SrKvEiQIRCwz3I9BfVcQRQuHODaG8s{% endblock meta_copydoc %}
 
 {% block hero %}
@@ -16,26 +18,20 @@
 
 {% block overview_tab %}
   <div class="p-strip is-shallow u-extra-space tab-content" id="overview">
-    <div class="row">
-      <div class="col-12">
-        <p><strong>Project Managers at Canonical are engaged during all phases of the project, from pre&dash;sales support, to delivery to handoff of complete projects to support or managed services.  Project managers create, manage, and maintain project specific schedules ensuring projects are delivered within time&sol;resources&sol;scope expectations. </strong></p>
-        <p>
-          They are responsible for managing multiple projects simultaneously. The Project Manager is responsible for managing the project through its life&dash;cycle and ensuring that the overall goals for both Canonical and the client are met. One advanced role is the Technical Program Manager, who provides technical account leadership and insight as the primary technical interface for our key enterprise accounts. The Technical Program Manager is a high&dash;profile technical engagement program management position where customer relationship management and advocacy for Canonical&rsquo;s technical assets are strategically crucial. All Program Managers are responsible for facilitating Customer-focused collaboration, team upskilling and driving innovation initiatives. Program managers proactively evaluate enterprise client situations and drive client vision that could ultimately lead to additional revenue-generating business opportunities.  
-        </p>
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-12">
-        <hr />
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-12">
-        <p class="p-muted-heading">
-          <span style="text-transform: capitalize">Europe&nbsp;&#124;&nbsp;Americas</span>
-        </p>
-        <a href="#available-roles">Apply now&nbsp;&rsaquo;</a>
-      </div>
-    </div>
+    <p><strong>Project Managers at Canonical are engaged during all phases of the project, from pre-sales support to delivery to the handoff of complete projects to support or managed services.</strong></p>
+    <p>
+      Project managers create, manage and maintain project-specific schedules ensuring projects are delivered within time, resource and scope expectations. Each project manager is responsible for multiple projects simultaneously. Managing each project through its life-cycle and ensuring that the goals for both Canonical and the client are met.  
+    </p>
+    <p>
+      One advanced role is the Technical Program Manager, who provides technical account leadership and insight as the primary technical interface for our key enterprise accounts. The Technical Program Manager is a high-profile technical engagement program management position where customer relationship management and advocacy for Canonical's technical assets are strategically crucial.
+    </p>
+    <p>
+      All Program Managers are responsible for facilitating customer-focused collaboration, team upskilling and driving innovation initiatives. Program managers proactively evaluate enterprise client situations and drive client vision that could ultimately lead to additional revenue-generating business opportunities.
+    </p>
+    <hr />
+    <p class="p-muted-heading">
+      <span style="text-transform: capitalize">EMEA&nbsp;&#124;&nbsp;Americas&nbsp;&#124;&nbsp;APAC</span>
+    </p>
+    <a href="#available-roles">Apply now&nbsp;&rsaquo;</a>
   </div>
 {% endblock %}

--- a/templates/careers/sales.html
+++ b/templates/careers/sales.html
@@ -1,5 +1,7 @@
 {% extends '/careers/careers_base.html' %}
 
+{% block meta_description %}Canonical is looking for Sales Professionals that are Trusted Advisors which bring confidence to our customers that we understand their transformation to multi-cloud, and we can bring the right solutions to the table in order to solve those problems.{% endblock %}
+
 {% block meta_copydoc %}https://docs.google.com/document/d/1fGBFiIfy7C58UXcJ0Q7q6VKxClxBfPyeWBSyO9GrStI{% endblock meta_copydoc %}
 
 {% block hero %}
@@ -16,32 +18,22 @@
 
 {% block overview_tab %}
   <div class="p-strip is-shallow u-extra-space tab-content" id="overview">
-    <div class="row">
-      <div class="col-12">
-        <p><strong>You love technology and you love doing business. You know what the enterprise technology future looks like and you enjoy helping customers get there.</strong></p>
-        <p>
-          Your approach is consultative, you are results and goal oriented, and you know how to invest your time to maximise the benefit for customers and the company.
-        </p>
-        <p>
-          You build long term relationships and you always promote the approach that is in the customers best interests, regardless of short term consequences. You are interested in the state of the art, you love to represent a company that knows how to transform customer operations, and you are keen to see new customers benefit from that knowledge.
-        </p>
-        <p>
-          You are organized, persistent, friendly and hard-working. You are effective in a digital world, keeping track of your plans and your progress, collaborating with colleagues to deliver for your customers. You are professionally competitive &ndash; respectful of the competition and determined to improve until you win regularly.
-        </p>
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-12">
-        <hr />
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-12">
-        <p class="p-muted-heading">
-          <span style="text-transform: capitalize">EMEA&nbsp;&#124;&nbsp;Americas&nbsp;&#124;&nbsp;Asia-Pacific</span>
-        </p>
-        <a href="#available-roles">Apply now&nbsp;&rsaquo;</a>
-      </div>
-    </div>
+    <p>
+      <strong>You love technology, and you love doing business. You know what the enterprise technology future looks like, and you enjoy helping customers get there.</strong>
+    </p>
+    <p>
+      Your approach is consultative, you are results and goal-oriented, and you know how to invest your time to maximise the benefit for customers and the company.
+    </p>
+    <p>
+      You build long term relationships, and you always promote the approach that is in the customers best interests, regardless of short term consequences. You are interested in the state of the art, you love to represent a company that knows how to transform customer operations, and you are keen to see new customers benefit from that knowledge.
+    </p>
+    <p>
+      You are organised, persistent, friendly and hard-working. You are effective in a digital world, keeping track of your plans and your progress, collaborating with colleagues to deliver for your customers. You are professionally competitive - respectful of the competition and determined to improve until you win regularly.
+    </p>
+    <hr />
+    <p class="p-muted-heading">
+      <span style="text-transform: capitalize">EMEA&nbsp;&#124;&nbsp;Americas&nbsp;&#124;&nbsp;Asia-Pacific</span>
+    </p>
+    <a href="#available-roles">Apply now&nbsp;&rsaquo;</a>
   </div>
 {% endblock %}

--- a/templates/careers/tech-ops.html
+++ b/templates/careers/tech-ops.html
@@ -7,7 +7,7 @@
     <div class="p-strip--suru-background">
       <div class="row">
         <div class="col-6">
-          <h1>Tech-ops</h1>
+          <h1>TechOps</h1>
         </div>
       </div>
     </div>
@@ -16,23 +16,14 @@
 
 {% block overview_tab %}
   <div class="p-strip is-shallow u-extra-space tab-content" id="overview">
-    <div class="row">
-      <div class="col-12">
-
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-12">
-        <hr />
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-12">
-        <p class="p-muted-heading">
-          <span style="text-transform: capitalize">Europe&nbsp;&#124;&nbsp;Middle East&nbsp;&#124;&nbsp;Africa&nbsp;&#124;&nbsp;Americas&nbsp;&#124;&nbsp;APAC</span>
-        </p>
-        <a href="#available-roles">Apply now&nbsp;&rsaquo;</a>
-      </div>
-    </div>
+    <p><strong>TechOps, or Technical Services and Operations role ranges from IT and managed services to developing commercial systems used by our company. We develop, test, ship and operate the systems that drive Canonical and underpin Ubuntu. We believe in a strong customer service ethic and operations through code. The robots we are constructing to run the data centre need to be backed by humans that care about the needs of our users and customers.</strong></p>
+    <p>In TechOps, you will enjoy the excitement of a team environment that is fun, diverse, distributed globally and incredibly competent. Every day, we work to enable our customers to work on some of the most challenging problems in the world.</p>
+    <p>While we all enjoy the feeling that comes from passionately working together, we also collectively respect each other's lives away from work. Part of standing together with a global team that is set up to work remotely means you can step away during your off-hours and know that your team has your back. Your manager will guide and mentor you through your work but equally wants you to make sure you are taking the time away from work to help you unwind and refocus. All of us are in this together, and we want you in TechOps for the long term.</p>
+    <p>If you enjoy supporting customers, operating software or building software, then TechOps at Canonical will present you with the challenging work environment to help you grow. We welcome you to apply with us!</p>
+    <hr />
+    <p class="p-muted-heading">
+      <span style="text-transform: capitalize">Worldwide</span>
+    </p>
+    <a href="#available-roles">Apply now&nbsp;&rsaquo;</a>
   </div>
 {% endblock %}

--- a/templates/careers/tech-ops.html
+++ b/templates/careers/tech-ops.html
@@ -1,5 +1,7 @@
 {% extends '/careers/careers_base.html' %}
 
+{% block meta_copydoc %}https://docs.google.com/document/d/1wzuu4pnd2Sx2BDONaaR9EaYUSjx7diTu6PzvYYwbMA8{% endblock meta_copydoc %}
+
 {% block hero %}
   <section class="p-strip--image is-dark is-deep u-no-padding--top u-no-padding--bottom u-extra-space">
     <div class="p-strip--suru-background">

--- a/templates/careers/travel.html
+++ b/templates/careers/travel.html
@@ -2,6 +2,8 @@
 
 {% block meta_description %}Travel is central to Canonical’s global, distributed workplace. All teams participate in regular team and cross-team events. We spread locations across time zones and look for interesting and diverse cultural places. Many employees return to these destinations with friends and family.{% endblock %}
 
+{% block meta_copydoc %}https://docs.google.com/document/d/1H2ILhAUckOWyah_6V69ImwLWOSRlXkaYnIhOHkUjclc{% endblock meta_copydoc %}
+
 {% block hero %}
   <section class="p-strip--image is-dark u-extra-space">
     <div class="p-strip--suru-background">
@@ -43,37 +45,20 @@
 {% endblock %}
 
 {% block overview %}
-  <div class="row">
-    <div class="col-12">
-      <p>
-        <strong>Less commuting, more real travel.</strong>
-      </p>
-    </div>
-  </div>
-  <div class="row u-sv3">
-    <div class="col-4">
-      <p>
-        Canonical is uniquely global - we hire the best open source team globally, regardless of nationality or language, creed or colour, and we serve the global market for technology in open infrastructure and open applications.
-      </p>
-      <p>
-        We do optimise team structure for time zone overlap - collaboration takes time and inspiration needs time to develop fully - but leadership at Canonical means building cross-team relationships and we do that through regular global summits which bring diverse teams or their leaders together. We aim to balance these events around the world to minimize the total travel and jet lag, and we try to discover great places to explore and appreciate in the process. Team events have taken place in Annecy, Vancouver, Brugge, New York, Budapest, Orlando, Cape Town, Warsaw, Seoul, Paris, Portland, Lyon, London, Toronto and many more.
-      </p>
-    </div>
-    <div class="col-4">
-      <img src="https://assets.ubuntu.com/v1/1e10b1d8-canonical-travel-city.jpg" alt="">
-    </div>
-  </div>
-  <div class="row u-extra-space">
-    <div class="col-3 u-hide--small">
-      <img src="https://assets.ubuntu.com/v1/95444386-canonical-travel-city-2.jpg" alt="">
-    </div>
-    <div class="col-5">
-      <p>
-        Our customers are transforming their deepest and most important infrastructure to benefit from open source and modern dev/ops insights, and they trust us to advise them and lead them to best practice. That also takes time on site, to whiteboard and to work shoulder to shoulder in their development halls and data centers. Many teams at Canonical travel for that deep customer presence.
-      </p>
-      <p>
-        Travel isn’t for everybody but if you are excited to see the world then Canonical is a great place to be. We expect everybody at Canonical to be willing to travel for up to two weeks at a time, four times a year, but in some roles the travel expectation is higher. There are multiple career paths at Canonical in technical, management and commercial spheres, and not all of them are travel centric, but our culture celebrates both global talent and face-time, so travel is part of the deal. We love it when people like our destinations so much they bring family and friends there later.
-      </p>
-    </div>
-  </div>
+  <p>
+    <strong>Less commuting, more real travel.</strong>
+  </p>
+  <p>
+    Canonical is uniquely global - we hire the best open source team globally, regardless of nationality or language, creed or colour, and we serve the global market for technology in open infrastructure and open applications.
+  </p>
+  <p>
+    We do optimise team structure for time zone overlap - collaboration takes time and inspiration needs time to develop fully - but leadership at Canonical means building cross-team relationships and we do that through regular global summits which bring diverse teams or their leaders together. We aim to balance these events around the world to minimize the total travel and jet lag, and we try to discover great places to explore and appreciate in the process. Team events have taken place in Annecy, Vancouver, Brugge, New York, Budapest, Orlando, Cape Town, Warsaw, Seoul, Paris, Portland, Lyon, London, Toronto and many more.
+  </p>
+  <img src="https://assets.ubuntu.com/v1/34b9fe84-cities2.jpg" width="600" height="249" alt="">
+  <p>
+    Our customers are transforming their deepest and most important infrastructure to benefit from open source and modern dev/ops insights, and they trust us to advise them and lead them to best practice. That also takes time on site, to whiteboard and to work shoulder to shoulder in their development halls and data centers. Many teams at Canonical travel for that deep customer presence.
+  </p>
+  <p>
+    Travel isn’t for everybody but if you are excited to see the world then Canonical is a great place to be. We expect everybody at Canonical to be willing to travel for up to two weeks at a time, four times a year, but in some roles the travel expectation is higher. There are multiple career paths at Canonical in technical, management and commercial spheres, and not all of them are travel centric, but our culture celebrates both global talent and face-time, so travel is part of the deal. We love it when people like our destinations so much they bring family and friends there later.
+  </p>
 {% endblock %}


### PR DESCRIPTION
## Done

- Update `/careers/tech-ops` page
- Update `/careers/sales` page
- Update all other careers pages with copy doc link and metadata if available
- Remove some unnecessary markup

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/careers/tech-ops and http://0.0.0.0:8002/careers/sales
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to [tech-ops copy](https://docs.google.com/document/d/1wzuu4pnd2Sx2BDONaaR9EaYUSjx7diTu6PzvYYwbMA8/edit) and [sales copy](https://docs.google.com/document/d/1fGBFiIfy7C58UXcJ0Q7q6VKxClxBfPyeWBSyO9GrStI/edit)


## Issue / Card

Fixes #86 
Fixes #105 
