### PR TITLE
Add missing meta data to pages

### DIFF
--- a/templates/404.html
+++ b/templates/404.html
@@ -1,5 +1,9 @@
 {% extends 'base_index.html' %}
 
+{% block title %}404: Page not found{% endblock %}
+
+{% block meta_description %}Sorry, we can't find the page you're looking for.{% endblock %}
+
 {% block content %}
 <div class="p-strip is-deep u-extra-space">
   <div class="row">

--- a/templates/500.html
+++ b/templates/500.html
@@ -1,5 +1,9 @@
 {% extends 'base_index.html' %}
 
+{% block title %}500: Server error{% endblock %}
+
+{% block meta_description %}Something&rsquo;s gone wrong.{% endblock %}
+
 {% block content %}
 <div class="p-strip is-deep u-extra-space">
   <div class="row">

--- a/templates/careers/admin.html
+++ b/templates/careers/admin.html
@@ -1,6 +1,10 @@
 {% extends '/careers/base-tabs.html' %}
 
+{% block meta_copydoc %}https://docs.google.com/document/d/1LRQrvgLlNnaBsW1RD7WLlNLZbn6-zj0EUtXr2jtMh3M/edit{% endblock %}
+
 {% block title %}Admin{% endblock %}
+
+{% block meta_description %}Canonical is a global distributed company with many offices and hundreds of remote workers.  This means the admin team a complex and rewarding role to help the company work effectively as possible.{% endblock %}
 
 {% block overview %}
   <p>

--- a/templates/careers/all.html
+++ b/templates/careers/all.html
@@ -1,8 +1,10 @@
 {% extends '/careers/base.html' %}
 
-{% block meta_description %}Canonical publishes Ubuntu, provides commercial services and solutions for Ubuntu, and works with hardware manufacturers, software vendors and public.{% endblock %}
-
 {% block meta_copydoc %}https://docs.google.com/document/d/1adoe3jR-_O3EC4LECotKiPo2SsC_Ht5YPTR0wr-BhH0{% endblock meta_copydoc %}
+
+{% block title %}All job roles{% endblock %}
+
+{% block meta_description %}Canonical publishes Ubuntu, provides commercial services and solutions for Ubuntu, and works with hardware manufacturers, software vendors and public.{% endblock %}
 
 {% block hero %}
   <section class="p-strip--image is-dark is-deep u-no-padding--top u-no-padding--bottom u-extra-space">

--- a/templates/careers/apply.html
+++ b/templates/careers/apply.html
@@ -1,5 +1,9 @@
 {% extends '/careers/base.html' %}
 
+{% block title %}Apply now{% endblock %}
+
+{% block meta_description %}Apply for a role at Canonical.{% endblock %}
+
 {% block hero %}
 <section class="p-strip--image is-dark is-deep u-no-padding--top u-no-padding--bottom u-extra-space">
   <div class="p-strip--suru-background">

--- a/templates/careers/commercial-ops.html
+++ b/templates/careers/commercial-ops.html
@@ -1,6 +1,11 @@
 {% extends '/careers/base-tabs.html' %}
 
+{% block meta_copydoc %}https://docs.google.com/document/d/1y2bqWcHW2rRrb5gA7XTt8_A0q6zPOLkkOIwCIaNLpTk/edit
+{% endblock %}
+
 {% block title %}Operations{% endblock %}
+
+{% block meta_description %}Excellence in operations enables Canonical to scale efficiently. We look for people who are passionate about tools and efficiency.{% endblock %}
 
 {% block overview %}
   <p>
@@ -10,9 +15,9 @@
   </p>
 
   <p>Getting it done right is the best feeling in the world. No shortcuts, no loose ends, no waste. It&rsquo;s only possible to operate with mastery if you understand the domain deeply, you prioritise re-use and iteration, and you bring a sharp mind to the problem. A well-run operation invests in improving its data and its tools to elevate its self-awareness and automate its processes. Fighting fires is the exception, not the norm, and those moments are an opportunity to learn and improve.</p>
