### PR TITLE
Set explicit list of careers department routes

### DIFF
--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -18,6 +18,24 @@ class TestRoutes(unittest.TestCase):
 
         self.assertEqual(self.client.get("/").status_code, 200)
 
+    def test_careers_department(self):
+        """
+        When given the URL of a valid careers department,
+        we should return a 200 status code
+        """
+
+        self.assertEqual(
+            self.client.get("/careers/engineering").status_code, 200
+        )
+
+    def test_invalid_careers_department(self):
+        """
+        When given the URL of an invalid careers department,
+        we should return a 404 status code
+        """
+
+        self.assertEqual(self.client.get("/careers/foo").status_code, 404)
+
     def test_not_found(self):
         """
         When given a non-existent URL,

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -29,6 +29,20 @@ app = FlaskBase(
     template_500="500.html",
 )
 
+departments = [
+    'admin',
+    'commercial-ops',
+    'design',
+    'engineering',
+    'finance',
+    'hr',
+    'legal',
+    'marketing',
+    'project-management',
+    'sales',
+    'tech-ops',
+]
+
 
 @app.route("/")
 def index():
@@ -63,7 +77,7 @@ def results():
 
 
 @app.route(
-    "/careers/<regex('[a-z-]*[a-z][a-z-]*'):department>",
+    "/careers/<any('({})'):department>".format(str(departments)[1:-1]),
     methods=["GET", "POST"],
 )
 def department_group(department):

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -30,17 +30,17 @@ app = FlaskBase(
 )
 
 departments = [
-    'admin',
-    'commercial-ops',
-    'design',
-    'engineering',
-    'finance',
-    'hr',
-    'legal',
-    'marketing',
-    'project-management',
-    'sales',
-    'tech-ops',
+    "admin",
+    "commercial-ops",
+    "design",
+    "engineering",
+    "finance",
+    "hr",
+    "legal",
+    "marketing",
+    "project-management",
+    "sales",
+    "tech-ops",
 ]
 
 

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -29,7 +29,7 @@ app = FlaskBase(
     template_500="500.html",
 )
 
-departments = [
+career_departments = [
     "admin",
     "commercial-ops",
     "design",
@@ -76,11 +76,11 @@ def results():
     return flask.render_template("careers/results.html", **context)
 
 
-@app.route(
-    "/careers/<any('({})'):department>".format(str(departments)[1:-1]),
-    methods=["GET", "POST"],
-)
+@app.route("/careers/<department>", methods=["GET", "POST"])
 def department_group(department):
+    if department not in career_departments:
+        flask.abort(404)
+
     vacancies = get_vacancies(department)
 
     if flask.request.method == "POST":


### PR DESCRIPTION
## Done

- removed route regex, set explicit list of career departments to match against

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/careers/engineering
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the page loads correctly
- Go to /careers/engineering1234
- See that the page 404s


## Issue / Card

Fixes #134