### PR TITLE
Copy updates

### DIFF
--- a/templates/careers/_secondary-navigation.html
+++ b/templates/careers/_secondary-navigation.html
@@ -13,10 +13,10 @@
           <a class="breadcrumbs__link {% if request.path|get_secondary_nav_path == 'admin' %}p-link--active{% else %}p-link--soft{% endif %}" href="/careers/admin">Admin</a>
         </li>
         <li class="breadcrumbs__item">
-          <a class="breadcrumbs__link {% if request.path|get_secondary_nav_path == 'commercial-ops' %}p-link--active{% else %}p-link--soft{% endif %}" href="/careers/commercial-ops">Commercial-ops</a>
+          <a class="breadcrumbs__link {% if request.path|get_secondary_nav_path == 'commercial-ops' %}p-link--active{% else %}p-link--soft{% endif %}" href="/careers/commercial-ops">Operations</a>
         </li>
         <li class="breadcrumbs__item">
-          <a class="breadcrumbs__link {% if request.path|get_secondary_nav_path == 'design' %}p-link--active{% else %}p-link--soft{% endif %}" href="/careers/design">Design</a>
+          <a class="breadcrumbs__link {% if request.path|get_secondary_nav_path == 'design' %}p-link--active{% else %}p-link--soft{% endif %}" href="/careers/design">Web & design</a>
         </li>
         <li class="breadcrumbs__item">
           <a class="breadcrumbs__link {% if request.path|get_secondary_nav_path == 'diversity' %}p-link--active{% else %}p-link--soft{% endif %}" href="/careers/diversity">Diversity</a>
@@ -31,7 +31,7 @@
           <a class="breadcrumbs__link {% if request.path|get_secondary_nav_path == 'finance' %}p-link--active{% else %}p-link--soft{% endif %}" href="/careers/finance">Finance</a>
         </li>
         <li class="breadcrumbs__item">
-          <a class="breadcrumbs__link {% if request.path|get_secondary_nav_path == 'hr' %}p-link--active{% else %}p-link--soft{% endif %}" href="/careers/hr">HR</a>
+          <a class="breadcrumbs__link {% if request.path|get_secondary_nav_path == 'hr' %}p-link--active{% else %}p-link--soft{% endif %}" href="/careers/hr">Human Resources</a>
         </li>
         <li class="breadcrumbs__item">
           <a class="breadcrumbs__link {% if request.path|get_secondary_nav_path == 'lifestyle' %}p-link--active{% else %}p-link--soft{% endif %}" href="/careers/lifestyle">Lifestyle</a>
@@ -52,7 +52,7 @@
           <a class="breadcrumbs__link {% if request.path|get_secondary_nav_path == 'sales' %}p-link--active{% else %}p-link--soft{% endif %}" href="/careers/sales">Sales</a>
         </li>
         <li class="breadcrumbs__item">
-          <a class="breadcrumbs__link {% if request.path|get_secondary_nav_path == 'tech-ops' %}p-link--active{% else %}p-link--soft{% endif %}" href="/careers/tech-ops">Tech-ops</a>
+          <a class="breadcrumbs__link {% if request.path|get_secondary_nav_path == 'tech-ops' %}p-link--active{% else %}p-link--soft{% endif %}" href="/careers/tech-ops">TechOps</a>
         </li>
         <li class="breadcrumbs__item">
           <a class="breadcrumbs__link {% if request.path|get_secondary_nav_path == 'travel' %}p-link--active{% else %}p-link--soft{% endif %}" href="/careers/travel">Travel</a>

--- a/templates/careers/commercial-ops.html
+++ b/templates/careers/commercial-ops.html
@@ -5,7 +5,7 @@
     <div class="p-strip--suru-background">
       <div class="row">
         <div class="col-6">
-          <h1>Commercial-ops</h1>
+          <h1>Operations</h1>
         </div>
       </div>
     </div>

--- a/templates/careers/commercial-ops.html
+++ b/templates/careers/commercial-ops.html
@@ -16,13 +16,13 @@
   <div class="p-strip is-shallow u-extra-space tab-content" id="overview">
     <p>
       <strong>
