### PR TITLE
Support disabling reduced motion

### DIFF
--- a/static/sass/_pattern_animations.scss
+++ b/static/sass/_pattern_animations.scss
@@ -52,4 +52,12 @@
       transform: translate(0, 0);
     }
   }
+
+  @media (prefers-reduced-motion: reduce) {
+    .u-animation--slide-from-bottom,
+    .u-animation--slide-from-right,
+    .u-animation--slide-from-top {
+      opacity: 1 !important;
+    }
+  }
 }


### PR DESCRIPTION
## Done
Override the opacity set for animations when reduced motion is set. As this stops all animations by Vanilla we need to just display the text.

## QA
- On Ubuntu 18.04 install a package called dconf Editor with `sudo apt install dconf-editor`
- Open it and go to `/org/gnome/desktop/interface/ and toggle` the “Enable-Animations” option to OFF.
- Visit https://canonical.com and see there is no text
- Go to the demo and see that there is text
- Smile with glee as you remember to turn back on Enable-Animations setting
- Close down dconf and forget it forever