-  
+
   <p>Whether it&rsquo;s running complex technical infrastructure or challenging projects, your consistent focus on data, your willingness to learn, and your personal organisation and teamwork means you&rsquo;re a force for good in the battle against entropy. Time zones are easy and technical customers are your favourite. If that&rsquo;s you - then there&rsquo;s room for you at Canonical. We don&rsquo;t just run a great business, we run the infrastructure and applications that power many great businesses.</p>
-    
+
   <hr />
   <p class="p-muted-heading">
     <span style="text-transform: capitalize">Europe&nbsp;&#124;&nbsp;Middle East&nbsp;&#124;&nbsp;Africa&nbsp;&#124;&nbsp;Americas&nbsp;&#124;&nbsp;APAC</span>

--- a/templates/careers/design.html
+++ b/templates/careers/design.html
@@ -1,10 +1,11 @@
 {% extends '/careers/base-tabs.html' %}
 
-{% block meta_description %}Canonical publishes Ubuntu and provides commercial services and solutions for Ubuntu. The design team works on web applications for enterprise, cloud services and operating system for IoT and embedded devices focusing on current design thinking, technology and innovation.{% endblock %}
-
 {% block meta_copydoc %}https://docs.google.com/document/d/1V8SzuqyJEqXAXf_FrobdNn5-OLzTvKWcRlfBXjI9oBo{% endblock meta_copydoc %}
 
 {% block title %}Web & design{% endblock %}
+
+{% block meta_description %}The design team at Canonical crafts and builds the user-experience for sophisticated technical specialists across a wide range of industries and geographies.{% endblock %}
+
 
 {% block overview %}
   <p><strong>Canonical and Ubuntu are central to modern tech &ndash; from cloud to the internet of things, from the web to mobile back-ends, from development to production.</strong>
@@ -30,4 +31,3 @@
   </p>
   <a href="#available-roles">Apply now&nbsp;&rsaquo;</a>
 {% endblock %}
-

--- a/templates/careers/diversity.html
+++ b/templates/careers/diversity.html
@@ -1,8 +1,10 @@
 {% extends '/careers/base.html' %}
 
-{% block meta_description %}Canonical proactively promotes leaders who represent new kinds of diversity, to grow the confidence of colleagues from every walk of life. We seek to create an environment that is welcoming to outstanding technology and business professionals committed to teamwork and open source.{% endblock %}
-
 {% block meta_copydoc %}https://docs.google.com/document/d/1L8z8Np75JN2wJa72iVrv-eRFzGiqiGW4HZiD8muPOAQ{% endblock meta_copydoc %}
+
+{% block title %}Diversity{% endblock %}
+
+{% block meta_description %}Canonical proactively promotes leaders who represent new kinds of diversity, to grow the confidence of colleagues from every walk of life. We seek to create an environment that is welcoming to outstanding technology and business professionals committed to teamwork and open source.{% endblock %}
 
 {% block hero %}
   <section class="p-strip--image is-dark is-deep u-no-padding--top u-no-padding--bottom u-extra-space">
@@ -21,7 +23,7 @@
     <strong>We believe that talent is evenly distributed around the world. No matter where you were born, or what you look like, or how you like to dress, we think you might have the brilliance and the work ethic and the passion for open source that would make you a Canonical candidate.</strong>
   </p>
   <p>
-    The diversity in our company is part of our strength. What unifies us isn’t our background or our culture, it’s our vision of the future and our dedication to delivering the best of the future for our customers and our colleagues. We are unified in our pursuit of company and personal excellence in our chosen fields, we are unified in our commitment to teamwork, and we have a common vision of open source as the platform that best empowers innovators in a modern digital society. 
+    The diversity in our company is part of our strength. What unifies us isn’t our background or our culture, it’s our vision of the future and our dedication to delivering the best of the future for our customers and our colleagues. We are unified in our pursuit of company and personal excellence in our chosen fields, we are unified in our commitment to teamwork, and we have a common vision of open source as the platform that best empowers innovators in a modern digital society.
   </p>
   <p>
     We believe in affirmative action, because we know it builds confidence in new team members when they can relate to people with similar backgrounds in their workplace. But we also expect people to look beyond the obvious and relate to intrinsic motivation and quality of work, not superficial qualities.

