### PR TITLE
Add social metadata to base + careers/start page

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -10,6 +10,33 @@
     <meta name="copydoc" content="{% block meta_copydoc %}https://drive.google.com/drive/folders/0B8feV0jqaac3TmExU3NDcHhFTGc{% endblock %}">
     <meta name="author" content="Canonical Ltd" />
 
+    <meta name="theme-color" content="#E95420">
+    <meta name="twitter:account_id" content="169015850">
+    <meta name="twitter:site" content="@canonical">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="{{ request.url }}">
+    <meta property="og:site_name" content="Canonical">
+
+    <title>Canonical | {% block title %}The company behind Ubuntu{% endblock %}</title>
+    {% if self.title() %}
+    <meta name="twitter:title" content="{{ self.title() }} | Canonical">
+    <meta property="og:title" content="{{ self.title() }} | Canonical">
+    {% endif %}
+    {% if self.meta_description() %}
+    <meta name="twitter:description" content="{{ self.meta_description() }}">
+    <meta property="og:description" content="{{ self.meta_description() }}">
+    {% endif %}
+
+    {# Define the required meta_image block #}
+    <!-- Meta image: {% block meta_image %}{% endblock %} -->
+    {% if self.meta_image() %}
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:image" content="{% if 'http' not in self.meta_image() %}https://assets.ubuntu.com/v1/{% endif %}{{ self.meta_image() }}">
+    <meta property="og:image" content="{% if 'http' not in self.meta_image() %}https://assets.ubuntu.com/v1/{% endif %}{{ self.meta_image() }}">
+    {% endif %}
+
+
+
     <link rel="shortcut icon" href="https://assets.ubuntu.com/v1/0843d517-favicon.ico" type="image/x-icon" />
     <link rel="apple-touch-icon-precomposed" sizes="144x144"
       href="https://assets.ubuntu.com/v1/9864667f-apple-touch-icon-144x144-precomposed.png">
@@ -19,8 +46,6 @@
       href="https://assets.ubuntu.com/v1/f193fb82-apple-touch-icon-72x72-precomposed.png">
     <link rel="apple-touch-icon-precomposed"
       href="https://assets.ubuntu.com/v1/205d458b-apple-touch-icon-precomposed.png">
-
-    <title>Canonical | The company behind Ubuntu</title>
 
     <link rel="preconnect" href="https://assets.ubuntu.com">
 
@@ -34,7 +59,7 @@
       crossorigin>
 
     <script src="/static/js/navigation.js" defer></script>
-    
+
     <link rel="stylesheet" type="text/css" media="screen" href="/static/css/styles.css" />
   </head>
 

--- a/templates/careers/start.html
+++ b/templates/careers/start.html
@@ -1,5 +1,9 @@
 {% extends 'base_index.html' %}
 
+{% block title %}What kind of excellent are you? Find your perfect career.{% endblock %}
+{% block meta_description %}Pick five of your strengths and ambitions and we will find the best Canonical careers for you.{% endblock %}
+{% block meta_image %}https://assets.ubuntu.com/v1/531968f9-canonical-careers-start-social.png{% endblock %}
+
 {% block content %}
   <section class="p-strip--suru-background is-shallow">
     <div class="row">
@@ -19,7 +23,7 @@
   <style>
     .p-strip--suru-background {
       background-image:
-   
+
         linear-gradient(140deg, #E95420 0%, #772953 33%, #2C001E 72%);
       background-size: cover;
       color: #fff;

--- a/templates/partners/become-a-partner.html
+++ b/templates/partners/become-a-partner.html
@@ -1,5 +1,8 @@
 {% extends 'base_index.html' %}
 
+{% block title %}Become a partner{% endblock %}
+{% block meta_description %}We run a range of partner programmes to help you maximise revenue and efficiency from the opportunities Ubuntu provides.{% endblock %}
+
 {% block content %}
 <section class="p-strip--image is-dark">
   <div class="p-strip--suru-top">


### PR DESCRIPTION
## Done

- Added the social meta data to the base_index.
- Added a social image, title, desc to the careers/start page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/careers/start
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the page's social data works on twitter, etc...

Fixed #151 