### PR TITLE
Update flask-base to 0.5.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,8 @@
 defaults: &defaults
   docker:
     - image: canonicalwebteam/dev
+      environment:
+        SECRET_KEY: local_development_fake_key
   working_directory: /srv
 
 version: 2

--- a/.env
+++ b/.env
@@ -1,3 +1,4 @@
 PORT=8002
 FLASK_DEBUG=true
 DEVEL=true
+SECRET_KEY=local_development_fake_key

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Flask==1.1.1
-canonicalwebteam.flask-base==0.4.3
+canonicalwebteam.flask-base==0.5.1
 gunicorn[gevent]
 canonicalwebteam.templatefinder==0.2.4
 canonicalwebteam.http==1.0.3


### PR DESCRIPTION
## Done

- Update flask-base to 0.5.1

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [List additional steps to QA the new features or prove the bug has been resolved]