-        Excellence in operations enables Canonical to scale efficiently. Our core operations - from IT to commercial operations or logistics - is central to the idea that we can be an effective global distributed company serving advanced customers in every geography. We celebrate relentless improvement. We look for people who are passionate about tools and efficiency, who are focused on measurement, feedback and continuous improvement, and who will take the time to help their colleagues and counterparts improve.
+        Excellence in operations enables Canonical to scale efficiently. Our core operations &mdash; from IT to commercial operations or logistics &mdash; is central to the idea that we can be an effective global distributed company serving advanced customers in every geography. We celebrate relentless improvement. We look for people who are passionate about tools and efficiency, who are focused on measurement, feedback and continuous improvement, and who will take the time to help their colleagues and counterparts improve.
       </strong>
     </p>
 
-    <p>Getting it done right is the best feeling in the world. No shortcuts, no loose ends, no waste. It’s only possible to operate with mastery if you understand the domain deeply, you prioritise re-use and iteration, and you bring a sharp mind to the problem. A well-run operation invests in improving its data and its tools to elevate its self-awareness and automate its processes. Fighting fires is the exception, not the norm, and those moments are an opportunity to learn and improve.</p>
+    <p>Getting it done right is the best feeling in the world. No shortcuts, no loose ends, no waste. It&rsquo;s only possible to operate with mastery if you understand the domain deeply, you prioritise re-use and iteration, and you bring a sharp mind to the problem. A well-run operation invests in improving its data and its tools to elevate its self-awareness and automate its processes. Fighting fires is the exception, not the norm, and those moments are an opportunity to learn and improve.</p>
     
-    <p>Whether it’s running complex technical infrastructure or challenging projects, your consistent focus on data, your willingness to learn, and your personal organisation and teamwork means you’re a force for good in the battle against entropy. Time zones are easy and technical customers are your favourite. If that’s you - then there’s room for you at Canonical. We don’t just run a great business, we run the infrastructure and applications that power many great businesses.</p>
+    <p>Whether it&rsquo;s running complex technical infrastructure or challenging projects, your consistent focus on data, your willingness to learn, and your personal organisation and teamwork means you&rsquo;re a force for good in the battle against entropy. Time zones are easy and technical customers are your favourite. If that&rsquo;s you - then there&rsquo;s room for you at Canonical. We don&rsquo;t just run a great business, we run the infrastructure and applications that power many great businesses.</p>
       
     <hr />
     <p class="p-muted-heading">

--- a/templates/careers/commercial-ops.html
+++ b/templates/careers/commercial-ops.html
@@ -14,6 +14,16 @@
 
 {% block overview_tab %}
   <div class="p-strip is-shallow u-extra-space tab-content" id="overview">
+    <p>
+      <strong>
+        Excellence in operations enables Canonical to scale efficiently. Our core operations - from IT to commercial operations or logistics - is central to the idea that we can be an effective global distributed company serving advanced customers in every geography. We celebrate relentless improvement. We look for people who are passionate about tools and efficiency, who are focused on measurement, feedback and continuous improvement, and who will take the time to help their colleagues and counterparts improve.
+      </strong>
+    </p>
+
+    <p>Getting it done right is the best feeling in the world. No shortcuts, no loose ends, no waste. It’s only possible to operate with mastery if you understand the domain deeply, you prioritise re-use and iteration, and you bring a sharp mind to the problem. A well-run operation invests in improving its data and its tools to elevate its self-awareness and automate its processes. Fighting fires is the exception, not the norm, and those moments are an opportunity to learn and improve.</p>
+    
+    <p>Whether it’s running complex technical infrastructure or challenging projects, your consistent focus on data, your willingness to learn, and your personal organisation and teamwork means you’re a force for good in the battle against entropy. Time zones are easy and technical customers are your favourite. If that’s you - then there’s room for you at Canonical. We don’t just run a great business, we run the infrastructure and applications that power many great businesses.</p>
+      
     <hr />
     <p class="p-muted-heading">
       <span style="text-transform: capitalize">Europe&nbsp;&#124;&nbsp;Middle East&nbsp;&#124;&nbsp;Africa&nbsp;&#124;&nbsp;Americas&nbsp;&#124;&nbsp;APAC</span>

--- a/templates/careers/design.html
+++ b/templates/careers/design.html
@@ -9,7 +9,7 @@
     <div class="p-strip--suru-background">
       <div class="row">
         <div class="col-6">
