### PR TITLE
Add versioned_static to cache bust local assets

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -58,9 +58,9 @@
     <link rel="preload" as="font" type="font/woff2" href="https://assets.ubuntu.com/v1/fff37993-Ubuntu-R_W.woff2"
       crossorigin>
 
-    <script src="/static/js/navigation.js" defer></script>
+    <script src="{{ versioned_static('js/navigation.js') }}" defer></script>
 
-    <link rel="stylesheet" type="text/css" media="screen" href="/static/css/styles.css" />
+    <link rel="stylesheet" type="text/css" media="screen" href="{{ versioned_static('css/styles.css') }}" />
   </head>
 
   <body>


### PR DESCRIPTION
## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check the styles and navigation works as before
- Check in the source that the styles.css and navigation.js have query params to bust the cache