### PR TITLE
A better fix for techops roles

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -29,22 +29,6 @@ app = FlaskBase(
     template_500="500.html",
 )
 
-career_departments = [
-    "admin",
-    "all",
-    "commercial-ops",
-    "design",
-    "engineering",
-    "finance",
-    "hr",
-    "legal",
-    "marketing",
-    "project-management",
-    "sales",
-    "tech-ops",
-    "---",
-]
-
 
 @app.route("/")
 def index():
@@ -78,11 +62,20 @@ def results():
     return flask.render_template("careers/results.html", **context)
 
 
-@app.route(
-    "/careers/<any('({})'):department>".format(str(career_departments)[1:-1]),
-    methods=["GET", "POST"],
-)
-def department_group(department):
+@app.route("/careers/admin", methods=["GET", "POST"])
+@app.route("/careers/all", methods=["GET", "POST"])
+@app.route("/careers/commercial-ops", methods=["GET", "POST"])
+@app.route("/careers/design", methods=["GET", "POST"])
+@app.route("/careers/engineering", methods=["GET", "POST"])
+@app.route("/careers/finance", methods=["GET", "POST"])
+@app.route("/careers/hr", methods=["GET", "POST"])
+@app.route("/careers/legal", methods=["GET", "POST"])
+@app.route("/careers/marketing", methods=["GET", "POST"])
+@app.route("/careers/project-management", methods=["GET", "POST"])
+@app.route("/careers/sales", methods=["GET", "POST"])
+@app.route("/careers/tech-ops", methods=["GET", "POST"])
+def department_group():
+    department = flask.request.path.split("/")[2]
     vacancies = get_vacancies(department)
 
     if flask.request.method == "POST":


### PR DESCRIPTION
This is an alternate fix for #154 - that roles weren't loading properly for the tech-ops page.

The reason this was happening was because the complex route definition for the `department_group` view wasn't matching `tech-ops` or `admin`, and so instead of using this view they were falling back to the default `TemplateFinder` view (and therefore didn't contain the context they needed).

I think it's simpler to declare these routes explicitly so it's harder to make mistakes.

We could further avoid confusion by moving the templates for these pages, e.g. into `careers/groups`. This way, if you fail to hit the correct view you'd get a 404, rather than what looks at first glance like success.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/careers/tech-ops#available-roles
- Check it loads job roles
- Check a few other departments all work too