### PR TITLE
Scott's post-launch fixes for Peter's pre-launch snags

### DIFF
--- a/static/sass/_pattern_footer.scss
+++ b/static/sass/_pattern_footer.scss
@@ -28,5 +28,10 @@
       background: rgba(255, 255, 255, .25);
       margin: 2rem 0;
     }
+
+    .p-inline-list--middot .p-inline-list__item::after {
+      color: $color-mid-light;
+      right: -0.8rem;
+    }
   }
 }

--- a/templates/careers/index.html
+++ b/templates/careers/index.html
@@ -31,48 +31,48 @@
     <div class="row u-equal-height">
       <div class="col-6 p-card--strip-thin">
         <h2 class="p-card--strip-thin__title">Engineering</h2>
-        <p class="p-card--strip-thin__content">Open source is transforming the entire stack. This is your chance to be right at the center of that revolution, to shape the platforms and tools that millions use to invent our global technology future. From bare metal to cloud to high performance computing, from AI and big data to the web and connected devices, open source is the key ingredient for success&hellip;</p>
+        <p class="p-card--strip-thin__content">Open source is transforming the entire stack. This is your chance to be right at the center of that revolution, to shape the platforms and tools that millions use to invent our global technology future. From bare metal to cloud to high performance computing, from AI and big data to the web and connected devices, open source is the key ingredient for success.</p>
         <a href="/careers/engineering">More&nbsp;&rsaquo;</a>
       </div>
       <div class="col-6 p-card--strip-thin">
         <h2 class="p-card--strip-thin__title">TechOps</h2>
-        <p class="p-card--strip-thin__content">Getting it done right is the best feeling in the world. Whether it’s running complex technical infrastructure or challenging projects, your consistent focus on data, organisation and teamwork means you’re a force for good in the battle against entropy. Time zones are easy and technical customers are your favourite&hellip;</p>
+        <p class="p-card--strip-thin__content">Getting it done right is the best feeling in the world. Whether it’s running complex technical infrastructure or challenging projects, your consistent focus on data, organisation and teamwork means you’re a force for good in the battle against entropy. Time zones are easy and technical customers are your favourite.</p>
         <a href="/careers/tech-ops">More&nbsp;&rsaquo;</a>
       </div>
     </div>
     <div class="row u-equal-height">
       <div class="col-4 p-card--strip-thin">
         <h4 class="p-card--strip-thin__title">Project Management</h4>
-        <p class="p-card--strip-thin__content">Project Managers at Canonical are engaged during all phases of the project, from pre-sales support, to delivery to handoff of complete projects to support or managed services.  Project managers create, manage, and maintain project specific schedules ensuring projects are delivered within time/resources/scope expectations&hellip;</p>
+        <p class="p-card--strip-thin__content">Project Managers at Canonical are engaged during all phases of the project, from pre-sales support, to delivery to handoff of complete projects to support or managed services.  Project managers create, manage, and maintain project specific schedules ensuring projects are delivered within time/resources/scope expectations.</p>
         <a href="/careers/project-management">More&nbsp;&rsaquo;</a>
       </div>
       <div class="col-4 p-card--strip-thin">
         <h4 class="p-card--strip-thin__title">Operations</h4>
-        <p class="p-card--strip-thin__content">Excellence in operations enables Canonical to scale efficiently. Our core operations - from IT to commercial operations or logistics - is central to the idea that we can be an effective global distributed company serving advanced customers in every geography. We celebrate relentless improvement. We look for people who are passionate about tools and efficiency&hellip;</p>
+        <p class="p-card--strip-thin__content">Excellence in operations enables Canonical to scale efficiently. Our core operations - from IT to commercial operations or logistics - is central to the idea that we can be an effective global distributed company serving advanced customers in every geography. We celebrate relentless improvement. We look for people who are passionate about tools and efficiency.</p>
         <a href="/careers/commercial-ops">More&nbsp;&rsaquo;</a>
       </div>
       <div class="col-4 p-card--strip-thin">
         <h4 class="p-card--strip-thin__title">Sales</h4>
