### PR TITLE
Add office addresses to the contact page

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -148,3 +148,32 @@ $color-brand: #7c355d;
 .p-navigation__dropdown-link--no-chevron > .p-navigation__link-anchor {
   padding: .75rem 1rem;
 }
+
+.p-reveal-link {
+  position: relative;
+  padding-right: 2rem;
+
+  &:visited {
+    color: $color-link;
+  }
+  
+  &::after {
+    @include vf-icon-chevron(vf-url-friendly-color($color-link));
+    background-position: top 52% right 50%;
+    background-repeat: no-repeat;
+    background-size: .75rem;
+    content: "";
+    height: 100%;
+    pointer-events: none;
+    position: absolute;
+    top: 0;
+    transition: transform .1s;
+    width: 2rem;
+  }
+
+  &.is-open {
+    &::after {
+      transform: rotate(-180deg);
+    }
+  }
+}

--- a/templates/contact-us.html
+++ b/templates/contact-us.html
@@ -11,10 +11,12 @@
       </div>
     </div>
   </section>
+
   <section class="p-strip is-deep u-no-padding--top">
     <div class="row">
       <div class="col-5">
         <h2 class="p-heading--three">Sales</h2>
+
         <ul class="p-list--divided u-sv1">
           <li class="p-list__item">Americas<a class="u-float-right" href="tel:+17372040291">+1 737 2040291</a></li>
           <li class="p-list__item">France<a class="u-float-right" href="tel:+33184889319">+33 184889319</a></li>
@@ -25,85 +27,102 @@
           <li class="p-list__item">Rest of World<a class="u-float-right" href="tel:+44203 6565291">+44 203 656 5291</a>
           </li>
         </ul>
+
         <h2 class="p-heading--three">Online</h2>
+
         <p class="u-sv3"><a href="https://ubuntu.com/contact-us/form?product=generic-contact-us">Get in touch</a> about
           open source infrastructure, applications, development and operations. We are proud to deliver the world’s best
           pathway to open source success.</p>
       </div>
+
       <div class="col-6 col-start-large-7">
         <h2 class="p-heading--three">Technical assistance</h2>
+
         <p class="u-sv1">Our <a href="https://www.ubuntu.com/support">support team</a> offers a range of services from enterprise support to fully managed infrastructure and applications.</p>
+
         <h2 class="p-heading--three">Trademark and other licenses</h2>
-        <p class="u-sv1">Publishing or distributing Ubuntu in any form other than our standard install media and packages
-          requires permission. To license the Ubuntu trademark or any other rights, please <a
-            href="https://www.ubuntu.com/legal/terms-and-policies/contact-us">submit an enquiry</a>.</p>
+
+        <p class="u-sv1">Publishing or distributing Ubuntu in any form other than our standard install media and packages requires permission. To license the Ubuntu trademark or any other rights, please <a href="https://www.ubuntu.com/legal/terms-and-policies/contact-us">submit an enquiry</a>.</p>
+
         <h2 class="p-heading--three">Press and analyst enquiries</h2>
+        
         <p class="u-sv1">Please contact <a href="mailto:pr@canonical.com">pr@canonical.com</a>.</p>
+        
         <h2 class="p-heading--three">Data Privacy enquiries</h2>
-        <p class="u-sv1">For information about data privacy, please read our <a
-            href="https://www.ubuntu.com/legal/data-privacy">Privacy Policy</a> or <a
-            href="https://ubuntu.com/legal/data-privacy/enquiry">submit an enquiry</a>. A member of our data privacy team
-          will be in touch with you shortly.</p>
+        
+        <p class="u-sv1">For information about data privacy, please read our <a href="https://www.ubuntu.com/legal/data-privacy">Privacy Policy</a> or <a href="https://ubuntu.com/legal/data-privacy/enquiry">submit an enquiry</a>. A member of our data privacy team will be in touch with you shortly.</p>
+
         <h2 class="p-heading--three">Legal enquiries</h2>
+
         <p>Please note that we cannot provide you with legal advice. For any other queries, please contact us on <a
             href="mailto:legal@canonical.com">legal@canonical.com</a>.</p>
       </div>
     </div>
   </section>