--- a/templates/careers/engineering.html
+++ b/templates/careers/engineering.html
@@ -4,6 +4,8 @@
 
 {% block title %}Engineering{% endblock %}
 
+{% block meta_description %}Open source is transforming the entire stack. This is your chance to be right at the center of that revolution, to shape the platforms and tools that millions use to invent our global technology future.{% endblock %}
+
 {% block overview %}
   <p>
     <strong>Open source is transforming the entire stack. This is your chance to be right at the center of that revolution, to shape the platforms and tools that millions use to invent our global technology future. From bare metal to cloud to high performance computing, from AI and big data to the web and connected devices, open source is the key ingredient for success. Canonical offers the opportunity to work across the entire spectrum.</strong>

--- a/templates/careers/ethics.html
+++ b/templates/careers/ethics.html
@@ -1,8 +1,12 @@
 {% extends '/careers/base.html' %}
 
+{% block meta_copydoc %}https://docs.google.com/document/d/1K2pY9lFlKvdL3jZ6Ih5sgritIP23z_KQS3DVMlZxbqw{% endblock meta_copydoc %}
+
+{% block title %}Trust{% endblock %}
+
 {% block meta_description %}Trust in Canonical’s Ubuntu and other products is well-earned and critical to our future. We have a very high expectation of ethical behaviour at the company and in particular among leaders of any sort.{% endblock %}
 
-{% block meta_copydoc %}https://docs.google.com/document/d/1K2pY9lFlKvdL3jZ6Ih5sgritIP23z_KQS3DVMlZxbqw{% endblock meta_copydoc %}
+
 
 {% block hero %}
   <section class="p-strip--image is-dark is-deep u-no-padding--top u-no-padding--bottom u-extra-space">

--- a/templates/careers/finance.html
+++ b/templates/careers/finance.html
@@ -4,6 +4,9 @@
 
 {% block title %}Finance{% endblock %}
 
+{% block meta_description %}Finance at Canonical isn’t just about numbers. It’s about connecting with people across the business, helping them to understand the value they bring, as well as promoting the commercial focus that will grow our brand.{% endblock %}
+
+
 {% block overview %}
   <p><strong>Finance at Canonical isn’t just about numbers. It’s about connecting with people across the business, helping them to understand the value they bring, as well as promoting the commercial focus that will grow our brand.</strong></p>
   <p>

--- a/templates/careers/hr.html
+++ b/templates/careers/hr.html
@@ -4,6 +4,10 @@
 
 {% block title %}Human Resources{% endblock %}
 
+
+{% block meta_description %}Canonical provides a unique window into the world of 21st-century digital business. We work with smart individuals from a wide range of professional backgrounds in more than 40 countries worldwide, bringing together.{% endblock %}
+
+
 {% block overview %}
   <p><strong>Canonical provides a unique window into the world of 21st-century digital business. We work with smart individuals from a wide range of professional backgrounds in more than 40 countries worldwide, bringing together distinct and diverse perspectives to contribute to the advancement of state-of-the-art technical infrastructure. Our team is united by a passion for open engineering and a commitment to crisp, reliable execution which enables us to exceed our customers’ expectations when it comes to next-generation open source technology.</strong>
   </p>

--- a/templates/careers/index.html
+++ b/templates/careers/index.html
@@ -2,6 +2,8 @@
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1pNyOXfR07FiBr6TmEMRdB7NZUB5SeBz6COuSxO3ylC0{% endblock meta_copydoc %}
 
+{% block title %}Careers{% endblock %}
+
 {% block meta_description %}Canonical publishes Ubuntu, provides commercial services and solutions for Ubuntu, and works with hardware manufacturers, software vendors and public clouds to certify Ubuntu.{% endblock %}
 
 {% block content %}

