### PR TITLE
Update desktop partners page, add strip and card variants

### DIFF
--- a/static/sass/_pattern_cards.scss
+++ b/static/sass/_pattern_cards.scss
@@ -13,21 +13,21 @@
       color: $color-x-light;
       padding: calc(#{$spv-inner--large} - 1px);
     }
+  }
 
-    &.is-highlighted {
-      @extend %vf-has-box-shadow;
+  .p-card--highlighted.has-cta {
+    background-color: $color-light;
+    display: flex;
+    flex-direction: column;
+    padding: calc(#{$spv-inner--large} * 2 - 1px);
 
-      padding: calc(#{$spv-inner--large} * 2 - 1px);
+    .p-card__content {
+      flex-grow: 1;
+      padding-bottom: $spv-inner--medium;
     }
 
-    &.has-cta {
-      padding-bottom: 4rem;
-      position: relative;
-
-      .p-card__cta {
-        bottom: 0;
-        position: absolute;
-      }
+    .p-card__cta {
+      margin-bottom: 0;
     }
   }
 

--- a/static/sass/_pattern_cards.scss
+++ b/static/sass/_pattern_cards.scss
@@ -13,7 +13,24 @@
       color: $color-x-light;
       padding: calc(#{$spv-inner--large} - 1px);
     }
+
+    &.is-highlighted {
+      @extend %vf-has-box-shadow;
+      padding: calc(#{$spv-inner--large} * 2 - 1px);
+    }
+
+    &.has-cta {
+      padding-bottom: 4rem;
+      position: relative;
+
+      .p-card__cta {
+        bottom: 0;
+        position: absolute;
+      }
+    }
   }
+
+
 
   .p-card--no-border {
     @extend %vf-card;

--- a/static/sass/_pattern_cards.scss
+++ b/static/sass/_pattern_cards.scss
@@ -16,6 +16,7 @@
 
     &.is-highlighted {
       @extend %vf-has-box-shadow;
+
       padding: calc(#{$spv-inner--large} * 2 - 1px);
     }
 
@@ -29,8 +30,6 @@
       }
     }
   }
-
-
 
   .p-card--no-border {
     @extend %vf-card;

--- a/static/sass/_pattern_strip.scss
+++ b/static/sass/_pattern_strip.scss
@@ -249,9 +249,10 @@
 @mixin canonical-p-strip-suru-topped {
   .p-strip--suru-topped {
     @extend %vf-strip;
+
     background-blend-mode: multiply, multiply, normal, normal;
     // sass-lint:disable-block no-color-literals
-    background-image: linear-gradient(to bottom left, rgba(228, 228, 228, .5) 0%, rgba(228, 228, 228, .5) 49%, rgba(228, 228, 228, 0) 50%, rgba(228, 228, 228, 0) 100%), linear-gradient(to bottom left, rgba(119, 41, 83, .16) 0%, rgba(119, 41, 83, .16) 49%, rgba(119, 41, 83, 0) 50%, rgba(119, 41, 83, 0) 100%), linear-gradient(to bottom right, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0) 49%, rgba(255, 255, 255, 1) 50%, rgba(255, 255, 255, 1) 100%), linear-gradient(90deg, rgba(60, 0, 30, 1) 4%, rgba(119, 41, 83, 1) 50%, rgba(233, 84, 32, 1) 88%);
+    background-image: linear-gradient(to bottom left, rgba(228, 228, 228, 0.5) 0%, rgba(228, 228, 228, 0.5) 49%, rgba(228, 228, 228, 0) 50%, rgba(228, 228, 228, 0) 100%), linear-gradient(to bottom left, rgba(119, 41, 83, 0.16) 0%, rgba(119, 41, 83, 0.16) 49%, rgba(119, 41, 83, 0) 50%, rgba(119, 41, 83, 0) 100%), linear-gradient(to bottom right, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0) 49%, rgba(255, 255, 255, 1) 50%, rgba(255, 255, 255, 1) 100%), linear-gradient(90deg, rgba(60, 0, 30, 1) 4%, rgba(119, 41, 83, 1) 50%, rgba(233, 84, 32, 1) 88%);
     background-position: top right, top right, top left, top left;
     background-repeat: no-repeat;
     background-size: 39.4% 6rem, 54% 4rem, 63% 4rem, 62.6% 4rem;

--- a/static/sass/_pattern_strip.scss
+++ b/static/sass/_pattern_strip.scss
@@ -8,6 +8,7 @@
   @include canonical-p-strip-tag;
   @include canonical-p-strip-suru-bottomed;
   @include canonical-p-strip-suru-half-and-half-reversed;
+  @include canonical-p-strip-suru-topped;
 
   .p-strip {
     background-color: $color-x-light;
@@ -242,5 +243,19 @@
     &.is-dark {
       color: $color-x-light;
     }
+  }
+}
+
+@mixin canonical-p-strip-suru-topped {
+  .p-strip--suru-topped {
+    @extend %vf-strip;
+    background-blend-mode: multiply, multiply, normal, normal;
+    // sass-lint:disable-block no-color-literals
+    background-image: linear-gradient(to bottom left, rgba(228, 228, 228, .5) 0%, rgba(228, 228, 228, .5) 49%, rgba(228, 228, 228, 0) 50%, rgba(228, 228, 228, 0) 100%), linear-gradient(to bottom left, rgba(119, 41, 83, .16) 0%, rgba(119, 41, 83, .16) 49%, rgba(119, 41, 83, 0) 50%, rgba(119, 41, 83, 0) 100%), linear-gradient(to bottom right, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0) 49%, rgba(255, 255, 255, 1) 50%, rgba(255, 255, 255, 1) 100%), linear-gradient(90deg, rgba(60, 0, 30, 1) 4%, rgba(119, 41, 83, 1) 50%, rgba(233, 84, 32, 1) 88%);
+    background-position: top right, top right, top left, top left;
+    background-repeat: no-repeat;
+    background-size: 39.4% 6rem, 54% 4rem, 63% 4rem, 62.6% 4rem;
+    padding-bottom: 4rem;
+    padding-top: 6rem;
   }
 }

--- a/templates/partners/desktop.html
+++ b/templates/partners/desktop.html
@@ -12,13 +12,13 @@
       <div class="col-6 u-vertically-center">
         <ul class="p-inline-images">
           <li class="p-inline-images__item">
-            <img src="https://assets.ubuntu.com/v1/d258d23b-2018-logo-dell.svg" alt="Dell" style="height: 75px;">
+            <img src="https://assets.ubuntu.com/v1/d258d23b-2018-logo-dell.svg" alt="Dell" width="75" height="75">
           </li>
           <li class="p-inline-images__item">
-            <img src="https://assets.ubuntu.com/v1/f627fbfb-hp.svg" alt="HP" style="height: 75px;">
+            <img src="https://assets.ubuntu.com/v1/f627fbfb-hp.svg" alt="HP" width="75" height="75">
           </li>
           <li class="p-inline-images__item">
-            <img src="https://assets.ubuntu.com/v1/3180a6b5-partner-logo-lenovo.svg" alt="Lenovo" style="height: 35px;">
+            <img src="https://assets.ubuntu.com/v1/3180a6b5-partner-logo-lenovo.svg" alt="Lenovo" width="170" height="35">
           </li>
         </ul>
       </div>
@@ -117,28 +117,34 @@
       <p>We’ve been working with partners like Dell, HP and Lenovo for years to ensure that Ubuntu devices reach market as effectively as possible. With the help of these partners, Ubuntu machines are distributed around the world and can be found in both their exclusive and partner stores.</p>
     </div>
     <div class="row">
-      <div class="col-4 p-card--strip is-highlighted has-cta">
-        <img src="https://assets.ubuntu.com/v1/d258d23b-2018-logo-dell.svg" alt="Dell" style="height: 80px;">
-        <p>Canonical and Dell work together to deliver Ubuntu computers from entry-level laptops to high-end developer machines.</p>
-        <p><a href="https://www.delltechnologies.com/en-gb/ai-technologies/index.htm" class="p-link--external">See the Ubuntu certified AI ready workstations</a></p>
+      <div class="col-4 p-card--highlighted has-cta">
+        <div class="p-card__content">
+          <img src="https://assets.ubuntu.com/v1/d258d23b-2018-logo-dell.svg" alt="Dell" width="80" height="80">
+          <p>Canonical and Dell work together to deliver Ubuntu computers from entry-level laptops to high-end developer machines.</p>
+          <p><a href="https://www.delltechnologies.com/en-gb/ai-technologies/index.htm" class="p-link--external">See the Ubuntu certified AI ready workstations</a></p>
+        </div>
         <a href="http://www.dell.com/linux" class="p-button--positive p-card__cta"><span class="p-link--external">Shop for Dell with Ubuntu</span></a>
       </div>
-      <div class="col-4 p-card--strip is-highlighted has-cta">
-        <img src="https://assets.ubuntu.com/v1/f627fbfb-hp.svg" alt="HP" style="height: 80px;">
-        <p>HP sells Ubuntu laptops globally</p>
+      <div class="col-4 p-card--highlighted has-cta">
+        <div class="p-card__content">
+          <img src="https://assets.ubuntu.com/v1/f627fbfb-hp.svg" alt="HP" width="80" height="80">
+          <p>HP sells Ubuntu laptops globally</p>
+        </div>
         <a href="https://certification.ubuntu.com/desktop/models?vendors=HP" class="p-button--positive p-card__cta"><span class="p-link--external">View HP with Ubuntu</span></a>
       </div>
-      <div class="col-4 p-card--strip is-highlighted has-cta">
-        <div class="u-vertically-center" style="height: 80px;">
-          <img src="https://assets.ubuntu.com/v1/3180a6b5-partner-logo-lenovo.svg" alt="Lenovo" style="height: 40px;">
+      <div class="col-4 p-card--highlighted has-cta">
+        <div class="p-card__content">
+          <div class="u-vertically-center" style="height: 80px;">
+            <img src="https://assets.ubuntu.com/v1/3180a6b5-partner-logo-lenovo.svg" alt="Lenovo" width="195" height="40">
+          </div>
+          <p>Canonical has been shipping Ubuntu on Lenovo’s popular [Name of the machine] machines and are available from Lenovo’s enterprise teams.</p>
+          <p><a href="https://www.lenovo.com/us/en/think-workstations/artificial-intelligence-industry/c/artificial-intelligence-industry" class="p-link--external">Buy AI workstations with Ubuntu</a></p>
         </div>
-        <p>Canonical has been shipping Ubuntu on Lenovo’s popular [Name of the machine] machines and are available from Lenovo’s enterprise teams.</p>
-        <p><a href="https://www.lenovo.com/us/en/think-workstations/artificial-intelligence-industry/c/artificial-intelligence-industry" class="p-link--external">Buy AI workstations with Ubuntu</a></p>
         <a href="https://certification.ubuntu.com/desktop/models?vendors=Lenovo" class="p-button--positive p-card__cta"><span class="p-link--external">View Lenovo with Ubuntu</span></a>
       </div>
     </div>
     <div class="row">
-      <div class="p-card--strip is-highlighted">
+      <div class="p-card--highlighted has-cta">
         <div class="row">
           <div class="col-8 u-vertically-center">
             <h2 class="p-heading--four">Buy Ubuntu Advantage</h2>

--- a/templates/partners/desktop.html
+++ b/templates/partners/desktop.html
@@ -15,10 +15,10 @@
             <img src="https://assets.ubuntu.com/v1/d258d23b-2018-logo-dell.svg" alt="Dell" style="height: 80px;">
           </li>
           <li class="p-inline-images__item">
-<img src="https://assets.ubuntu.com/v1/f627fbfb-hp.svg" alt="HP" style="height: 80px;">
+            <img src="https://assets.ubuntu.com/v1/f627fbfb-hp.svg" alt="HP" style="height: 80px;">
           </li>
           <li class="p-inline-images__item">
-      <img src="https://assets.ubuntu.com/v1/3180a6b5-partner-logo-lenovo.svg" alt="Lenovo" style="height: 40px;">
+            <img src="https://assets.ubuntu.com/v1/3180a6b5-partner-logo-lenovo.svg" alt="Lenovo" style="height: 40px;">
           </li>
         </ul>
       </div>

--- a/templates/partners/desktop.html
+++ b/templates/partners/desktop.html
@@ -128,7 +128,7 @@
       <div class="col-4 p-card--highlighted has-cta">
         <div class="p-card__content">
           <img src="https://assets.ubuntu.com/v1/f627fbfb-hp.svg" alt="HP" width="80" height="80">
-          <p>HP sells Ubuntu laptops globally</p>
+          <p>HP sells a wide range of Canonical-certified Ubuntu laptops and desktop machines globally.</p>
         </div>
         <a href="https://certification.ubuntu.com/desktop/models?vendors=HP" class="p-button--positive p-card__cta"><span class="p-link--external">View HP with Ubuntu</span></a>
       </div>
@@ -137,7 +137,7 @@
           <div class="u-vertically-center" style="height: 80px;">
             <img src="https://assets.ubuntu.com/v1/3180a6b5-partner-logo-lenovo.svg" alt="Lenovo" width="195" height="40">
           </div>
-          <p>Canonical has been shipping Ubuntu on Lenovo’s popular [Name of the machine] machines and are available from Lenovo’s enterprise teams.</p>
+          <p>Canonical has been shipping Ubuntu on a variety of Lenovo’s popular machines which are available from Lenovo’s enterprise teams.</p>
           <p><a href="https://www.lenovo.com/us/en/think-workstations/artificial-intelligence-industry/c/artificial-intelligence-industry" class="p-link--external">Buy AI workstations with Ubuntu</a></p>
         </div>
         <a href="https://certification.ubuntu.com/desktop/models?vendors=Lenovo" class="p-button--positive p-card__cta"><span class="p-link--external">View Lenovo with Ubuntu</span></a>
@@ -150,7 +150,7 @@
             <h2 class="p-heading--four">Buy Ubuntu Advantage</h2>
             <p style="max-width: none;">Security, compliance and support to improve efficiency while reducing complexity and cost.</p>
           </div>
-          <div class="col-4 u-vertically-center u-align--right">
+          <div class="col-4 u-vertically-center" style="justify-content: inherit;">
             <a href="https://buy.ubuntu.com/" class="p-button--positive"><span class="p-link--external">Learn about our support options</span></a>
           </div>
         </div>

--- a/templates/partners/desktop.html
+++ b/templates/partners/desktop.html
@@ -1,14 +1,28 @@
 {% extends 'base_index.html' %}
 
 {% block content %}
-  <section class="p-strip--suru-desktop">
+  <section class="p-strip--suru-topped">
     <div class="row">
-      <div class="col-6">
-        <h1>Desktop</h1>
-        <p>Partnering with Canonical is a great way to keep your products ahead of the competition. The Technical Partner Programme gives you access to information, tools and training that can help you get to market quicker and for less. And in retail and online, we work with our hardware partners on the promotion of Ubuntu to consumers and businesses.</p>
+      <div class="col-5">
+        <h1>Desktop Programme</h1>
+        <p>Canonical collaborates with the world's leading vendors to optimise and certify Ubuntu on 100s of laptops, desktops and workstations for a secure and constantly updated platform.</p>
+        <p>Whether built with the developer in mind or to power AI ambitions, these out-of the-box platforms give practitioners everything they need to transform their enterprise IT.</p>
+        <a href="https://certification.ubuntu.com/desktop" class="p-button--neutral"><span class="p-link--external">Find a certified PC</span></a><a href="https://partners.ubuntu.com/contact-us" class="p-button--positive"><span class="p-link--external">Get in touch</span></a>
+      </div>
+      <div class="col-7 u-vertically-center">
+        <ul class="p-inline-images">
+          <li class="p-inline-images__item">
+            <img src="https://assets.ubuntu.com/v1/d258d23b-2018-logo-dell.svg" alt="Dell" style="height: 80px;">
+          </li>
+          <li class="p-inline-images__item">
+<img src="https://assets.ubuntu.com/v1/f627fbfb-hp.svg" alt="HP" style="height: 80px;">
+          </li>
+          <li class="p-inline-images__item">
+      <img src="https://assets.ubuntu.com/v1/3180a6b5-partner-logo-lenovo.svg" alt="Lenovo" style="height: 40px;">
+          </li>
+        </ul>
       </div>
     </div>
-    <img src="https://assets.ubuntu.com/v1/690d0479-disco-dingo-laptop.png" alt="disco dingo laptop" class="p-image-desktop u-hide--small">
   </section>
   <style>
     .p-strip--suru-desktop {
@@ -52,7 +66,7 @@
         background-image:
           linear-gradient(to bottom right, rgba(210,180,202,0.05) 0%, rgba(210,180,202,0.05) 49.9%, rgba(210,180,202,0) 50%, rgba(210,180,202,0) 100%),
           linear-gradient(to top right, rgba(74,24,60,0) 0%, rgba(74,24,60,0) 49.9%, rgba(74,24,60,0.34) 50%, rgba(74,24,60,0.34) 100%),
-          linear-gradient(to top right, #f7f7f7 0%, #f7f7f7 49.5%, transparent 50%),
+        socket  linear-gradient(to top right, #f7f7f7 0%, #f7f7f7 49.5%, transparent 50%),
           linear-gradient(50deg, #E95420 0%, #772953 33%, #2C001E 72%);
         background-position: left top, right top, left bottom -1px;
         background-repeat: no-repeat;
@@ -62,93 +76,59 @@
   </style>
   <section class="p-strip--light is-deep">
     <div class="row">
-      <div class="col-8">
-        <h2 class="u-sv3">What you get when you work with us</h2>
-        <ul class="p-list--divided">
-          <li class="p-list__item is-ticked">Lorem ipsum dolor sit amet, consectetur ipsum dolor sit amet ipsum dolor sit amet adipiscing elit, sed do eiusmod tempor incididunt</li>
-          <li class="p-list__item is-ticked">Lorem ipsum dolor sit amet, consectetur ipsum dolor sit amet ipsum dolor sit amet adipiscing elit, sed do eiusmod tempor incididunt</li>
-          <li class="p-list__item is-ticked">Lorem ipsum dolor sit amet, consectetur ipsum dolor sit amet ipsum dolor sit amet adipiscing elit, sed do eiusmod tempor incididunt</li>
-          <li class="p-list__item is-ticked">Lorem ipsum dolor sit amet, consectetur ipsum dolor sit amet ipsum dolor sit amet adipiscing elit, sed do eiusmod tempor incididunt</li>
-          <li class="p-list__item is-ticked">Lorem ipsum dolor sit amet, consectetur ipsum dolor sit amet ipsum dolor sit amet adipiscing elit, sed do eiusmod tempor incididunt</li>
-        </ul>
+      <div class="col-12">
+        <h2 style="margin-bottom: 3rem;">Why buy a certified Ubuntu desktop?</h2>
       </div>
-      <div class="col-4 u-align--center u-vertically-center">
-        <img src="https://assets.ubuntu.com/v1/eb9e7ede-What-youget-working-withus-icon.svg" alt="">
-      </div>
+      <div class="col-4 p-card--highlighted">
+            <h3 class="p-matrix__title">Preloaded with Ubuntu</h3>
+            <div class="p-matrix__desc">
+              <p>Ubuntu certified PCs ship with a clean version of Ubuntu, straight from Canonical</p>
+            </div>
+          </div>
+          <div class="col-4 p-card--highlighted">
+            <h3 class="p-matrix__title">Works out of the box</h3>
+            <div class="p-matrix__desc">
+              <p>Canonical performs 100s of stringent tests to ensure all Ubuntu functionalities work out of the box</p>
+            </div>
+          </div>
+          <div class="col-4 p-card--highlighted">
+            <h3 class="p-matrix__title">5 years support</h3>
+            <p class="p-matrix__desc">Certified PCs are continuously tested throughout the lifetime of the preloaded Ubuntu release</p>
+          </div>
+          <div class="col-4 p-card--highlighted">
+            <h3 class="p-matrix__title">Optimised images</h3>
+            <div class="p-matrix__desc">
+              <p>PCs preloaded with Ubuntu at the factory come with an optimised image to provide users with the best experience for their hardware</p>
+            </div>
+          </div>
+          <div class="col-4 p-card--highlighted">
+            <h3 class="p-matrix__title">Latest hardware</h3>
+            <p class="p-matrix__desc">Collaboration with Intel, NVIDIA and AMD guarantees Ubuntu runs flawlessly on the the latest CPUs and GPUs</p>
+          </div>
+          <div class="col-4 p-card--highlighted">
+            <h3 class="p-matrix__title">Battery life</h3>
+            <p class="p-matrix__desc">Ubuntu certified PCs meet the most stringent energy regulations &mdash; Energy Star, CEC</p>
+          </div>
+          <div class="col-4 p-card--highlighted">
+            <h3 class="p-matrix__title">Reliability</h3>
+            <div class="p-matrix__desc">
+              <p>Ubuntu certified PCs undergo rigorous testing to ensure they perform flawlessly after 30+ suspend/resume cycles</p>
+            </div>
+          </div>
+          <div class="col-4 p-card--highlighted">
+            <h3 class="p-matrix__title">Ready for Enterprise</h3>
+            <div class="p-matrix__desc">
+              <p>Ubuntu certified PCs are eligible for <a href="https://buy.ubuntu.com" class="p-link--external">Ubuntu Advantage</a>, the most comprehensive Linux enterprise subscription</p>
+            </div>
+          </div>
+          <div class="col-4 p-card--highlighted">
+            <h3 class="p-matrix__title">The key to corporate fleet</h3>
+            <div class="p-matrix__desc">
+              <p>With 100s of certified models, ranging from low-cost tower PCs to AI workstations</p>
+            </div>
+          </div>
     </div>
   </section>
-  <section class="p-strip is-deep">
-    <div class="row">
-      <div class="col-6 u-align--center u-vertically-center">
-        <img src="https://assets.ubuntu.com/v1/73c9b800-increase+sales+icon.svg" alt="">
-      </div>
-      <div class="col-6">
-        <h2>Increase your sales by becoming Ubuntu Certified</h2>
-        <p>Lorem ipsum dolor sit, amet consectetur adipisicing elit. Rerum veniam eveniet at nam odio culpa voluptate labore. Sequi vero quo dolore, corporis a eaque id exercitationem qui minus, repudiandae consectetur.</p>
-        <a href="https://certification.ubuntu.com/" class="p-link--external">Learn more about certification&nbsp;&rsaquo;</a>
-        <ul class="p-inline-images u-align--left">
-          <li class="p-inline-images__item" style="margin-left: 0; margin-right: 0;">
-            <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/5ddba83a-logo-dell.svg" alt="dell image" style="max-height: 60px;">
-          </li>
-          <li class="p-inline-images__item" style="margin-right: 0;">
-            <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/683950fd-logo-ibm.svg" alt="ibm image" style="max-height: 40px;">
-          </li>
-          <li class="p-inline-images__item" style="margin-right: 0;">
-            <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/a298e7ec-logo-hp.svg" alt="hp image" style="max-height: 60px;">
-          </li>
-          <li class="p-inline-images__item" style="margin-right: 0;">
-            <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/68713fd5-logo-lenovo.svg" alt="lenovo image" style="max-height: 60px;">
-          </li>
-        </ul>
-      </div>
-    </div>
-  </section>
-  <section class="p-strip--image is-dark">
-    <div class="p-strip--suru-innovation">
-      <div class="row">
-        <div class="col-6">
-          <h1>Innovation with Ubuntu and Canonical</h1>
-          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
-          <p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
-          <!-- Add url -->
-          <a href="" class="p-button--outline">Get started</a>
-        </div>
-      </div>
-    </div>
-  </section>
-  <style>
-    .p-strip--suru-innovation {
-      background-image:
-        linear-gradient(to top right, rgba(74,24,60,0) 0%, rgba(74,24,60,0) 49.9%, rgba(74, 24, 60, 0.4) 50%, rgba(74, 24, 60, 0.4) 100%),
-        linear-gradient(to bottom right, rgba(210,180,202,0.05) 0%, rgba(210,180,202,0.05) 49.9%, rgba(210,180,202,0) 50%, rgba(210,180,202,0) 100%),
-        linear-gradient(120deg, #2C001E  4%, #4C193E 54.9%, transparent 55%),
-        url('https://assets.ubuntu.com/v1/8be1b040-blackhole_long.jpg');
-      background-position: right top, top left, top left, center right, right bottom;
-      background-repeat: no-repeat;
-      background-size: 85% 100%, 60% 80%, 100% 100%, 105% auto;
-      padding-bottom: 6rem;
-      padding-top: 6rem;
-    }
-
-    @media (min-width: 620px) and (max-width: 1036px){
-      .p-strip--suru-innovation > .row {
-        grid-template-columns: repeat(6, minmax(0, 1fr));
-      }
-    }
-
-    @media (max-width: 1036px) {
-      .p-strip--suru-innovation {
-        background-image:
-          linear-gradient(to top right, rgba(74,24,60,0) 0%, rgba(74,24,60,0) 49.9%, rgba(74, 24, 60, 0.4) 50%, rgba(74, 24, 60, 0.4) 100%),
-          linear-gradient(to top left, #fff 0%, #fff 49%, transparent 50%),
-          linear-gradient(to bottom right, rgba(210,180,202,0.05) 0%, rgba(210,180,202,0.05) 49.9%, rgba(210,180,202,0) 50%, rgba(210,180,202,0) 100%),
-          linear-gradient(120deg, #2C001E  4%, #4C193E 100%);
-        background-position: right top, bottom right, top left, top left, center right;
-        background-repeat: no-repeat;
-        background-size: 100% 100%, 105% 25%, 60% 80%, 100% 100%;
-      }
-    }
-  </style>
   <section class="p-strip is-deep">
     <div class="u-fixed-width">
       <h2 class="p-muted-heading u-align-text--center">A selection of our Desktop partners</h2>
@@ -181,18 +161,47 @@
     </div>
   </section>
   <hr />
-  <section class="p-strip is-deep" style="position: relative;">
+  <section class="p-strip is-deep">
     <div class="row">
-      <div class="col-6">
-        <h2>Join the future of open source</h2>
-        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
-        <p>At vero eos et accusamus et iusto odio dignissimos ducimus qui blanditiis praesentium voluptatum deleniti atque.</p>
-        <a href="/partners/become-a-partner">Become a partner&nbsp;&rsaquo;</a>
+      <h2>Buy a certified Ubuntu PC</h2>
+      <p>We’ve been working with partners like Dell, HP and Lenovo for years to ensure that Ubuntu devices reach market as effectively as possible. With the help of these partners, Ubuntu machines are distributed around the world and can be found in both their exclusive and partner stores.</p>
+    </div>
+    <div class="row">
+      <div class="col-4 p-card--strip is-highlighted has-cta">
+        <img src="https://assets.ubuntu.com/v1/d258d23b-2018-logo-dell.svg" alt="Dell" style="height: 80px;">
+        <p>Canonical and Dell work together to deliver Ubuntu computers from entry-level laptops to high-end developer machines.</p>
+        <p><a href="https://www.delltechnologies.com/en-gb/ai-technologies/index.htm" class="p-link--external">See the Ubuntu certified AI ready workstations</a></p>
+        <a href="http://www.dell.com/linux" class="p-button--positive p-card__cta"><span class="p-link--external">Shop for Dell with Ubuntu</span></a>
       </div>
-      <img class="u-hide--small" src="https://assets.ubuntu.com/v1/4f3cd96e-Ubuntu_19.04__Disco_Dingo_.png" alt="disco dingo desktop" style="bottom: 0; max-height: 95%; position: absolute; left: 50%;">
+      <div class="col-4 p-card--strip is-highlighted has-cta">
+        <img src="https://assets.ubuntu.com/v1/f627fbfb-hp.svg" alt="HP" style="height: 80px;">
+        <p>HP sells Ubuntu laptops globally</p>
+        <a href="https://certification.ubuntu.com/desktop/models?vendors=HP" class="p-button--positive p-card__cta"><span class="p-link--external">View HP with Ubuntu</span></a>
+      </div>
+      <div class="col-4 p-card--strip is-highlighted has-cta">
+        <div class="u-vertically-center" style="height: 80px;">
+          <img src="https://assets.ubuntu.com/v1/3180a6b5-partner-logo-lenovo.svg" alt="Lenovo" style="height: 40px;">
+        </div>
+        <p>Canonical has been shipping Ubuntu on Lenovo’s popular [Name of the machine] machines and are available from Lenovo’s enterprise teams.</p>
+        <p><a href="https://www.lenovo.com/us/en/think-workstations/artificial-intelligence-industry/c/artificial-intelligence-industry" class="p-link--external">Buy AI workstations with Ubuntu</a></p>
+        <a href="https://certification.ubuntu.com/desktop/models?vendors=Lenovo" class="p-button--positive p-card__cta"><span class="p-link--external">View Lenovo with Ubuntu</span></a>
+      </div>
+    </div>
+    <div class="row">
+      <div class="p-card--strip is-highlighted">
+        <div class="row">
+          <div class="col-8 u-vertically-center">
+            <h2 class="p-heading--four">Buy Ubuntu Advantage</h2>
+            <p style="max-width: none;">Security, compliance and support to improve efficiency while reducing complexity and cost.</p>
+          </div>
+          <div class="col-4 u-vertically-center u-align--right">
+            <a href="https://buy.ubuntu.com/" class="p-button--positive"><span class="p-link--external">Learn about our support options</span></a>
+          </div>
+        </div>
+      </div>
     </div>
   </section>
-  
+
   {% include 'partial/_partners-footer.html' %}
 
 {% endblock %}

--- a/templates/partners/desktop.html
+++ b/templates/partners/desktop.html
@@ -24,109 +24,59 @@
       </div>
     </div>
   </section>
-  <style>
-    .p-strip--suru-desktop {
-      background-image:
-        linear-gradient(to bottom right, rgba(210,180,202,0.05) 0%, rgba(210,180,202,0.05) 49.9%, rgba(210,180,202,0) 50%, rgba(210,180,202,0) 100%),
-        linear-gradient(to top right, rgba(74,24,60,0) 0%, rgba(74,24,60,0) 49.9%, rgba(74,24,60,0.34) 50%, rgba(74,24,60,0.34) 100%),
-        linear-gradient(to top right, #f7f7f7 0%, #f7f7f7 49.5%, transparent 50%),
-        linear-gradient(50deg, #E95420 0%, #772953 33%, #2C001E 72%);
-      background-position: left top, right top, left bottom -1px;
-      background-repeat: no-repeat;
-      background-size: 50% 40%, 60% 80%, 102% 20%, 100% 100%;
-      color: #fff;
-      padding-bottom: 6rem;
-      padding-top: 6rem;
-    }
-
-    .p-image-desktop {
-      left: 45%;
-      position: absolute;
-      top: 8rem;
-      width: 40rem;
-    }
-
-    @media (max-width: 1200px) {
-      .p-image-desktop {
-      left: 35%;
-      top: 10rem;
-      width: 35rem;
-      }
-    }
-
-    @media (max-width: 900px) {
-      .p-image-desktop {
-      top: 13rem;
-      width: 30rem;
-      }
-    }
-
-    @media (max-width: 620px) {
-      .p-strip--suru-desktop {
-        background-image:
-          linear-gradient(to bottom right, rgba(210,180,202,0.05) 0%, rgba(210,180,202,0.05) 49.9%, rgba(210,180,202,0) 50%, rgba(210,180,202,0) 100%),
-          linear-gradient(to top right, rgba(74,24,60,0) 0%, rgba(74,24,60,0) 49.9%, rgba(74,24,60,0.34) 50%, rgba(74,24,60,0.34) 100%),
-        socket  linear-gradient(to top right, #f7f7f7 0%, #f7f7f7 49.5%, transparent 50%),
-          linear-gradient(50deg, #E95420 0%, #772953 33%, #2C001E 72%);
-        background-position: left top, right top, left bottom -1px;
-        background-repeat: no-repeat;
-        background-size: 50% 40%, 60% 80%, 102% 20%, 100% 100%;
-      }
-    }
-  </style>
   <section class="p-strip--light is-deep">
     <div class="row">
       <div class="col-12">
         <h2 style="margin-bottom: 3rem;">Why buy a certified Ubuntu desktop?</h2>
       </div>
       <div class="col-4 p-card--highlighted">
-            <h3 class="p-matrix__title">Preloaded with Ubuntu</h3>
-            <div class="p-matrix__desc">
-              <p>Ubuntu certified PCs ship with a clean version of Ubuntu, straight from Canonical</p>
-            </div>
-          </div>
-          <div class="col-4 p-card--highlighted">
-            <h3 class="p-matrix__title">Works out of the box</h3>
-            <div class="p-matrix__desc">
-              <p>Canonical performs 100s of stringent tests to ensure all Ubuntu functionalities work out of the box</p>
-            </div>
-          </div>
-          <div class="col-4 p-card--highlighted">
-            <h3 class="p-matrix__title">5 years support</h3>
-            <p class="p-matrix__desc">Certified PCs are continuously tested throughout the lifetime of the preloaded Ubuntu release</p>
-          </div>
-          <div class="col-4 p-card--highlighted">
-            <h3 class="p-matrix__title">Optimised images</h3>
-            <div class="p-matrix__desc">
-              <p>PCs preloaded with Ubuntu at the factory come with an optimised image to provide users with the best experience for their hardware</p>
-            </div>
-          </div>
-          <div class="col-4 p-card--highlighted">
-            <h3 class="p-matrix__title">Latest hardware</h3>
-            <p class="p-matrix__desc">Collaboration with Intel, NVIDIA and AMD guarantees Ubuntu runs flawlessly on the the latest CPUs and GPUs</p>
-          </div>
-          <div class="col-4 p-card--highlighted">
-            <h3 class="p-matrix__title">Battery life</h3>
-            <p class="p-matrix__desc">Ubuntu certified PCs meet the most stringent energy regulations &mdash; Energy Star, CEC</p>
-          </div>
-          <div class="col-4 p-card--highlighted">
-            <h3 class="p-matrix__title">Reliability</h3>
-            <div class="p-matrix__desc">
-              <p>Ubuntu certified PCs undergo rigorous testing to ensure they perform flawlessly after 30+ suspend/resume cycles</p>
-            </div>
-          </div>
-          <div class="col-4 p-card--highlighted">
-            <h3 class="p-matrix__title">Ready for Enterprise</h3>
-            <div class="p-matrix__desc">
-              <p>Ubuntu certified PCs are eligible for <a href="https://buy.ubuntu.com" class="p-link--external">Ubuntu Advantage</a>, the most comprehensive Linux enterprise subscription</p>
-            </div>
-          </div>
-          <div class="col-4 p-card--highlighted">
-            <h3 class="p-matrix__title">The key to corporate fleet</h3>
-            <div class="p-matrix__desc">
-              <p>With 100s of certified models, ranging from low-cost tower PCs to AI workstations</p>
-            </div>
-          </div>
+        <h3 class="p-matrix__title">Preloaded with Ubuntu</h3>
+        <div class="p-matrix__desc">
+          <p>Ubuntu certified PCs ship with a clean version of Ubuntu, straight from Canonical</p>
+        </div>
+      </div>
+      <div class="col-4 p-card--highlighted">
+        <h3 class="p-matrix__title">Works out of the box</h3>
+        <div class="p-matrix__desc">
+          <p>Canonical performs 100s of stringent tests to ensure all Ubuntu functionalities work out of the box</p>
+        </div>
+      </div>
+      <div class="col-4 p-card--highlighted">
+        <h3 class="p-matrix__title">5 years support</h3>
+        <p class="p-matrix__desc">Certified PCs are continuously tested throughout the lifetime of the preloaded Ubuntu release</p>
+      </div>
+      <div class="col-4 p-card--highlighted">
+        <h3 class="p-matrix__title">Optimised images</h3>
+        <div class="p-matrix__desc">
+          <p>PCs preloaded with Ubuntu at the factory come with an optimised image to provide users with the best experience for their hardware</p>
+        </div>
+      </div>
+      <div class="col-4 p-card--highlighted">
+        <h3 class="p-matrix__title">Latest hardware</h3>
+        <p class="p-matrix__desc">Collaboration with Intel, NVIDIA and AMD guarantees Ubuntu runs flawlessly on the the latest CPUs and GPUs</p>
+      </div>
+      <div class="col-4 p-card--highlighted">
+        <h3 class="p-matrix__title">Battery life</h3>
+        <p class="p-matrix__desc">Ubuntu certified PCs meet the most stringent energy regulations &mdash; Energy Star, CEC</p>
+      </div>
+      <div class="col-4 p-card--highlighted">
+        <h3 class="p-matrix__title">Reliability</h3>
+        <div class="p-matrix__desc">
+          <p>Ubuntu certified PCs undergo rigorous testing to ensure they perform flawlessly after 30+ suspend/resume cycles</p>
+        </div>
+      </div>
+      <div class="col-4 p-card--highlighted">
+        <h3 class="p-matrix__title">Ready for Enterprise</h3>
+        <div class="p-matrix__desc">
+          <p>Ubuntu certified PCs are eligible for <a href="https://buy.ubuntu.com" class="p-link--external">Ubuntu Advantage</a>, the most comprehensive Linux enterprise subscription</p>
+        </div>
+      </div>
+      <div class="col-4 p-card--highlighted">
+        <h3 class="p-matrix__title">The key to corporate fleet</h3>
+        <div class="p-matrix__desc">
+          <p>With 100s of certified models, ranging from low-cost tower PCs to AI workstations</p>
+        </div>
+      </div>
     </div>
   </section>
   <section class="p-strip is-deep">

--- a/templates/partners/desktop.html
+++ b/templates/partners/desktop.html
@@ -3,22 +3,22 @@
 {% block content %}
   <section class="p-strip--suru-topped">
     <div class="row">
-      <div class="col-5">
+      <div class="col-6">
         <h1>Desktop Programme</h1>
         <p>Canonical collaborates with the world's leading vendors to optimise and certify Ubuntu on 100s of laptops, desktops and workstations for a secure and constantly updated platform.</p>
         <p>Whether built with the developer in mind or to power AI ambitions, these out-of the-box platforms give practitioners everything they need to transform their enterprise IT.</p>
         <a href="https://certification.ubuntu.com/desktop" class="p-button--neutral"><span class="p-link--external">Find a certified PC</span></a><a href="https://partners.ubuntu.com/contact-us" class="p-button--positive"><span class="p-link--external">Get in touch</span></a>
       </div>
-      <div class="col-7 u-vertically-center">
+      <div class="col-6 u-vertically-center">
         <ul class="p-inline-images">
           <li class="p-inline-images__item">
-            <img src="https://assets.ubuntu.com/v1/d258d23b-2018-logo-dell.svg" alt="Dell" style="height: 80px;">
+            <img src="https://assets.ubuntu.com/v1/d258d23b-2018-logo-dell.svg" alt="Dell" style="height: 75px;">
           </li>
           <li class="p-inline-images__item">
-            <img src="https://assets.ubuntu.com/v1/f627fbfb-hp.svg" alt="HP" style="height: 80px;">
+            <img src="https://assets.ubuntu.com/v1/f627fbfb-hp.svg" alt="HP" style="height: 75px;">
           </li>
           <li class="p-inline-images__item">
-            <img src="https://assets.ubuntu.com/v1/3180a6b5-partner-logo-lenovo.svg" alt="Lenovo" style="height: 40px;">
+            <img src="https://assets.ubuntu.com/v1/3180a6b5-partner-logo-lenovo.svg" alt="Lenovo" style="height: 35px;">
           </li>
         </ul>
       </div>
@@ -112,7 +112,7 @@
   </section>
   <hr />
   <section class="p-strip is-deep">
-    <div class="row">
+    <div class="row" style="margin-bottom: 3rem;">
       <h2>Buy a certified Ubuntu PC</h2>
       <p>We’ve been working with partners like Dell, HP and Lenovo for years to ensure that Ubuntu devices reach market as effectively as possible. With the help of these partners, Ubuntu machines are distributed around the world and can be found in both their exclusive and partner stores.</p>
     </div>


### PR DESCRIPTION
## Done

Updated desktop partner page
[copy](https://docs.google.com/document/d/1MBVH4kou0Q7yO_Lq6DPQpZL_rc0K1-nVfvg4aF3biSc/edit#)
[design](https://usercontent.irccloud-cdn.com/file/TZtWqNTC/Partner%20-%20Desktop.png)

Note: some aspects of the design are unimplemented 

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/partners/desktop
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check the design, copy and responsiveness at all viewports


## Issue / Card

Fixes #2566