+
   <section class="p-strip--light is-shallow" style="padding-bottom: 6rem;">
     <div class="u-fixed-width">
       <h2 class="p-heading--three">
         <a href="#" class="p-reveal-link js-location-toggle-button">Where we are</a>
       </h2>
     </div>
+
     <div class="js-location-container">
       <div class="u-fixed-width">
         <hr style="margin: 2rem 0;" />
       </div>
+
       <div class="row">
         <div class="col-4 p-card" style="border-style: none;">
-          <p class="p-card__title">Canonical Group Limited</p>
+          <h3 class="p-card__title p-heading--four u-no-margin--top">Canonical Group Limited</h3>
           <p><small>5th Floor, Blue Fin Building<br>110 Southwark Street<br>London, SE1 0SU<br>United Kigdom</small></p>
           <p><a target="_blank" href="https://maps.google.com/?q=51.506312,-0.099871&ll=51.506312,-0.099871&z=18"><small>View map&nbsp;&rsaquo;</small></a></p>
         </div>
+
         <div class="col-4 p-card" style="border-style: none;">
-          <p class="p-card__title">Canonical USA Inc.</p>
+          <h3 class="p-card__title p-heading--four u-no-margin--top">Canonical USA Inc.</h3>
           <p><small>Link Flex<br>2301 W Anderson Ln<br>Austin, TX 78757<br>United States of America</small></p>
           <p><a target="_blank" href="https://maps.google.com/?q=30.355390,-97.730311&ll=30.355390,-97.730311&z=18"><small>View map&nbsp;&rsaquo;</small></a></p>
         </div>
+
         <div class="col-4 p-card" style="border-style: none;">
-          <p class="p-card__title">Canonical USA Inc.</p>
+          <h3 class="p-card__title p-heading--four u-no-margin--top">Canonical USA Inc.</h3>
           <p><small>18 Tremont Street<br>Suite 210<br>Boston, MA 02108<br>United States of America</small></p>
           <p><a target="_blank" href="https://maps.google.com/?q=42.358795,-71.059627&ll=42.358795,-71.059627&z=18"><small>View map&nbsp;&rsaquo;</small></a></p>
         </div>
       </div>
+
       <div class="row">
         <div class="col-4 p-card" style="border-style: none;">
-          <p class="p-card__title">Canonical China</p>
+          <h3 class="p-card__title p-heading--four u-no-margin--top">Canonical China</h3>
           <p><small>Room 1246, 12F<br>No. 331 North Caoxi Road<br>Shanghai 200031<br>China<br>上海市漕溪北路331号12楼1246室
               200031</small></p>
           <p><a target="_blank" href="https://maps.google.com/?q=31.190677,121.438980&ll=31.190677,121.438980&z=18"><small>View map&nbsp;&rsaquo;</small></a></p>
         </div>
+
         <div class="col-4 p-card" style="border-style: none;">
-          <p class="p-card__title">Canonical China</p>
+          <h3 class="p-card__title p-heading--four u-no-margin--top">Canonical China</h3>
           <p><small>Unit 1118-19, Level 11, China World Office 1<br>1 Jianguomenwai Avenue, Chaoyang District<br>Beijing
               P.R.C. 100004<br>China<br>北京市朝阳区建国门外大街1号国贸写字楼1座11层1118-19室 100004</small></p>
           <p><a target="_blank" href="https://maps.google.com/?q=39.909514,116.458169&ll=39.909514,116.458169&z=18"><small>View map&nbsp;&rsaquo;</small></a></p>
         </div>
+
         <div class="col-4 p-card" style="border-style: none;">
-          <p class="p-card__title">Canonical Limited Taiwan Branch</p>
+          <h3 class="p-card__title p-heading--four u-no-margin--top">Canonical Limited Taiwah3 Branch</p>
           <p><small>Room D, 46F<br>No. 7, Xin Yi Rd., Sec.5<br>Taipei 101<br>Taiwan</small></p>
           <p><a target="_blank" href="https://maps.google.com/?q=25.034010,121.564461&ll=25.034010,121.564461&z=18"><small>View map&nbsp;&rsaquo;</small></a></p>
         </div>
       </div>
