### PR TITLE
GA events clean-up

### DIFF
--- a/static/js/navigation.js
+++ b/static/js/navigation.js
@@ -125,11 +125,11 @@ if (!(window.location.pathname==="/")) {
     if (t) {
       t.querySelectorAll('a').forEach(function (a) {
         if (a.className.includes('p-button--positive')) {
-          var category = 'www.ubuntu.com-content-cta-0';
+          var category = 'canonical.com-content-cta-0';
         } else if (a.className.includes('p-button')) {
-          var category = 'www.ubuntu.com-content-cta-1';
+          var category = 'canonical.com-content-cta-1';
         } else {
-          var category = 'www.ubuntu.com-content-link';
+          var category = 'canonical.com-content-link';
         }
         if (!a.href.startsWith("#")) {
           a.addEventListener('click', function () {
@@ -140,26 +140,6 @@ if (!(window.location.pathname==="/")) {
               'eventLabel': a.text,
               'eventValue': undefined
             });
-          });
-        }
-      });
-    }
-  }
-
-  addGAImpressionEvents('.js-takeover')
-
-  function addGAImpressionEvents(target) {
-    var t = document.querySelectorAll(target);
-    if (t) {
-      t.forEach(function (section) {
-        if (!section.className.includes('u-hide')) {
-          var a = section.querySelector("a");
-          dataLayer.push({
-            'event': 'NonInteractiveGAEvent',
-            'eventCategory': "www.ubuntu.com-impression",
-            'eventAction': `from:${origin} to:${a.href}`,
-            'eventLabel': a.text,
-            'eventValue': undefined,
           });
         }
       });


### PR DESCRIPTION
## Done

* Renamed remaining ubuntu.com events to canonical.com
* Removed takeover impression events

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Google Analytics (combo tracker)-> realtime group -> filter "content" view on the domain serving the PR -> switch to "events" view, and navigate around the site, ensure you don't see impression or ubuntu.com event categories
