### PR TITLE
Add missing row of departments to /careers

### DIFF
--- a/templates/careers/index.html
+++ b/templates/careers/index.html
@@ -40,6 +40,27 @@
         <a href="/careers/tech-ops">More&nbsp;&rsaquo;</a>
       </div>
     </div>
+
+
+    <div class="row u-equal-height">
+      <div class="col-4 p-card--strip-thin">
+        <h4 class="p-card--strip-thin__title">Finance</h4>
+        <p class="p-card--strip-thin__content">Finance at Canonical isn’t just about numbers. It’s about connecting with people across the business, helping them to understand the value they bring, as well as promoting the commercial focus that will grow our brand.</p>
+        <a href="/careers/finance">More&nbsp;&rsaquo;</a>
+      </div>
+      <div class="col-4 p-card--strip-thin">
+        <h4 class="p-card--strip-thin__title">Web &amp; design</h4>
+        <p class="p-card--strip-thin__content">The design team at Canonical crafts and builds the user-experience for sophisticated technical specialists across a wide range of industries and geographies. We design and build websites, complex web apps and support Ubuntu itself.</p>
+        <a href="/careers/design">More&nbsp;&rsaquo;</a>
+      </div>
+      <div class="col-4 p-card--strip-thin">
+        <h4 class="p-card--strip-thin__title">Marketing</h4>
+        <p class="p-card--strip-thin__content">We deliver the right technology message to a highly competent audience, at exactly the right moment. Success depends on having good instincts for tech trends and topics and a natural inclination to leadership.</p>
+        <a href="/careers/marketing">More&nbsp;&rsaquo;</a>
+      </div>
+    </div>
+
+
     <div class="row u-equal-height">
       <div class="col-4 p-card--strip-thin">
         <h4 class="p-card--strip-thin__title">Project Management</h4>


### PR DESCRIPTION
## Done

- Add missing row of departments to /careers

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/careers
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to the [copy doc](https://docs.google.com/document/d/1pNyOXfR07FiBr6TmEMRdB7NZUB5SeBz6COuSxO3ylC0/edit?ts=5e217d85#)


## Issue / Card

Fixes #159 

## Screenshots

![image](https://user-images.githubusercontent.com/441217/72602277-eacf4900-390e-11ea-9a7f-01e81a501d6d.png)
