### PR TITLE
Fix typo

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -147,7 +147,7 @@
             </a>
           </div>
           <div class="p-card__content">
-            <p>The app store with secure packages and ultra-reliable updates for multiple Linus distros</p>
+            <p>The app store with secure packages and ultra-reliable updates for multiple Linux distros</p>
             <p><a href="https://snapcraft.io">snapcraft.io&nbsp;&rsaquo;</a></p>
           </div>
         </div>


### PR DESCRIPTION
Calling them Linus distros would do, but likely Linux distros is what we are after.