--- a/templates/careers/job-detail.html
+++ b/templates/careers/job-detail.html
@@ -1,5 +1,7 @@
 {% extends '/careers/base.html' %}
 
+{% block title %}Job details{% endblock %}
+
 {% block meta_description %}Canonical offers a truly distributed workplace for exceptional colleagues who are self-motivated, organised. Maintain a home office and experience the top of global technology strategy and engineering. Travel regularly to interesting destinations for team, conference and customer engagements.{% endblock %}
 
 {% block hero %}

--- a/templates/careers/legal.html
+++ b/templates/careers/legal.html
@@ -4,6 +4,9 @@
 
 {% block title %}Legal{% endblock %}
 
+{% block meta_description %}Canonical works at the forefront of global digital trends and the legal, licensing and regulatory frameworks that support them. We are a tight-knit team of professionals that enjoy playing a part in the rapid change.{% endblock %}
+
+
 {% block overview %}
   <p><strong>Canonical works at the forefront of global digital trends and the legal, licensing and regulatory frameworks that support them. We are a tight-knit team of professionals that enjoy playing a part in the rapid change of the software landscape to open infrastructure and applications, while supporting a fast-moving and global business.</strong>
   </p>

--- a/templates/careers/lifestyle.html
+++ b/templates/careers/lifestyle.html
@@ -1,8 +1,10 @@
 {% extends '/careers/base.html' %}
 
-{% block meta_description %}Canonical offers a truly distributed workplace for exceptional colleagues who are self-motivated, organised. Maintain a home office and experience the top of global technology strategy and engineering. Travel regularly to interesting destinations for team, conference and customer engagements.{% endblock %}
-
 {% block meta_copydoc %}https://docs.google.com/document/d/15Ofb6vRUXbQ3evcWmrOu9ymuY37ayg4M_xZ2QXQyIts{% endblock meta_copydoc %}
+
+{% block title %}Lifestyle{% endblock %}
+
+{% block meta_description %}Canonical offers a truly distributed workplace for exceptional colleagues who are self-motivated, organised. Maintain a home office and experience the top of global technology strategy and engineering. Travel regularly to interesting destinations for team, conference and customer engagements.{% endblock %}
 
 {% block hero %}
   <section class="p-strip--image is-dark is-deep u-no-padding--top u-no-padding--bottom u-extra-space">

--- a/templates/careers/marketing.html
+++ b/templates/careers/marketing.html
@@ -4,6 +4,9 @@
 
 {% block title %}Marketing{% endblock %}
 
+{% block meta_description %}We deliver the right technology message to a highly competent audience, at exactly the right moment. Success depends on having good instincts for tech trends and topics and a natural inclination to leadership.{% endblock %}
+
+
 {% block overview %}
   <p>
     <strong>We deliver the right technology message to a highly competent audience, at exactly the right moment. Success depends on having good instincts for tech trends and topics and a natural inclination to leadership.</strong>

--- a/templates/careers/progression.html
+++ b/templates/careers/progression.html
@@ -1,8 +1,10 @@
 {% extends '/careers/base.html' %}
 
-{% block meta_description %}Canonical prefers internal promotion and encourages high-performing colleagues to pursue diverse roles at the company over the course of their career, to develop a well-rounded perspective.{% endblock %}
-
 {% block meta_copydoc %}https://docs.google.com/document/d/13lzdbhQ2mmNPuwBdajOubNyRxXAXTt5lRq0iUk5HfuQ{% endblock meta_copydoc %}
+
+{% block title %}Progression{% endblock %}
+
+{% block meta_description %}Canonical prefers internal promotion and encourages high-performing colleagues to pursue diverse roles at the company over the course of their career, to develop a well-rounded perspective.{% endblock %}
 
 {% block hero %}
   <section class="p-strip--image is-dark is-deep u-no-padding--top u-no-padding--bottom u-extra-space">

--- a/templates/careers/project-management.html
+++ b/templates/careers/project-management.html
@@ -1,15 +1,16 @@
 {% extends '/careers/base-tabs.html' %}
 