+
       <div class="row">
         <div class="col-4 p-card" style="border-style: none;">
-          <p class="p-card__title">Canonical Limited</p>
+          <h3 class="p-card__title p-heading--four u-no-margin--top">Canonical Limited</h3>
           <p><small>One Circular Road<br>Douglas<br>Isle of Man<br>IM1 1SB<br>United Kingdom</small></p>
           <p><a target="_blank" href="https://maps.google.com/?q=54.15272,-4.487221&ll=54.15272,-4.487221&z=18"><small>View map&nbsp;&rsaquo;</small></a></p>
         </div>
+
         <div class="col-4 p-card" style="border-style: none;">
-          <p class="p-card__title">Canonical Limited</p>
+          <h3 class="p-card__title p-heading--four u-no-margin--top">Canonical Limited</h3>
           <p><small>3rd Floor, Sanno Park Tower<br>2-11-1 Nagata-cho<br>Chiyoda-ku<br>Tokyo 100-6162<br>Japan</small></p>
           <p><a target="_blank" href="https://maps.google.com/?q=35.673363,139.740328&ll=35.673363,139.740328&z=18"><small>View map&nbsp;&rsaquo;</small></a></p>
         </div>

--- a/templates/contact-us.html
+++ b/templates/contact-us.html
@@ -5,15 +5,16 @@
     <div class="p-strip--suru-image">
       <div class="row">
         <div class="col-6">
-          <img src="https://assets.ubuntu.com/v1/6685f10c-contact-canonical-icon.svg" alt="Canonical contact icon">
+          <h1 class="u-off-screen">Contact Canonical</h1>
+          <img src="https://assets.ubuntu.com/v1/6685f10c-contact-canonical-icon.svg" alt="Contact Canonical">
         </div>
       </div>
     </div>
   </section>
-  <section class="p-strip" style="margin-bottom: 8rem;">
+  <section class="p-strip is-deep u-no-padding--top">
     <div class="row">
       <div class="col-5">
-        <p class="p-heading--three">Sales</p>
+        <h2 class="p-heading--three">Sales</h2>
         <ul class="p-list--divided u-sv1">
           <li class="p-list__item">Americas<a class="u-float-right" href="tel:+17372040291">+1 737 2040291</a></li>
           <li class="p-list__item">France<a class="u-float-right" href="tel:+33184889319">+33 184889319</a></li>
@@ -21,23 +22,114 @@
           <li class="p-list__item">Japan<a class="u-float-right" href="tel:+81362053075">+81 3 6205 3075</a></li>
           <li class="p-list__item">Spain<a class="u-float-right" href="tel:+34932201131">+34 932 201131</a></li>
           <li class="p-list__item">UK<a class="u-float-right" href="tel:+44203 6565291">+44 203 656 5291</a></li>
-          <li class="p-list__item">Rest of World<a class="u-float-right" href="tel:+44203 6565291">+44 203 656 5291</a></li>
+          <li class="p-list__item">Rest of World<a class="u-float-right" href="tel:+44203 6565291">+44 203 656 5291</a>
+          </li>
         </ul>
-        <p class="p-heading--three">Online</p>
-        <p class="u-sv3"><a href="https://ubuntu.com/contact-us/form?product=generic-contact-us">Get in touch</a> about open source infrastructure, applications, development and operations. We are proud to deliver the world’s best pathway to open source success.</p>
+        <h2 class="p-heading--three">Online</h2>
+        <p class="u-sv3"><a href="https://ubuntu.com/contact-us/form?product=generic-contact-us">Get in touch</a> about
+          open source infrastructure, applications, development and operations. We are proud to deliver the world’s best
+          pathway to open source success.</p>
       </div>
       <div class="col-6 col-start-large-7">