-        <p class="p-card--strip-thin__content">You build long term relationships and you always promote the approach that is in the customers best interests. You are interested in the state of the art, you love to represent a company that knows how to transform customer operations&hellip;</p>
+        <p class="p-card--strip-thin__content">You build long term relationships and you always promote the approach that is in the customers best interests. You are interested in the state of the art, you love to represent a company that knows how to transform customer operations.</p>
         <a href="/careers/sales">More&nbsp;&rsaquo;</a>
       </div>
     </div>
     <div class="row u-equal-height u-sv3">
       <div class="col-4 p-card--strip-thin">
         <h4 class="p-card--strip-thin__title">Legal</h4>
-        <p class="p-card--strip-thin__content">Canonical works at the forefront of global digital trends and the legal, licensing and regulatory frameworks that support them. We are a tight-knit team of professionals that enjoy playing a part in the rapid change&mldr;
+        <p class="p-card--strip-thin__content">Canonical works at the forefront of global digital trends and the legal, licensing and regulatory frameworks that support them. We are a tight-knit team of professionals that enjoy playing a part in the rapid change.
         </p>
         <a href="/careers/legal">More&nbsp;&rsaquo;</a>
       </div>
       <div class="col-4 p-card--strip-thin">
         <h4 class="p-card--strip-thin__title">Admin</h4>
-        <p class="p-card--strip-thin__content">Canonical is a completely new kind of organisation - almost entirely distributed, we are a global team of technology leaders who collaborate online to enable the transformation of enterprise software to open source&mldr;
+        <p class="p-card--strip-thin__content">Canonical is a completely new kind of organisation - almost entirely distributed, we are a global team of technology leaders who collaborate online to enable the transformation of enterprise software to open source.
         </p>
         <a href="/careers/admin">More&nbsp;&rsaquo;</a>
       </div>
       <div class="col-4 p-card--strip-thin">
         <h4 class="p-card--strip-thin__title">Human resources</h4>
-        <p class="p-card--strip-thin__content">Canonical provides a unique window into the world of 21st-century digital business. We work with smart individuals from a wide range of professional backgrounds in more than 40 countries worldwide, bringing together&mldr;
+        <p class="p-card--strip-thin__content">Canonical provides a unique window into the world of 21st-century digital business. We work with smart individuals from a wide range of professional backgrounds in more than 40 countries worldwide, bringing together.
         </p>
         <a href="/careers/hr">More&nbsp;&rsaquo;</a>
       </div>

--- a/templates/careers/index.html
+++ b/templates/careers/index.html
@@ -22,7 +22,7 @@
     </div>
     <div class="row u-sv3">
       <div class="col-8">
-        <p>Life at Canonical is anything but corporate. As a company that exists to support Ubuntu, one of today’s most important open source projects. We are changing the world on a daily basis. It’s a collaborative environment, but one in which every member of the team takes personal responsibility for everything they produce.</p>
+        <p>Life at Canonical is anything but corporate. As a company that exists to support Ubuntu, one of today’s most important open source projects, we are changing the world on a daily basis. It’s a collaborative environment, but one in which every member of the team takes personal responsibility for everything they produce.</p>
       </div>
       <div class="col-4 u-vertically-center">
         <p><a href="/careers/start" class="p-button--positive">Explore a career at Canonical</a></p>

--- a/templates/index.html
+++ b/templates/index.html
@@ -31,11 +31,11 @@
       </div>
     </div>
     <div class="row u-equal-height" style="grid-gap: 1rem;">
-      <div class="col-3 u-equal-height" data-animation="u-animation--slide-from-bottom">
+      <div class="col-4 u-equal-height" data-animation="u-animation--slide-from-bottom">
         <div class="p-card--strip u-no-padding">
           <div class="p-strip is-shallow">
             <a href="https://ubuntu.com">
-              <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/25be0ace-products-ubuntu-wht-aubergine.svg" alt="Ubuntu logo">
+              <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/25be0ace-products-ubuntu-wht-aubergine.svg" alt="Ubuntu">
             </a>
           </div>
           <div class="p-card__content">