+{% block title %}Project Management{% endblock %}
+
 {% block meta_description %}Canonical’s Engagement Project Management Office team owns, drives and communicates delivery excellence by providing strong Project process guidelines,  project continuity and data analytics.{% endblock %}
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1IMXbRXvmvSKe_SrKvEiQIRCwz3I9BfVcQRQuHODaG8s{% endblock meta_copydoc %}
 
-{% block title %}Project Management{% endblock %}
 
 {% block overview %}
   <p><strong>Project Managers at Canonical are engaged during all phases of the project, from pre-sales support to delivery to the handoff of complete projects to support or managed services.</strong></p>
   <p>
-    Project managers create, manage and maintain project-specific schedules ensuring projects are delivered within time, resource and scope expectations. Each project manager is responsible for multiple projects simultaneously. Managing each project through its life-cycle and ensuring that the goals for both Canonical and the client are met.  
+    Project managers create, manage and maintain project-specific schedules ensuring projects are delivered within time, resource and scope expectations. Each project manager is responsible for multiple projects simultaneously. Managing each project through its life-cycle and ensuring that the goals for both Canonical and the client are met.
   </p>
   <p>
     One advanced role is the Technical Program Manager, who provides technical account leadership and insight as the primary technical interface for our key enterprise accounts. The Technical Program Manager is a high-profile technical engagement program management position where customer relationship management and advocacy for Canonical's technical assets are strategically crucial.

--- a/templates/careers/results.html
+++ b/templates/careers/results.html
@@ -1,5 +1,7 @@
 {% extends '/careers/base.html' %}
 
+{% block title %}Jobs{% endblock %}
+
 {% block meta_description %}Canonical offers a truly distributed workplace for exceptional colleagues who are
 self-motivated, organised. Maintain a home office and experience the top of global technology strategy and engineering.
 Travel regularly to interesting destinations for team, conference and customer engagements.{% endblock %}
@@ -39,7 +41,7 @@ Travel regularly to interesting destinations for team, conference and customer e
           <i class="p-icon--success" style="height: 1.5rem; width: 1.5rem;"></i>
         </div>
         <div style="padding-left: 1rem;">
-          <p class="p-heading--three">Looks like you're interested in 
+          <p class="p-heading--three">Looks like you're interested in
             {% if departments|length == 1 %}
               {{ departments[0]|lower }}
             {% else %}

--- a/templates/careers/sales.html
+++ b/templates/careers/sales.html
@@ -1,10 +1,10 @@
 {% extends '/careers/base-tabs.html' %}
 
-{% block meta_description %}Canonical is looking for Sales Professionals that are Trusted Advisors which bring confidence to our customers that we understand their transformation to multi-cloud, and we can bring the right solutions to the table in order to solve those problems.{% endblock %}
-
 {% block meta_copydoc %}https://docs.google.com/document/d/1fGBFiIfy7C58UXcJ0Q7q6VKxClxBfPyeWBSyO9GrStI{% endblock meta_copydoc %}
 
 {% block title %}Sales{% endblock %}
+
+{% block meta_description %}Canonical is looking for Sales Professionals that are Trusted Advisors which bring confidence to our customers that we understand their transformation to multi-cloud, and we can bring the right solutions to the table in order to solve those problems.{% endblock %}
 
 {% block overview %}
   <p>

--- a/templates/careers/start.html
+++ b/templates/careers/start.html
@@ -1,5 +1,11 @@
 {% extends 'base_index.html' %}
 
+{% block meta_copydoc %}https://docs.google.com/document/d/1JEJaOghggrocxnRCoTrJMCg_z_xD9n6xBSnovcX3HMg/edit{% endblock %}
+
+{% block title %}Find your perfect career{% endblock %}
+
+{% block meta_description %}What kind of excellent are you? Choose 5 that best describe your strengths and ambition.{% endblock %}
+
 {% block content %}
   <section class="p-strip--suru-background is-shallow">
     <div class="row">