-        <p class="p-heading--three">Technical assistance</p>
-        <p class="u-sv1">Our <a href="https://www.ubuntu.com/support">support team</a> team offers a range of services from enterprise support to fully managed infrastructure and applications.</p>
-        <p class="p-heading--three">Trademark and other licenses</p>
-        <p class="u-sv1">Publishing or distributing Ubuntu in any form other than our standard install media and packages requires permission. To license the Ubuntu trademark or any other rights, please <a href="https://www.ubuntu.com/legal/terms-and-policies/contact-us">submit an enquiry</a>.</p>
-        <p class="p-heading--three">Press and analyst enquiries</p>
+        <h2 class="p-heading--three">Technical assistance</h2>
+        <p class="u-sv1">Our <a href="https://www.ubuntu.com/support">support team</a> offers a range of services from enterprise support to fully managed infrastructure and applications.</p>
+        <h2 class="p-heading--three">Trademark and other licenses</h2>
+        <p class="u-sv1">Publishing or distributing Ubuntu in any form other than our standard install media and packages
+          requires permission. To license the Ubuntu trademark or any other rights, please <a
+            href="https://www.ubuntu.com/legal/terms-and-policies/contact-us">submit an enquiry</a>.</p>
+        <h2 class="p-heading--three">Press and analyst enquiries</h2>
         <p class="u-sv1">Please contact <a href="mailto:pr@canonical.com">pr@canonical.com</a>.</p>
-        <p class="p-heading--three">Data Privacy enquiries</p>
-        <p class="u-sv1">For information about data privacy, please read our <a href="https://www.ubuntu.com/legal/data-privacy">Privacy Policy</a> or <a href="https://ubuntu.com/legal/data-privacy/enquiry">submit an enquiry</a>. A member of our data privacy team will be in touch with you shortly.</p>
-        <p class="p-heading--three">Legal enquiries</p>
-        <p>Please note that we cannot provide you with legal advice. For any other queries, please contact us on <a href="mailto:legal@canonical.com">legal@canonical.com</a>.</p>
+        <h2 class="p-heading--three">Data Privacy enquiries</h2>
+        <p class="u-sv1">For information about data privacy, please read our <a
+            href="https://www.ubuntu.com/legal/data-privacy">Privacy Policy</a> or <a
+            href="https://ubuntu.com/legal/data-privacy/enquiry">submit an enquiry</a>. A member of our data privacy team
+          will be in touch with you shortly.</p>
+        <h2 class="p-heading--three">Legal enquiries</h2>
+        <p>Please note that we cannot provide you with legal advice. For any other queries, please contact us on <a
+            href="mailto:legal@canonical.com">legal@canonical.com</a>.</p>
       </div>
     </div>
   </section>
