### PR TITLE
Parse the feed departments to work with the site

### DIFF
--- a/tests/test_greenhouse_api.py
+++ b/tests/test_greenhouse_api.py
@@ -1,0 +1,18 @@
+import unittest
+from webapp.greenhouse_api import parse_feed_department
+
+
+class TestGreenhouseAPI(unittest.TestCase):
+    def test_parse_feed_department_not_matched(self):
+        department = "foo"
+        parsed_department = parse_feed_department(department)
+        self.assertEqual(parsed_department, department)
+
+    def test_parse_feed_department_matched(self):
+        department = "cloud engineering"
+        parsed_department = parse_feed_department(department)
+        self.assertEqual(parsed_department, "engineering")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/webapp/greenhouse_api.py
+++ b/webapp/greenhouse_api.py
@@ -22,6 +22,7 @@ def get_vacancies(department):
     vacancies = []
     for job in feed["jobs"]:
         feed_department = remove_hyphens(job["metadata"][2]["value"])
+        feed_department = parse_feed_department(feed_department)
         if path_department.lower() == "all":
             vacancies.append(
                 {
@@ -135,6 +136,21 @@ def submit_to_greenhouse(form_data, form_files, job_id="1658196"):
     )
 
     return response
+
+
+def parse_feed_department(feed_department):
+    if (
+        feed_department.lower() == "cloud engineering"
+        or feed_department.lower() == "device engineering"
+    ):
+        feed_department = "engineering"
+    if feed_department.lower() == "web and design":
+        feed_department = "design"
+    if feed_department.lower() == "operations":
+        feed_department = "commercialops"
+    if feed_department.lower() == "human resources":
+        feed_department = "hr"
+    return feed_department
 
 
 def remove_hyphens(text):

--- a/webapp/greenhouse_api.py
+++ b/webapp/greenhouse_api.py
@@ -21,8 +21,9 @@ def get_vacancies(department):
     path_department = remove_hyphens(department)
     vacancies = []
     for job in feed["jobs"]:
-        feed_department = remove_hyphens(job["metadata"][2]["value"])
-        feed_department = parse_feed_department(feed_department)
+        feed_department = parse_feed_department(
+            remove_hyphens(job["metadata"][2]["value"])
+        )
         if path_department.lower() == "all":
             vacancies.append(
                 {
@@ -139,17 +140,17 @@ def submit_to_greenhouse(form_data, form_files, job_id="1658196"):
 
 
 def parse_feed_department(feed_department):
-    if (
-        feed_department.lower() == "cloud engineering"
-        or feed_department.lower() == "device engineering"
-    ):
-        feed_department = "engineering"
-    if feed_department.lower() == "web and design":
-        feed_department = "design"
-    if feed_department.lower() == "operations":
-        feed_department = "commercialops"
-    if feed_department.lower() == "human resources":
-        feed_department = "hr"
+    field = {
+        "cloud engineering": "engineering",
+        "device engineering": "engineering",
+        "web and design": "design",
+        "operations": "commercialops",
+        "human resources": "hr",
+    }
+
+    if feed_department.lower() in field:
+        return field[feed_department.lower()]
+
     return feed_department
 
 


### PR DESCRIPTION
## Done
Added a parsing function to the returned feed department data to align with the site content.

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/careers
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Click through and check to engineer and we and design have roles available
- The others do not yet
- Compare to the `department - external` here: https://boards-api.greenhouse.io/v1/boards/Canonical/jobs 