### PR TITLE
Multistage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,46 @@
+# syntax=docker/dockerfile:experimental
+
+
+# Build stage: Install python dependencies
+# ===
+FROM ubuntu:bionic AS python-dependencies
+RUN apt-get update && apt-get install --no-install-recommends --yes python3-pip python3-setuptools
+ADD requirements.txt /tmp/requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip pip3 install --user --requirement /tmp/requirements.txt
+
+
+# Build stage: Build CSS
+# ===
+FROM node:10-slim AS build-css
+WORKDIR /srv
+ADD package.json .
+RUN --mount=type=cache,target=/usr/local/share/.cache/yarn yarn install
+ADD static/sass static/sass
+RUN yarn run build-css
+
+
+# Build the production image
+# ===
 FROM ubuntu:bionic
+
+# Install python and import python dependencies
+RUN apt-get update && apt-get install --no-install-recommends --yes python3-lib2to3 python3-pkg-resources ca-certificates libsodium-dev
+COPY --from=python-dependencies /root/.local/lib/python3.6/site-packages /root/.local/lib/python3.6/site-packages
+COPY --from=python-dependencies /root/.local/bin /root/.local/bin
+ENV PATH="/root/.local/bin:${PATH}"
 
 # Set up environment
 ENV LANG C.UTF-8
 WORKDIR /srv
 
-# System dependencies
-RUN apt-get update -y && apt-get install -y --no-install-recommends python3 python3-setuptools python3-pip
+# Import code, build assets and mirror list
+ADD . .
+RUN rm -rf package.json yarn.lock .babelrc webpack.config.js
+COPY --from=build-css /srv/static/css static/css
 
-# Set git commit ID
-ARG TALISKER_REVISION_ID
-ENV TALISKER_REVISION_ID "${TALISKER_REVISION_ID}"
-
-# Import code, install code dependencies
-COPY . .
-RUN python3 -m pip install --no-cache-dir -r requirements.txt
+# Set revision ID
+ARG BUILD_ID
+ENV TALISKER_REVISION_ID "${BUILD_ID}"
 
 # Setup commands to run server
 ENTRYPOINT ["./entrypoint"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN --mount=type=cache,target=/root/.cache/pip pip3 install --user --requirement
 
 # Build stage: Build CSS
 # ===
-FROM node:10-slim AS build-css
+FROM node:12-slim AS build-css
 WORKDIR /srv
 ADD package.json .
 RUN --mount=type=cache,target=/usr/local/share/.cache/yarn yarn install

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "scripts": {
     "clean": "rm -rf node_modules yarn-error.log css static/css *.log *.sqlite _site/ build/ .jekyll-metadata .bundle",
     "watch": "watch -p 'static/sass/**/*.scss' -c 'yarn run build'",
-    "build": "node-sass --include-path node_modules static/sass --source-map true --output-style compressed --output static/css && postcss --map false --use autoprefixer --replace 'static/css/**/*.css'",
+    "build": "yarn run build-css",
+    "build-css": "node-sass --include-path node_modules static/sass --source-map true --output-style compressed --output static/css && postcss --map false --use autoprefixer --replace 'static/css/**/*.css'",
     "format-python": "black --line-length 79 webapp",
     "lint-python": "flake8 webapp tests && black --check --line-length 79 webapp tests",
     "lint-scss": "sass-lint static/**/*.scss --verbose --no-exit",


### PR DESCRIPTION
Switch over to multistage build to fix the problem with node version in the build for production.

## QA

``` bash
./run clean  # To prove we don't need it
DOCKER_BUILDKIT=1 docker build --tag ccom --build-arg BUILD_ID=abuild .
docker run -ti -p 8555:80 ccom
```

Go to http://localhost:8555, check it works a charm.

Then, do:

``` bash
$ curl -I http://localhost:8555
X-VCS-Revision: abuild
```

^ Check you see the `BUILD_ID` there.