@@ -44,11 +44,11 @@
           </div>
         </div>
       </div>
-      <div class="col-3 u-equal-height" data-animation="u-animation--slide-from-bottom">
+      <div class="col-4 u-equal-height" data-animation="u-animation--slide-from-bottom">
         <div class="p-card--strip u-no-padding">
           <div class="p-strip is-shallow">
             <a href="https://ubuntu.com/security">
-              <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/c47655d3-products-security-wht-aubergine4.svg" alt="Ubuntu security logo">
+              <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/c47655d3-products-security-wht-aubergine4.svg" alt="Security and support">
             </a>
           </div>
           <div class="p-card__content">
@@ -57,24 +57,11 @@
           </div>
         </div>
       </div>
-      <div class="col-3 u-equal-height" data-animation="u-animation--slide-from-bottom">
-        <div class="p-card--strip u-no-padding">
-          <div class="p-strip is-shallow">
-            <a href="https://ubuntu.com/support">
-              <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/45466075-products-support-wht-aubergine3.svg" alt="Ubuntu support logo">
-            </a>
-          </div>
-          <div class="p-card__content">
-            <p>Extended Security Maintenance, Kernel Livepatch, FIPS, enterprise support and certification</p>
-            <p><a href="https://ubuntu.com/support">ubuntu.com/support&nbsp;&rsaquo;</a></p>
-          </div>
-        </div>
-      </div>
-      <div class="col-3 u-equal-height" data-animation="u-animation--slide-from-bottom">
+      <div class="col-4 u-equal-height" data-animation="u-animation--slide-from-bottom">
         <div class="p-card--strip u-no-padding">
           <div class="p-strip is-shallow">
             <a href="https://landscape.canonical.com">
-              <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/7f8d7403-products-landscape-wht.svg" alt="Landscape logo">
+              <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/7f8d7403-products-landscape-wht.svg" alt="Landscape">
             </a>
           </div>
           <div class="p-card__content">
@@ -85,11 +72,11 @@
       </div>
     </div>
     <div class="row u-equal-height" style="grid-gap: 1rem;">
-      <div class="col-3 u-equal-height"  data-animation="u-animation--slide-from-bottom">
+      <div class="col-4 u-equal-height"  data-animation="u-animation--slide-from-bottom">
         <div class="p-card--strip u-no-padding">
           <div class="p-strip is-shallow">
             <a href="https://maas.io">
-              <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/3c26ff14-products-maas-wht-aubergine2.svg" alt="MAAS logo">
+              <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/3c26ff14-products-maas-wht-aubergine2.svg" alt="MAAS">
             </a>
           </div>
           <div class="p-card__content">
@@ -98,11 +85,11 @@
           </div>
         </div>
       </div>
-      <div class="col-3 u-equal-height" data-animation="u-animation--slide-from-bottom">
+      <div class="col-4 u-equal-height" data-animation="u-animation--slide-from-bottom">
         <div class="p-card--strip u-no-padding">
           <div class="p-strip is-shallow">
             <a href="https://linuxcontainers.org">
-              <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/a737970a-products-lxd-wht-aubergine4.svg" alt="LXD logo">
+              <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/a737970a-products-lxd-wht-aubergine4.svg" alt="LXD">
             </a>
           </div>
           <div class="p-card__content">
@@ -111,11 +98,11 @@
           </div>
         </div>
       </div>
-      <div class="col-3 u-equal-height" data-animation="u-animation--slide-from-bottom">
+      <div class="col-4 u-equal-height" data-animation="u-animation--slide-from-bottom">
         <div class="p-card--strip u-no-padding">
           <div class="p-strip is-shallow">
             <a href="https://jaas.ai">
-              <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/1dee5076-products-juju-wht-aubergine2.svg" alt="Juju logo">
+              <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/1dee5076-products-juju-wht-aubergine2.svg" alt="Juju">
             </a>
           </div>
           <div class="p-card__content">
@@ -124,26 +111,13 @@
           </div>
         </div>
       </div>