+  <section class="p-strip--light is-shallow" style="padding-bottom: 6rem;">
+    <div class="u-fixed-width">
+      <h2 class="p-heading--three">
+        <a href="#" class="p-reveal-link js-location-toggle-button">Where we are</a>
+      </h2>
+    </div>
+    <div class="js-location-container">
+      <div class="u-fixed-width">
+        <hr style="margin: 2rem 0;" />
+      </div>
+      <div class="row">
+        <div class="col-4 p-card" style="border-style: none;">
+          <p class="p-card__title">Canonical Group Limited</p>
+          <p><small>5th Floor, Blue Fin Building<br>110 Southwark Street<br>London, SE1 0SU<br>United Kigdom</small></p>
+          <p><a target="_blank" href="https://maps.google.com/?q=51.506312,-0.099871&ll=51.506312,-0.099871&z=18"><small>View map&nbsp;&rsaquo;</small></a></p>
+        </div>
+        <div class="col-4 p-card" style="border-style: none;">
+          <p class="p-card__title">Canonical USA Inc.</p>
+          <p><small>Link Flex<br>2301 W Anderson Ln<br>Austin, TX 78757<br>United States of America</small></p>
+          <p><a target="_blank" href="https://maps.google.com/?q=30.355390,-97.730311&ll=30.355390,-97.730311&z=18"><small>View map&nbsp;&rsaquo;</small></a></p>
+        </div>
+        <div class="col-4 p-card" style="border-style: none;">
+          <p class="p-card__title">Canonical USA Inc.</p>
+          <p><small>18 Tremont Street<br>Suite 210<br>Boston, MA 02108<br>United States of America</small></p>
+          <p><a target="_blank" href="https://maps.google.com/?q=42.358795,-71.059627&ll=42.358795,-71.059627&z=18"><small>View map&nbsp;&rsaquo;</small></a></p>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-4 p-card" style="border-style: none;">
+          <p class="p-card__title">Canonical China</p>
+          <p><small>Room 1246, 12F<br>No. 331 North Caoxi Road<br>Shanghai 200031<br>China<br>上海市漕溪北路331号12楼1246室
+              200031</small></p>
+          <p><a target="_blank" href="https://maps.google.com/?q=31.190677,121.438980&ll=31.190677,121.438980&z=18"><small>View map&nbsp;&rsaquo;</small></a></p>
+        </div>
+        <div class="col-4 p-card" style="border-style: none;">
+          <p class="p-card__title">Canonical China</p>
+          <p><small>Unit 1118-19, Level 11, China World Office 1<br>1 Jianguomenwai Avenue, Chaoyang District<br>Beijing
+              P.R.C. 100004<br>China<br>北京市朝阳区建国门外大街1号国贸写字楼1座11层1118-19室 100004</small></p>
+          <p><a target="_blank" href="https://maps.google.com/?q=39.909514,116.458169&ll=39.909514,116.458169&z=18"><small>View map&nbsp;&rsaquo;</small></a></p>
+        </div>
+        <div class="col-4 p-card" style="border-style: none;">
+          <p class="p-card__title">Canonical Limited Taiwan Branch</p>
+          <p><small>Room D, 46F<br>No. 7, Xin Yi Rd., Sec.5<br>Taipei 101<br>Taiwan</small></p>
+          <p><a target="_blank" href="https://maps.google.com/?q=25.034010,121.564461&ll=25.034010,121.564461&z=18"><small>View map&nbsp;&rsaquo;</small></a></p>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-4 p-card" style="border-style: none;">
+          <p class="p-card__title">Canonical Limited</p>
+          <p><small>One Circular Road<br>Douglas<br>Isle of Man<br>IM1 1SB<br>United Kingdom</small></p>
+          <p><a target="_blank" href="https://maps.google.com/?q=54.15272,-4.487221&ll=54.15272,-4.487221&z=18"><small>View map&nbsp;&rsaquo;</small></a></p>
+        </div>
+        <div class="col-4 p-card" style="border-style: none;">
+          <p class="p-card__title">Canonical Limited</p>
+          <p><small>3rd Floor, Sanno Park Tower<br>2-11-1 Nagata-cho<br>Chiyoda-ku<br>Tokyo 100-6162<br>Japan</small></p>
+          <p><a target="_blank" href="https://maps.google.com/?q=35.673363,139.740328&ll=35.673363,139.740328&z=18"><small>View map&nbsp;&rsaquo;</small></a></p>
+        </div>
+      </div>
+    </div>
+  </section>
+  <script>
+    function init() {
+      const locationContainer = document.querySelector(".js-location-container");
+      if (locationContainer) {
+        const toggleButton = document.querySelector(".js-location-toggle-button");
+        locationContainer.classList.add("u-hide");
+        if (toggleButton) {
+          toggleButton.addEventListener("click", function(e) {
+            e.preventDefault();
+            if (locationContainer.classList.contains("u-hide")) {
+              locationContainer.classList.toggle("u-hide");
+              toggleButton.classList.toggle("is-open");
+            } else {
+              locationContainer.classList.toggle("u-hide");
+              toggleButton.classList.toggle("is-open");
+            }
+          });
+        }
+      }
+    }
+    init();
+  </script>
 {% endblock %}

--- a/templates/contact-us.html
+++ b/templates/contact-us.html
@@ -6,7 +6,7 @@
       <div class="row">
         <div class="col-6">
           <h1 class="u-off-screen">Contact Canonical</h1>
