### PR TITLE
increase padding on nav on x-small screens

### DIFF
--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -296,13 +296,6 @@ $nudge--small: .55rem;
         }
       }
     }
-
-    &__link-anchor {
-      @media (max-width: $breakpoint-x-small - 1) {
-        padding-left: $grid-margin-width / 4 !important;
-        padding-right: $grid-margin-width / 4 !important;
-      }
-    }
   }
 
   .dropdown-window-overlay {


### PR DESCRIPTION
## Done

Increased padding of nav items on x-small screens, to align with logo

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- View the page at <460px, and see that the header logo and nav are aligned to the left


## Issue / Card

Fixes #123 