### PR TITLE
Fix filters on results

### DIFF
--- a/static/js/careers-filter-and-sort.js
+++ b/static/js/careers-filter-and-sort.js
@@ -43,16 +43,8 @@
 
       if (sortSelect) {
         sortSelect.addEventListener("change", function (e) {
-          var sortBy = "date";
-          switch (sortSelect.options[sortSelect.options.selectedIndex].value) {
-            case "Date":
-              sortBy = "date";
-              break;
-            case "Location":
-              sortBy = "location";
-          }
-          jobList.sort((a, b) => a.dataset[sortBy] !== b.dataset[sortBy] ? a.dataset[sortBy] < b.dataset[sortBy] ? -1 : 1 : 0);
-          if (sortBy === "date") {
+          jobList.sort((a, b) => a.dataset[sortSelect.value] !== b.dataset[sortSelect.value] ? a.dataset[sortSelect.value] < b.dataset[sortSelect.value] ? -1 : 1 : 0);
+          if (sortSelect.value === "date") {
             jobList.reverse();
           }
           // Create new DOM list

--- a/static/js/careers-filter-and-sort.js
+++ b/static/js/careers-filter-and-sort.js
@@ -107,12 +107,12 @@
     switch (filter) {
       case "home-based":
         filterBy.filterName = "office";
-        filterBy.filterText = "Home based";
+        filterBy.filterText = "Home Based";
         filterBy.filterValue = "home-based";
         break;
       case "office-based":
         filterBy.filterName = "office";
-        filterBy.filterText = "Office based";
+        filterBy.filterText = "Office Based";
         filterBy.filterValue = "office-based";
         break;
       case "management":

--- a/static/js/careers-filter-and-sort.js
+++ b/static/js/careers-filter-and-sort.js
@@ -36,7 +36,7 @@
           }
           updateFilterBy(filterSelect.options[filterSelect.options.selectedIndex].value);
           filterJobs(filterBy, jobList);
-          updateUlr(filterBy);
+          updateURL(filterBy);
           updateNoResultsMessage();
         });
       }
@@ -150,18 +150,15 @@
     }
   }
 
-  function updateUlr(filterBy) {
-    const currentUrl = window.location.href;
-    const baseUrl = currentUrl.split("#")[0].split("?")[0];
-    var newUrl = `${baseUrl}#available-roles`;
-    if (filterBy.filterValue === "all") {
-      window.history.pushState({ filter: "all" }, "", newUrl);
-    } else {
-      newUrl = `${baseUrl}?filter=${filterBy.filterValue}#available-roles`;
-      window.history.pushState({ filter: filterBy.filterValue }, "", newUrl);
-    }
+  function updateURL(filterBy) {
+    var baseURL = window.location.origin + window.location.pathname;
+    
+    urlParams.set('filter', filterBy.filterValue);
+
+    var url = baseURL + '?' + urlParams.toString() + '#available-roles';
+
+    window.history.pushState({}, "", url);
   }
 
   init();
-
 })();

--- a/templates/careers/_filters.html
+++ b/templates/careers/_filters.html
@@ -14,10 +14,10 @@
   <div class="p-form__group">
     <label for="sort" aria-label="Sort resources" class="p-form__label">Sort by</label>
     <select class="js-sort p-form__control" id="sort" name="sort" aria-label="Sort resources">
-      <option>Date</option>
-      <option>Location</option>
+      <option value="date">Date</option value="">
+      <option value="location">Location</option>
       {% if request.path == "/careers/all"%}
-      <option>Job sector</option>
+      <option value="sector">Job sector</option>
       {% endif %}
     </select>
   </div>

--- a/templates/careers/_filters.html
+++ b/templates/careers/_filters.html
@@ -1,0 +1,26 @@
+<form action="" method="get" class="p-form p-form--inline">
+  <div class="p-form__group">
+    <label for="filter" aria-label="Filter by job type" class="p-form__label">Filter by</label>
+    <select class="js-filter p-form__control" id="filter" name="filter"
+      aria-label="Filter by job type">
+      <option value="all">All</option>
+      <option value="home-based">Home based</option>
+      <option value="office-based">Office based</option>
+      <option value="management">Management</option>
+      <option value="full-time">Full-time</option>
+      <option value="part-time">Part-time</option>
+    </select>
+  </div>
+  <div class="p-form__group">
+    <label for="sort" aria-label="Sort resources" class="p-form__label">Sort by</label>
+    <select class="js-sort p-form__control" id="sort" name="sort" aria-label="Sort resources">
+      <option>Date</option>
+      <option>Location</option>
+      {% if request.path == "/careers/all"%}
+      <option>Job sector</option>
+      {% endif %}
+    </select>
+  </div>
+</form>
+
+<hr />

