### PR TITLE
Add check for job id

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -110,6 +110,8 @@ def department_group():
 @app.route("/careers/<regex('[0-9]+'):job_id>", methods=["GET", "POST"])
 def job_details(job_id):
     job = get_vacancy(job_id)
+    if not job:
+        flask.abort(404)
 
     if flask.request.method == "POST":
         response = submit_to_greenhouse(

--- a/webapp/greenhouse_api.py
+++ b/webapp/greenhouse_api.py
@@ -10,7 +10,7 @@ from html import unescape
 
 
 api_session = CachedSession(
-    fallback_cache_duration=300, file_cache_directory=".webcache", timeout=6
+    fallback_cache_duration=300, file_cache_directory=".webcache"
 )
 
 base_url = "https://boards-api.greenhouse.io/v1/boards/Canonical/jobs"

--- a/webapp/greenhouse_api.py
+++ b/webapp/greenhouse_api.py
@@ -10,7 +10,7 @@ from html import unescape
 
 
 api_session = CachedSession(
-    fallback_cache_duration=300, file_cache_directory=".webcache"
+    fallback_cache_duration=300, file_cache_directory=".webcache", timeout=6
 )
 
 base_url = "https://boards-api.greenhouse.io/v1/boards/Canonical/jobs"
@@ -86,14 +86,17 @@ def get_vacancies_by_skills(core_skills):
 
 def get_vacancy(job_id):
     feed = api_session.get(f"{base_url}/{job_id}").json()
-    job = {
-        "id": job_id,
-        "title": feed["title"],
-        "content": unescape(feed["content"]),
-        "location": feed["location"]["name"],
-        "department": feed["metadata"][2]["value"],
-    }
-    return job
+    if feed.get("status") == 404:
+        return None
+    else:
+        job = {
+            "id": job_id,
+            "title": feed["title"],
+            "content": unescape(feed["content"]),
+            "location": feed["location"]["name"],
+            "department": feed["metadata"][2]["value"],
+        }
+        return job
 
 
 # Default Job ID (1658196) is used below to submit CV without applying for a


### PR DESCRIPTION
## Done
Add check for job id and return 404 if not found

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Go to http://0.0.0.0:8002/careers/1952359 and check the job loads
- Go to http://0.0.0.0:8002/careers/195235923 and check the site 404's
- Go to https://canonical.com/careers/195235923 and see it 500's
