### PR TITLE
Add rediect from contributors

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -1,5 +1,6 @@
 about/?: "/"
 index.html/?: "/"
+contributors/?: "https://ubuntu.com/legal/contributors"
 careers/all-vacancies/?: "/careers/all"
 partners/contact-us/?: "/partners/become-a-partner"
 projects/?: "/#products"


### PR DESCRIPTION
## Done
Added redirect from contributors ubuntu.com

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Go to /contributors and check it redirects to https://ubuntu.com/legal/contributors

## Issue / Card
Fixes https://github.com/canonical-web-and-design/canonical.com/issues/172