### PR TITLE
Fix missing spaces in HTML attributes

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -244,7 +244,7 @@
           <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/bd4452d1-microsoft.svg" width="144" height="30" alt="Microsoft logo">
         </li>
         <li class="p-inline-images__item">
-          <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/1008033a-arm.svg" width="112" height="34"alt="ARM logo">
+          <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/1008033a-arm.svg" width="112" height="34" alt="ARM logo">
         </li>
         <li class="p-inline-images__item">
           <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/f627fbfb-hp.svg" width="61" height="61" alt="HP logo">

--- a/templates/index.html
+++ b/templates/index.html
@@ -112,7 +112,7 @@
         </div>
       </div>
     </div>
-    <div class="row u-equal-height"style="grid-gap: 1rem;">
+    <div class="row u-equal-height" style="grid-gap: 1rem;">
       <div class="col-4 u-equal-height" data-animation="u-animation--slide-from-bottom">
         <div class="p-card--strip u-no-padding">
           <div class="p-strip is-shallow">


### PR DESCRIPTION
## Done

Simple fix to openstack grid HTML attributes

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)


## Issue / Card


## Screenshots