-      <div class="col-3 u-equal-height" data-animation="u-animation--slide-from-bottom">
-        <div class="p-card--strip u-no-padding">
-          <div class="p-strip is-shallow">
-            <a href="https://snapcraft.io">
-              <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/11776603-snapcraft_lrg.svg" alt="Snapcraft logo">
-            </a>
-          </div>
-          <div class="p-card__content">
-            <p>The app store with secure packages and ultra-reliable updates for multiple Linus distros</p>
-            <p><a href="https://snapcraft.io">snapcraft.io&nbsp;&rsaquo;</a></p>
-          </div>
-        </div>
-      </div>
     </div>
     <div class="row u-equal-height"style="grid-gap: 1rem;">
-      <div class="col-6 u-equal-height" data-animation="u-animation--slide-from-bottom">
+      <div class="col-4 u-equal-height" data-animation="u-animation--slide-from-bottom">
         <div class="p-card--strip u-no-padding">
           <div class="p-strip is-shallow">
             <a href="https://ubuntu.com/openstack">
-              <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/0694ab7a-openstack_lrg.svg" alt="OpenStack logo">
+              <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/0694ab7a-openstack_lrg.svg" alt="OpenStack">
             </a>
           </div>
           <div class="p-card__content">
@@ -152,16 +126,29 @@
           </div>
         </div>
       </div>
-      <div class="col-6 u-equal-height" data-animation="u-animation--slide-from-bottom">
+      <div class="col-4 u-equal-height" data-animation="u-animation--slide-from-bottom">
         <div class="p-card--strip u-no-padding">
           <div class="p-strip is-shallow">
             <a href="https://ubuntu.com/kubernetes">
-              <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/32ef9123-kubernetes_lrg.svg" alt="Kubernetes logo">
+              <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/32ef9123-kubernetes_lrg.svg" alt="Kubernetes">
             </a>
           </div>
           <div class="p-card__content">
             <p>App portability for K8s on VMware, Amazon, Azure, Google, Oracle, IBM and bare metal</p>
             <p><a href="https://ubuntu.com/kubernetes">ubuntu.com/kubernetes&nbsp;&rsaquo;</a></p>
+          </div>
+        </div>
+      </div>
+      <div class="col-4 u-equal-height" data-animation="u-animation--slide-from-bottom">
+        <div class="p-card--strip u-no-padding">
+          <div class="p-strip is-shallow">
+            <a href="https://snapcraft.io">
+              <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/11776603-snapcraft_lrg.svg" alt="Snapcraft">
+            </a>
+          </div>
+          <div class="p-card__content">
+            <p>The app store with secure packages and ultra-reliable updates for multiple Linus distros</p>
+            <p><a href="https://snapcraft.io">snapcraft.io&nbsp;&rsaquo;</a></p>
           </div>
         </div>
       </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -9,8 +9,8 @@
   <div class="p-strip--suru-large is-dark u-no-padding--top is-parallax">
     <div class="row u-vertically-center" style="height: 100vh;">
       <div class="col-6 p-heading-highlight--left u-animation--slide-from-top">
-        <h1 class="p-heading-highlight--left__item " style="margin-bottom: 0.5rem;">Deliver, maintain,<br />secure and sustain</h1>
-        <h2>open source from cloud to desktop and devices</h2>
+        <h1 class="p-heading-highlight--left__item " style="margin-bottom: 0.5rem;">Deliver, maintain,<br class="u-hide--medium u-hide--small" />secure and sustain</h1>
+        <h2>open source from cloud to desktop and devices.</h2>
       </div>
       <div class="col-4 col-start-large-8 u-hide--small u-animation--slide-from-bottom">
         <img src="https://assets.ubuntu.com/v1/670abb00-header_illustration.svg" alt="Canonical products logo" width="100%">
@@ -39,7 +39,7 @@
             </a>
           </div>
           <div class="p-card__content">
-            <p>The fastest growing secure enterprise Linux for servers, desktops, cloud, developers and things</p>
+            <p>The new standard secure enterprise Linux for servers, desktops, cloud, developers and things</p>
             <p><a href="https://ubuntu.com">ubuntu.com&nbsp;&rsaquo;</a></p>
           </div>
         </div>