@@ -19,7 +25,7 @@
   <style>
     .p-strip--suru-background {
       background-image:
-   
+
         linear-gradient(140deg, #E95420 0%, #772953 33%, #2C001E 72%);
       background-size: cover;
       color: #fff;

--- a/templates/careers/tech-ops.html
+++ b/templates/careers/tech-ops.html
@@ -4,6 +4,8 @@
 
 {% block title %}TechOps{% endblock %}
 
+{% block meta_description %}Getting it done right is the best feeling in the world. Whether it’s running complex technical infrastructure or challenging projects, your consistent focus on data, organisation and teamwork means you’re a force for good in the battle against entropy.{% endblock %}
+
 {% block overview %}
   <p><strong>TechOps, or Technical Services and Operations role ranges from IT and managed services to developing commercial systems used by our company. We develop, test, ship and operate the systems that drive Canonical and underpin Ubuntu. We believe in a strong customer service ethic and operations through code. The robots we are constructing to run the data centre need to be backed by humans that care about the needs of our users and customers.</strong></p>
   <p>In TechOps, you will enjoy the excitement of a team environment that is fun, diverse, distributed globally and incredibly competent. Every day, we work to enable our customers to work on some of the most challenging problems in the world.</p>

--- a/templates/careers/travel.html
+++ b/templates/careers/travel.html
@@ -1,8 +1,10 @@
 {% extends '/careers/base.html' %}
 
-{% block meta_description %}Travel is central to Canonical’s global, distributed workplace. All teams participate in regular team and cross-team events. We spread locations across time zones and look for interesting and diverse cultural places. Many employees return to these destinations with friends and family.{% endblock %}
-
 {% block meta_copydoc %}https://docs.google.com/document/d/1H2ILhAUckOWyah_6V69ImwLWOSRlXkaYnIhOHkUjclc{% endblock meta_copydoc %}
+
+{% block title %}Travel{% endblock %}
+
+{% block meta_description %}Travel is central to Canonical’s global, distributed workplace. All teams participate in regular team and cross-team events. We spread locations across time zones and look for interesting and diverse cultural places. Many employees return to these destinations with friends and family.{% endblock %}
 
 {% block hero %}
   <section class="p-strip--image is-dark u-extra-space">

--- a/templates/contact-us.html
+++ b/templates/contact-us.html
@@ -1,5 +1,11 @@
 {% extends 'base_index.html' %}
 
+{% block meta_copydoc %}https://docs.google.com/document/d/1Qxvhl6_kgCDarcem1wcFPQyHk0JEFUP1zIzNsIrT3_Y/edit#heading=h.2cifs8ay7uv0{% endblock %}
+
+{% block title %}Contact us{% endblock %}
+
+{% block meta_description %}Contact information for Canonical, the publisher of Ubuntu.{% endblock %}
+
 {% block content %}
   <section class="p-strip--image is-dark is-deep u-no-padding--top u-no-padding--bottom u-extra-space">
     <div class="p-strip--suru-image">
@@ -45,11 +51,11 @@
         <p class="u-sv1">Publishing or distributing Ubuntu in any form other than our standard install media and packages requires permission. To license the Ubuntu trademark or any other rights, please <a href="https://www.ubuntu.com/legal/terms-and-policies/contact-us">submit an enquiry</a>.</p>
 
         <h2 class="p-heading--three">Press and analyst enquiries</h2>
-        
+
         <p class="u-sv1">Please contact <a href="mailto:pr@canonical.com">pr@canonical.com</a>.</p>
-        
+
         <h2 class="p-heading--three">Data Privacy enquiries</h2>
-        
+
         <p class="u-sv1">For information about data privacy, please read our <a href="https://www.ubuntu.com/legal/data-privacy">Privacy Policy</a> or <a href="https://ubuntu.com/legal/data-privacy/enquiry">submit an enquiry</a>. A member of our data privacy team will be in touch with you shortly.</p>
 
         <h2 class="p-heading--three">Legal enquiries</h2>


### PR DESCRIPTION
## Done

- Added missing meta data to all pages
- Updated all copy docs

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Click through and see that all pages have been updated.  It will be more visible once #158 is live