-          <h1>Design</h1>
+          <h1>Web & design</h1>
         </div>
       </div>
     </div>

--- a/templates/careers/hr.html
+++ b/templates/careers/hr.html
@@ -7,7 +7,7 @@
     <div class="p-strip--suru-background">
       <div class="row">
         <div class="col-6">
-          <h1>HR</h1>
+          <h1>Human Resources</h1>
         </div>
       </div>
     </div>

--- a/templates/careers/index.html
+++ b/templates/careers/index.html
@@ -35,7 +35,7 @@
         <a href="/careers/engineering">More&nbsp;&rsaquo;</a>
       </div>
       <div class="col-6 p-card--strip-thin">
-        <h2 class="p-card--strip-thin__title">Tech-ops</h2>
+        <h2 class="p-card--strip-thin__title">TechOps</h2>
         <p class="p-card--strip-thin__content">Getting it done right is the best feeling in the world. Whether it’s running complex technical infrastructure or challenging projects, your consistent focus on data, organisation and teamwork means you’re a force for good in the battle against entropy. Time zones are easy and technical customers are your favourite&hellip;</p>
         <a href="/careers/tech-ops">More&nbsp;&rsaquo;</a>
       </div>
@@ -47,7 +47,7 @@
         <a href="/careers/project-management">More&nbsp;&rsaquo;</a>
       </div>
       <div class="col-4 p-card--strip-thin">
-        <h4 class="p-card--strip-thin__title">Commercial-ops</h4>
+        <h4 class="p-card--strip-thin__title">Operations</h4>
         <p class="p-card--strip-thin__content">Excellence in operations enables Canonical to scale efficiently. Our core operations - from IT to commercial operations or logistics - is central to the idea that we can be an effective global distributed company serving advanced customers in every geography. We celebrate relentless improvement. We look for people who are passionate about tools and efficiency&hellip;</p>
         <a href="/careers/commercial-ops">More&nbsp;&rsaquo;</a>
       </div>

--- a/templates/careers/results.html
+++ b/templates/careers/results.html
@@ -43,19 +43,19 @@ Travel regularly to interesting destinations for team, conference and customer e
             {% if departments|length == 1 %}
               {{ departments[0]|lower }}
             {% else %}
-              {% for departments in departments %}
+              {% for department in departments %}
                 {% if loop.index < departments|length-1 %}
-                  {{ departments|lower }},
+                  {{ department|lower }},
                 {% elif loop.index < departments|length %}
-                  {{ departments|lower }}
+                  {{ department|lower }}
                 {% else %}
-                  and {{ departments|lower }}
+                  and {{ department|lower }}.
                 {% endif %}
               {% endfor %}
             {% endif %}</p>
           <div class="row">
             <div class="col-6">
-              <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Laudantium ad ducimus repellat ipsa exercitationem rem at vitae amet consectetur repudiandae possimus nulla, quasi facilis magnam iste recusandae libero accusantium?</p>
+              <p>We have tailored the roles below based on your choices. Apply to any which you feel are suitable or retake your choices.</p>
             </div>
             <div class="col-2 u-align--center u-vertically-center">
               <p>

--- a/templates/partial/_careers-navigation.html
+++ b/templates/partial/_careers-navigation.html
@@ -5,10 +5,10 @@
         <a href="/careers/engineering" class="p-link--soft">Engineering</a>
       </li>
       <li class="p-content-list-section__item js-navigation-link">
-        <a href="/careers/tech-ops" class="p-link--soft">Tech-ops</a>
+        <a href="/careers/tech-ops" class="p-link--soft">TechOps</a>
       </li>
       <li class="p-content-list-section__item js-navigation-link">
-        <a href="/careers/commercial-ops" class="p-link--soft">Commercial-ops</a>
+        <a href="/careers/commercial-ops" class="p-link--soft">Operations</a>
       </li>
       <li class="p-content-list-section__item js-navigation-link">
         <a href="/careers/sales" class="p-link--soft">Sales</a>
@@ -17,7 +17,7 @@
         <a href="/careers/marketing" class="p-link--soft">Marketing</a>
       </li>
       <li class="p-content-list-section__item js-navigation-link">
