### PR TITLE
Fix missing "no results" message when filtering job results

### DIFF
--- a/templates/careers/results.html
+++ b/templates/careers/results.html
@@ -81,7 +81,7 @@ Travel regularly to interesting destinations for team, conference and customer e
         {% else %}
         <div class="js-filter-jobs-container">
           {% include "partial/_careers-job-list.html" %}
-        </form>
+        </div>
         {% endif %}
 
         <h2 class="p-heading--four js-filter__no-results u-hide">


### PR DESCRIPTION
## Done

- Fixed invalid HTML that was causing missing "no results" message when filtering job results

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/careers/start
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Select 5 choices and submit them
- On the results page, filter by "Part-time"
- See that "Sorry, there are no open positions matching your criteria." is visible