-          <img src="https://assets.ubuntu.com/v1/6685f10c-contact-canonical-icon.svg" alt="Contact Canonical">
+          <img src="https://assets.ubuntu.com/v1/6685f10c-contact-canonical-icon.svg" alt="">
         </div>
       </div>
     </div>

--- a/templates/partial/_navigation.html
+++ b/templates/partial/_navigation.html
@@ -1,11 +1,14 @@
-
-<header id="navigation" class="p-navigation {% if request.path == '/' %}is-sticky{% endif %}" role="banner">
+<header id="navigation"
+  class="p-navigation {% if request.path == '/' %}is-sticky{% endif %}"
+  role="banner">
   {% block header_banner %}
   <div class="p-navigation__row u-fixed-width">
     <div class="p-navigation__banner">
       <div class="p-navigation__logo">
         <a class="p-navigation__link" href="/">
-          <img class="p-navigation__image" src="https://assets.ubuntu.com/v1/2eec3fd9-logo.svg" alt="" width="95">
+          <img class="p-navigation__image"
+            src="https://assets.ubuntu.com/v1/2eec3fd9-logo.svg" alt=""
+            width="95">
           <script>performance.mark("Logo rendered")</script>
         </a>
       </div>
@@ -24,31 +27,45 @@
         </li>
       </ul>
       {% else %}
-      <ul class="p-navigation__links u-hide js-show-nav" >
-        <li class="p-navigation__dropdown-link {% if request.path|get_nav_path == 'products' %}is-selected{% endif %}" role="menuitem" id="products-nav" onmouseover="fetchDropdown('/partial/_navigation-products', 'products-nav-content'); this.onmouseover = null;">
+      <ul class="p-navigation__links u-hide js-show-nav">
+        <li
+          class="p-navigation__dropdown-link {% if request.path|get_nav_path == 'products' %}is-selected{% endif %}"
+          role="menuitem" id="products-nav"
+          onmouseover="fetchDropdown('/partial/_navigation-products', 'products-nav-content'); this.onmouseover = null;">
           {% if request.path|get_nav_path == 'products' %}
           <a class="p-navigation__link-anchor" href="/products">Products</a>
           {% else %}
-          <a class="p-navigation__link-anchor" href="#products-nav-content" onfocus="fetchDropdown('/partial/_navigation-products', 'products-nav-content');">Products</a>
+          <a class="p-navigation__link-anchor" href="#products-nav-content"
+            onfocus="fetchDropdown('/partial/_navigation-products', 'products-nav-content');">Products</a>
           {% endif %}
         </li>
-        <li class="p-navigation__dropdown-link {% if request.path|get_nav_path == 'careers' %}is-selected{% endif %}" role="menuitem" id="careers-nav" onmouseover="fetchDropdown('/partial/_navigation-careers', 'careers-nav-content'); this.onmouseover = null;">
+        <li
+          class="p-navigation__dropdown-link {% if request.path|get_nav_path == 'careers' %}is-selected{% endif %}"
+          role="menuitem" id="careers-nav"
+          onmouseover="fetchDropdown('/partial/_navigation-careers', 'careers-nav-content'); this.onmouseover = null;">
           {% if request.path|get_nav_path == 'careers' %}
           <a class="p-navigation__link-anchor" href="/careers">Careers</a>
           {% else %}
-          <a class="p-navigation__link-anchor" href="#careers-nav-content" onfocus="fetchDropdown('/partial/_navigation-careers', 'careers-nav-content');">Careers</a>
+          <a class="p-navigation__link-anchor" href="#careers-nav-content"
+            onfocus="fetchDropdown('/partial/_navigation-careers', 'careers-nav-content');">Careers</a>
           {% endif %}
         </li>
       </ul>
       <noscript>
         <ul class="p-navigation__links">
-          <li class="p-navigation__link {% if request.path|get_nav_path == 'products' %}is-selected{% endif %}" role="menuitem">
+          <li
+            class="p-navigation__link {% if request.path|get_nav_path == 'products' %}is-selected{% endif %}"
+            role="menuitem">
             <a href="/products">Products</a>
           </li>
