### PR TITLE
add missing validation and application js

### DIFF
--- a/templates/careers/job-detail.html
+++ b/templates/careers/job-detail.html
@@ -81,6 +81,6 @@
     </div>
   </div>
 
-  <script async defer src="/static/js/file-validation.js"></script>
-  <script async defer src="/static/js/apply-for-jobs.js"></script>
+  <script async defer src="{{ versioned_static('js/file-validation.js') }}"></script>
+  <script async defer src="{{ versioned_static('js/apply-for-jobs.js') }}"></script>
 {% endblock %}

--- a/templates/careers/job-detail.html
+++ b/templates/careers/job-detail.html
@@ -70,7 +70,7 @@
             <button type="button" class="js-locate-me">Locate me</button>
             <span class="js-locate-error u-hide" style="color: #c7162b">Location unavailable</span>
             <label for="resume" class="is-required">Upload CV</label>
-            <input type="file" id="resume" name="resume" accept=".pdf, .doc, .docx, .txt, .rtf">
+            <input type="file" id="resume" name="resume" required accept=".pdf, .doc, .docx, .txt, .rtf">
             <label for="cover_letter">Cover Letter</label>
             <input type="file" id="cover_letter" name="cover_letter" accept=".pdf, .doc, .docx, .txt, .rtf">
             <hr style="margin: 1rem 0;" />
@@ -80,4 +80,7 @@
       </div>
     </div>
   </div>
+
+  <script async defer src="/static/js/file-validation.js"></script>
+  <script async defer src="/static/js/apply-for-jobs.js"></script>
 {% endblock %}


### PR DESCRIPTION
## Done

Re-added job application JS that was accidentally removed during the careers section refactor.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Go to /careers/1504935:
  - Click the Locate Me button, you should see either "Location unavailable", or the Location field filled automatically.
  - Fill out the rest of the form, but leave the CV field blank, attempt to submit it. You should not be able to.


## Issue / Card

Fixes #153 & #179 