### PR TITLE
Fix tech ops available job view

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -42,6 +42,7 @@ career_departments = [
     "project-management",
     "sales",
     "tech-ops",
+    "---",
 ]
 
 


### PR DESCRIPTION
## Done
Fix the routing for tech ops

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/careers/tech-ops#available-roles
- Check it loads job roles
- Check a few other departments all work too