### PR TITLE
Update page title

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -17,7 +17,7 @@
     <meta property="og:url" content="{{ request.url }}">
     <meta property="og:site_name" content="Canonical">
 
-    <title>Canonical | {% block title %}The company behind Ubuntu{% endblock %}</title>
+    <title>Canonical | {% block title %}Publisher of Ubuntu{% endblock %}</title>
     {% if self.title() %}
     <meta name="twitter:title" content="{{ self.title() }} | Canonical">
     <meta property="og:title" content="{{ self.title() }} | Canonical">


### PR DESCRIPTION
## Done

Updated the page title to "Canonical | Publisher of Ubuntu"

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the page title is "Canonical | Publisher of Ubuntu"


## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/7094