-        <a href="/careers/design" class="p-link--soft">Design</a>
+        <a href="/careers/design" class="p-link--soft">Web & design</a>
       </li>
       <li class="p-content-list-section__item js-navigation-link">
         <a href="/careers/project-management" class="p-link--soft">Project Management</a>
@@ -32,7 +32,7 @@
         <a href="/careers/admin" class="p-link--soft">Admin</a>
       </li>
       <li class="p-content-list-section__item js-navigation-link">
-        <a href="/careers/hr" class="p-link--soft">HR</a>
+        <a href="/careers/hr" class="p-link--soft">Human Resources</a>
       </li>
     </ul>
     <ul class="p-content-list-section">
@@ -63,16 +63,16 @@
   <select name="menu" onchange="location.href=this.value">
     <option disabled="disabled" value="" selected="">Go to...</option>
     <option value="/careers/engineering">Engineering</option>
-    <option value="/careers/tech-ops">Tech-ops</option>
-    <option value="/careers/commercial-ops">Commercial-ops</option>
+    <option value="/careers/tech-ops">TechOps</option>
+    <option value="/careers/commercial-ops">Operations</option>
     <option value="/careers/sales">Sales</option>
     <option value="/careers/marketing">Marketing</option>
-    <option value="/careers/design">Design</option>
+    <option value="/careers/design">Web & design</option>
     <option value="/careers/project-management">Project Management</option>
     <option value="/careers/finance">Finance</option>
     <option value="/careers/legal">Legal</option>
     <option value="/careers/admin">Admin</option>
-    <option value="/careers/hr">HR</option>
+    <option value="/careers/hr">Human Resources</option>
     <option value="/careers/lifestyle">Lifestyle</option>
     <option value="/careers/ethics">Ethics</option>
     <option value="/careers/travel">Travel</option>

--- a/templates/partial/_navigation-careers.html
+++ b/templates/partial/_navigation-careers.html
@@ -41,14 +41,14 @@
         <div class="col-3">
           <h4 class="p-heading--four is-dense p-muted-heading" style="padding-top: .5rem; margin-bottom: 1.5rem;">Explore opportunities in</h4>
           <ul class="p-list">
-            <li class="p-list__item"><a href="/careers/tech-ops">Tech-ops&nbsp;&rsaquo;</a></li>
-            <li class="p-list__item"><a href="/careers/commercial-ops">Commercial-ops&nbsp;&rsaquo;</a></li>
-            <li class="p-list__item"><a href="/careers/design">Design&nbsp;&rsaquo;</a></li>
+            <li class="p-list__item"><a href="/careers/tech-ops">TechOps&nbsp;&rsaquo;</a></li>
+            <li class="p-list__item"><a href="/careers/commercial-ops">Operations&nbsp;&rsaquo;</a></li>
+            <li class="p-list__item"><a href="/careers/design">Web & design&nbsp;&rsaquo;</a></li>
             <li class="p-list__item"><a href="/careers/finance">Finance&nbsp;&rsaquo;</a></li>
             <li class="p-list__item"><a href="/careers/project-management">Project Management&nbsp;&rsaquo;</a></li>
             <li class="p-list__item"><a href="/careers/legal">Legal&nbsp;&rsaquo;</a></li>
             <li class="p-list__item"><a href="/careers/admin">Admin&nbsp;&rsaquo;</a></li>
-            <li class="p-list__item"><a href="/careers/hr">HR&nbsp;&rsaquo;</a></li>
+            <li class="p-list__item"><a href="/careers/hr">Human Resources&nbsp;&rsaquo;</a></li>
           </ul>
           <div class="u-hide u-show--small">
             <small>In every time zone</small>


### PR DESCRIPTION
## Done

- Added missing overview copy to /careers/commercial-ops
- Updated copy in search results message
- Updated careers category titles in line with copy docs

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/careers/commercial-ops
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the overview copy matches the [copy doc](https://docs.google.com/document/d/1y2bqWcHW2rRrb5gA7XTt8_A0q6zPOLkkOIwCIaNLpTk/edit)
- Visit /careers/start, play the game and submit your choices, then see that the "Looks like you're interested in..." copy makes sense.


## Issue / Card

Fixes #116 