### PR TITLE
remove "send your cv" tab

### DIFF
--- a/templates/careers/base-tabs.html
+++ b/templates/careers/base-tabs.html
@@ -34,19 +34,11 @@
           <li class="p-tabs__item" role="presentation">
             <a href="#available-roles" class="p-tabs__link" tabindex="-1" role="tab" aria-controls="available-roles">Available roles</a>
           </li>
-          <li class="p-tabs__item" role="presentation">
-            <a href="#send-cv" class="p-tabs__link" tabindex="-1" role="tab" aria-controls="send-cv">Send your
-              CV</a>
-          </li>
         </ul>
       </nav>
 
       <div class="p-strip p-tabs__content is-shallow u-extra-space" id="available-roles">
         {% include 'partial/_careers-available-roles.html' %}
-      </div>
-
-      <div class="p-strip p-tabs__content is-shallow u-extra-space" id="send-cv">
-        {% include 'partial/_careers-send-cv.html' %}
       </div>
 
       <div class="p-strip p-tabs__content is-shallow u-extra-space" id="overview">

--- a/templates/partial/_careers-available-roles.html
+++ b/templates/partial/_careers-available-roles.html
@@ -11,5 +11,4 @@
 {% else %}
   <h2 class="p-heading--three">We don&apos;t have any open positions right now.
   </h2>
-  <p>If you&apos;d like <a href="#send-cv">send us your CV</a> and we&apos;ll send you an email any time a position opens up.</p>
 {% endif %}

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -76,11 +76,11 @@ def results():
     return flask.render_template("careers/results.html", **context)
 
 
-@app.route("/careers/<department>", methods=["GET", "POST"])
+@app.route(
+    "/careers/<any('({})'):department>".format(str(career_departments)[1:-1]),
+    methods=["GET", "POST"],
+)
 def department_group(department):
-    if department not in career_departments:
-        flask.abort(404)
-
     vacancies = get_vacancies(department)
 
     if flask.request.method == "POST":

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -31,6 +31,7 @@ app = FlaskBase(
 
 career_departments = [
     "admin",
+    "all",
     "commercial-ops",
     "design",
     "engineering",


### PR DESCRIPTION
## Done

- Disabled ability to submit CV on career departments.
- Fixed non-department /career pages 404ing

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/careers/engineering
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that there are only two tabs, "overview" and "available roles"
- Visit /careers/start, /careers/lifsetyle and /careers/all
- See that none of them 404