-          <li class="p-navigation__link {% if request.path|get_nav_path == 'partners' %}is-selected{% endif %}" role="menuitem">
+          <li
+            class="p-navigation__link {% if request.path|get_nav_path == 'partners' %}is-selected{% endif %}"
+            role="menuitem">
             <a href="/partners">Partners</a>
           </li>
-          <li class="p-navigation__link {% if request.path|get_nav_path == 'careers' %}is-selected{% endif %}" role="menuitem">
+          <li
+            class="p-navigation__link {% if request.path|get_nav_path == 'careers' %}is-selected{% endif %}"
+            role="menuitem">
             <a href="/careers">Careers</a>
           </li>
         </ul>
@@ -71,27 +88,25 @@
   if (nav) {
     nav.classList.remove('u-hide');
   }
-
   // If the page loads with a preselected hash load and open the menu
-  if ((hash) && (!((hash==="#products") || (hash==="#careers")))) {
+  if ((hash) && (!((hash === "#products") || (hash === "#careers")))) {
     var selected = nav.querySelector(hash);
     if (selected) {
       selected.onmouseover();
     }
   }
-
   function fetchDropdown(url, id) {
     const div = document.getElementById(id);
     fetch(url)
-    .then(function(response) {
-      return response.text();
-    })
-    .then(function(text) {
-      div.innerHTML = text;
-    })
-    .catch(function(error) {
-      console.log('Request failed', error)
-    })
+      .then(function (response) {
+        return response.text();
+      })
+      .then(function (text) {
+        div.innerHTML = text;
+      })
+      .catch(function (error) {
+        console.log('Request failed', error)
+      })
   }
 </script>
 
@@ -100,51 +115,40 @@
     toggle.setAttribute('aria-expanded', show);
     dropdown.setAttribute('aria-hidden', !show);
   }
-
   function setupContextualMenuListeners(contextualMenuSelector) {
     var menus = document.querySelectorAll(contextualMenuSelector);
-
     for (var i = 0; i < menus.length; i++) {
       var toggle = menus[i].querySelector('.p-contextual-menu__toggle'),
-          dropdown = menus[i].querySelector('.p-contextual-menu__dropdown'),
-          timer = null;
-
-      toggle.addEventListener('click', function(e) {
+        dropdown = menus[i].querySelector('.p-contextual-menu__dropdown'),
+        timer = null;
+      toggle.addEventListener('click', function (e) {
         e.preventDefault();
       });
-
-      toggle.addEventListener('mouseover', function() {
+      toggle.addEventListener('mouseover', function () {
         clearTimeout(timer);
         toggleMenu(toggle, dropdown, true);
       });
-
-      toggle.addEventListener('mouseleave', function() {
+      toggle.addEventListener('mouseleave', function () {
         toggleMenu(toggle, dropdown, true);
-
-        timer = setTimeout(function() {
+        timer = setTimeout(function () {
           toggleMenu(toggle, dropdown, false);
         }, 50);
       });
-
-      dropdown.addEventListener('mouseover', function() {
+      dropdown.addEventListener('mouseover', function () {
         clearTimeout(timer);
       });
-
-      dropdown.addEventListener('mouseleave', function() {
-        timer = setTimeout(function() {
+      dropdown.addEventListener('mouseleave', function () {
+        timer = setTimeout(function () {
           toggleMenu(toggle, dropdown, false);
         }, 50);
       });
-
-      document.onkeydown = function(e) {
+      document.onkeydown = function (e) {
         e = e || window.event;
-
         if (e.keyCode === 27) {
           toggleMenu(toggle, dropdown, false);
         }
       };
     };
   }
-
   setupContextualMenuListeners('.p-contextual-menu');
 </script>


### PR DESCRIPTION
## Done

- Add office addresses to the `/contact-us` page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/contact-us
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to [design and text](https://github.com/canonical-web-and-design/canonical.com/issues/107)
- Make sure the addresses are visible if you disable JS
- Check the location of the offices on maps is correct (I got the coordinates from https://canonical.com/about)


## Issue / Card

Fixes #107 