--- a/templates/careers/base.html
+++ b/templates/careers/base.html
@@ -11,4 +11,6 @@
   </div>
 </section>
 
+<script defer src="/static/js/careers-filter-and-sort.js"></script>
+
 {% endblock %}

--- a/templates/careers/results.html
+++ b/templates/careers/results.html
@@ -68,30 +68,8 @@ Travel regularly to interesting destinations for team, conference and customer e
     </div>
     {% endif %}
     <div class="row u-vertically-center">
-      <div class="col-8 u-align--right">
-        <form action="" method="get" class="p-form p-form--inline">
-          <div class="p-form__group">
-            <label for="filter" aria-label="Filter by job type" class="p-form__label">Filter by</label>
-            <select class="js-filter p-form__control" id="filter" name="filter"
-              aria-label="Filter by job type">
-              <option>All</option>
-              <option>Home based</option>
-              <option>Office based</option>
-              <option>Management</option>
-              <option>Full-time</option>
-              <option>Part-time</option>
-            </select>
-          </div>
-          <div class="p-form__group">
-            <label for="sort" aria-label="Sort resources" class="p-form__label">Sort by</label>
-            <select class="js-sort p-form__control" id="sort" name="sort" aria-label="Sort resources">
-              <option>Date</option>
-              <option>Location</option>
-              <option>Job sector</option>
-            </select>
-          </div>
-        </form>
-        <hr />
+      <div class="col-8 u-align--right js-filter-form u-hide">
+        {% include "careers/_filters.html" %}
       </div>
     </div>
     <div class="row">
@@ -101,7 +79,7 @@ Travel regularly to interesting destinations for team, conference and customer e
           <p>{{ message }} <a href="/careers/start">Retake choices again?</a></p>
         </div>
         {% else %}
-        <form>
+        <form class="js-filter-jobs-container">
           {% with checkbox="true" %}
             {% include "partial/_careers-job-list.html" %}
           {% endwith %}
@@ -109,6 +87,10 @@ Travel regularly to interesting destinations for team, conference and customer e
           <button type="submit">Apply now</button>
         </form>
         {% endif %}
+
+        <h2 class="p-heading--four js-filter__no-results u-hide">
+          Sorry, there are no open positions matching your criteria.
+        </h2>
       </div>
     </div>
   </div>

--- a/templates/partial/_careers-available-roles.html
+++ b/templates/partial/_careers-available-roles.html
@@ -1,30 +1,6 @@
 {% if vacancies %}
 <div class="u-align--right js-filter-form u-hide">
-  <form action="" method="get" class="p-form p-form--inline">
-    <div class="p-form__group">
-      <label for="filter" aria-label="Filter by job type" class="p-form__label">Filter by</label>
-      <select class="js-filter p-form__control" id="filter" name="filter"
-        aria-label="Filter by job type">
-        <option value="all">All</option>
-        <option value="home-based">Home based</option>
-        <option value="office-based">Office based</option>
-        <option value="management">Management</option>
-        <option value="full-time">Full-time</option>
-        <option value="part-time">Part-time</option>
-      </select>
-    </div>
-    <div class="p-form__group">
-      <label for="sort" aria-label="Sort resources" class="p-form__label">Sort by</label>
-      <select class="js-sort p-form__control" id="sort" name="sort" aria-label="Sort resources">
-        <option>Date</option>
-        <option>Location</option>
-        {% if request.path == "/careers/all"%}
-        <option>Job sector</option>
-        {% endif %}
-      </select>
-    </div>
-  </form>
-  <hr />
+  {% include "careers/_filters.html" %}
 </div>
 <h2 class="p-heading--four js-filter__no-results u-hide">
   Sorry, there are no open positions matching your criteria.

--- a/templates/partial/_careers-job-list.html
+++ b/templates/partial/_careers-job-list.html
@@ -7,7 +7,7 @@
     data-date="{{ job.date }}" 
     data-location="{{ job.location }}" 
     data-management="{{ job.management}}" 
-    data-sector="{{ job.departments }}"
+    data-sector="{{ job.department }}"
   >
     <p class="u-no-margin--bottom u-sv1">
       <small {% if checkbox %}style="padding-left: 2rem;"{% endif %}>


### PR DESCRIPTION
## Done

- fixed dropdown filters on /careers/results
- fixed issue where refreshing the page after using the dropdown filter would cause the 'coreskills' values to be lost

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/careers/start
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- select some options, submit them - you should land on /careers/results
- using the dropdown, filter the results
- see that the results are indeed filtered
- refresh the page, see that the page loads successfully, and the relevant results are shown


## Issue / Card

Fixes #125 