@@ -322,7 +322,7 @@
         <div class="p-heading-highlight--bottom">
           <h3 class="p-heading-highlight--bottom__item">Truly distributed</h3>
         </div>
-        <p>Exceptional, self-motivated, organised and passionate people deserve the freedom to live where they want. Our teams travel regularly to meet colleaques and customers.</p>
+        <p>Exceptional, self-motivated, organised and passionate people deserve the freedom to live where they want. Our teams travel regularly to meet colleagues and customers.</p>
         <blockquote class="p-pull-quote">
           <p class="p-pull-quote__quote">I have seen incredible places &ndash; an unexpected benefit of life at Canonical</p>
         </blockquote>
@@ -332,7 +332,7 @@
         <div class="p-heading-highlight--bottom">
           <h3 class="p-heading-highlight--bottom__item">Best in class</h3>
         </div>
-        <p>We rate top for Linux security. We run more hosts, and more workloads, and more devices than anybody else, because we strive to do everything insightfully, properly, fairly, and openly.</p>
+        <p>We rate top for Linux security. We run more hosts, more workloads and more devices than anybody else, because we strive to do everything insightfully, properly, fairly, and openly.</p>
         <blockquote class="p-pull-quote">
           <p class="p-pull-quote__quote">These are exciting challenges and we measure ourselves against the world leaders. It’s tough, but satisfying</p>
         </blockquote>

--- a/templates/partial/_careers-job-list.html
+++ b/templates/partial/_careers-job-list.html
@@ -20,7 +20,7 @@
     <input type="checkbox" name="roles" id="{{ job.id }}" value="{{ job.id }}" />
     <label class="p-checkbox-label--h2 u-no-padding--top" for="{{ job.id }}">
     {% endif %}
-      <h2 class="{% if checkbox %}u-sv3{% else %}u-no-padding--top u-sv1{% endif %}">
+      <h2 class="p-heading--three {% if checkbox %}u-sv3{% else %}u-no-padding--top u-sv1{% endif %}">
         <a class="p-link--soft" href="/careers/{{ job.id }}">{{ job.title }}&nbsp;&rsaquo;</a>
       </h2>
     {% if checkbox %}

--- a/templates/partial/_footer.html
+++ b/templates/partial/_footer.html
@@ -4,11 +4,12 @@
     </div>
     <div class="row">
       <div class="col-8">
-        <p>&copy; {{ current_year }} Canonical Ltd.<br />
-          <a href="/contact-us" class="p-footer__link">Contact information</a> |
-          <a href="https://ubuntu.com/legal" class="p-footer__link">Legal information</a> |
-          <a href="https://github.com/canonical-web-and-design/canonical.com/issues/new" class="p-footer__link">Improve this site</a>
-        </p>
+        <p>&copy; {{ current_year }} Canonical Ltd.</p>
+        <ul class="p-inline-list--middot">
+          <li class="p-inline-list__item"><a href="/contact-us" class="p-footer__link">Contact information</a></li>
+          <li class="p-inline-list__item"><a href="https://ubuntu.com/legal" class="p-footer__link">Legal information</a></li>
+          <li class="p-inline-list__item"><a href="https://github.com/canonical-web-and-design/canonical.com/issues/new" class="p-footer__link">Improve this site</a></li>
+        </ul>
       </div>
       <div class="col-4 u-align--right">
         <ul class="p-inline-list">


### PR DESCRIPTION
## Done

- Addressed the points raised [here](https://github.com/canonical-web-and-design/canonical.com/issues/147):
  - Numerous grammar corrections
  - Replaced pipes with middots in footer link list
  - Removed 'Support' item from product table, as it isn't a standalone item in the [copy doc](https://docs.google.com/document/d/16ltouT0Yo-2RccGiE_irzrCloYaEleqFyU34fmT9OiQ/edit#)
  - Updated heading sizes on /careers/results and other job listings to be h3, rather than h2
  - Removed ellipsis from career department descriptions on /careers

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that each of the points raised in the issue have been addressed


## Issue / Card

Fixes #147 