### PR TITLE
replace large file size images with optimised versions

### DIFF
--- a/templates/careers/index.html
+++ b/templates/careers/index.html
@@ -108,7 +108,7 @@
         linear-gradient(to top left, #fff 0%, #fff 49%, transparent 50%),
         linear-gradient(to bottom right, rgba(210,180,202,0.05) 0%, rgba(210,180,202,0.05) 49.9%, rgba(210,180,202,0) 50%, rgba(210,180,202,0) 100%),
         linear-gradient(120deg, #2C001E  4%, #4C193E 54.9%, transparent 55%),
-        url('https://assets.ubuntu.com/v1/437c013a-AdobeStock_193792692.jpg');
+        url('https://assets.ubuntu.com/v1/5c69a4be-AdobeStock_193792692.jpg');
       background-position: right top, bottom -1px right -1px, top left, top left, center right, right bottom;
       background-repeat: no-repeat;
       background-size: 85% 100%, 105% 25%, 70% 80%, 100% 100%, 55% auto;

--- a/templates/careers/lifestyle.html
+++ b/templates/careers/lifestyle.html
@@ -21,7 +21,7 @@
         linear-gradient(to top left, #fff 0%, #fff 49%, transparent 50%),
         linear-gradient(to bottom right, rgba(210,180,202,0.05) 0%, rgba(210,180,202,0.05) 49.9%, rgba(210,180,202,0) 50%, rgba(210,180,202,0) 100%),
         linear-gradient(120deg, #2C001E 4%, #4C193E 54.9%, transparent 55%),
-        url('https://assets.ubuntu.com/v1/883df027-canonical-travel.jpg');
+        url('https://assets.ubuntu.com/v1/f08c945e-canonical-travel.jpg');
       background-position: right top, bottom -1px right -1px, top left, top left, center right, right bottom;
       background-repeat: no-repeat;
       background-size: 85% 100%, 105% 25%, 70% 80%, 100% 100%, 65% auto;

--- a/templates/careers/travel.html
+++ b/templates/careers/travel.html
@@ -21,7 +21,7 @@
         linear-gradient(to top left, #fff 0%, #fff 49%, transparent 50%),
         linear-gradient(to bottom right, rgba(210,180,202,0.05) 0%, rgba(210,180,202,0.05) 49.9%, rgba(210,180,202,0) 50%, rgba(210,180,202,0) 100%),
         linear-gradient(120deg, #2C001E  4%, #4C193E 54.9%, transparent 55%),
-        url('https://assets.ubuntu.com/v1/883df027-canonical-travel.jpg');
+        url('https://assets.ubuntu.com/v1/f08c945e-canonical-travel.jpg');
       background-position: right top, bottom -1px right -1px, top left, top left, center right, right bottom;
       background-repeat: no-repeat;
       background-size: 85% 100%, 105% 25%, 70% 80%, 100% 100%, 65% auto;
@@ -54,7 +54,7 @@
   <p>
     We do optimise team structure for time zone overlap - collaboration takes time and inspiration needs time to develop fully - but leadership at Canonical means building cross-team relationships and we do that through regular global summits which bring diverse teams or their leaders together. We aim to balance these events around the world to minimize the total travel and jet lag, and we try to discover great places to explore and appreciate in the process. Team events have taken place in Annecy, Vancouver, Brugge, New York, Budapest, Orlando, Cape Town, Warsaw, Seoul, Paris, Portland, Lyon, London, Toronto and many more.
   </p>
-  <img src="https://assets.ubuntu.com/v1/34b9fe84-cities2.jpg" width="600" height="249" alt="">
+  <img src="https://assets.ubuntu.com/v1/5d35895c-cities2.jpg" width="600" height="249" alt="">
   <p>
     Our customers are transforming their deepest and most important infrastructure to benefit from open source and modern dev/ops insights, and they trust us to advise them and lead them to best practice. That also takes time on site, to whiteboard and to work shoulder to shoulder in their development halls and data centers. Many teams at Canonical travel for that deep customer presence.
   </p>


### PR DESCRIPTION
## Done

- replaced large file size images with optimised versions

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Open the network tab in dev tools
- Visit /careers, /careers/travel and /careers/lifestyle, checking the network tab each time to ensure that images loaded are all < 200kb


## Issue / Card

Fixes #135 