### PR TITLE
Update become a partner page

### DIFF
--- a/templates/partners/become-a-partner.html
+++ b/templates/partners/become-a-partner.html
@@ -1,16 +1,17 @@
 {% extends 'base_index.html' %}
 
 {% block title %}Become a partner{% endblock %}
-{% block meta_description %}We run a range of partner programmes to help you maximise revenue and efficiency from the opportunities Ubuntu provides.{% endblock %}
+
+{% block meta_description %}Technology companies, consider partnering with Canonical and increase your revenues with Ubuntu.{% endblock %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1Ihh9s3i72saCYaheXRVRn1Meg5lYN5U1gFbdvLMdWcc{% endblock meta_copydoc %}
 
 {% block content %}
 <section class="p-strip--image is-dark">
   <div class="p-strip--suru-top">
-    <div class="row">
-      <div class="col-12">
-        <h1>Become a partner</h1>
-        <p class="u-sv3">Ubuntu is an open source computing platform that is transforming the way millions of people and businesses use the client, the server and the cloud. Canonical is the company that supports it, providing strategic guidance and driving its adoption.</p>
-      </div>
+    <div class="u-fixed-width">
+      <h1>Become a partner</h1>
+      <p class="u-sv3">Ubuntu is an open source platform that is transforming the way millions of people and businesses use devices, the server and the cloud. Canonical is the company that supports it, providing strategic guidance and driving its adoption.</p>
     </div>
     <div class="row">
       <div class="col-4">
@@ -21,7 +22,7 @@
           <p class="p-heading--three p-heading-highlight--bottom__item">Grow your business</p>
         </div>
         <p>
-          Leveraging the enormous popularity of Ubuntu opens additional revenue opportunities allowing you to sell management, monitoring and commercial support from Canonical.
+          Leveraging the enormous popularity of Ubuntu opens additional revenue opportunities, allowing you to sell management, monitoring and commercial support from Canonical.
         </p>
       </div>
       <div class="col-4">
@@ -32,7 +33,7 @@
           <p class="p-heading--three p-heading-highlight--bottom__item">Certification of products</p>
         </div>
         <p>
-          As a certified partner, you can make secure and up-to-date certified Ubuntu cloud images that are tuned and tested to ensure optimal performance.
+          As a certified partner, you can make secure and up&dash;to&dash;date certified Ubuntu images that are tuned and tested to ensure optimal performance.
         </p>
       </div>
       <div class="col-4 u-extra-space">
@@ -40,7 +41,7 @@
           <img src="https://assets.ubuntu.com/v1/fd384383-group-55.svg" alt="">
         </div>
         <div class="p-heading-highlight--bottom">
-          <p class="p-heading--three p-heading-highlight--bottom__item">Save time & money</p>
+          <p class="p-heading--three p-heading-highlight--bottom__item">Leverage our support</p>
         </div>
         <p>
           We run a range of partner programmes to help you maximise revenue and efficiency from the opportunities Ubuntu provides.
@@ -84,9 +85,9 @@
     <div class="col-5">
       <h2>How we work with our partners</h2>
       <p>
-        By formalising their partnership with Canonical, technology companies of all kinds – from hardware makers and ISVs to cloud providers and mobile carriers – benefit from significant opportunities to increase their revenues with Ubuntu.
+        By formalising their partnership with Canonical, technology companies of all kinds &ndash; from hardware makers and ISVs to cloud providers and systems integrators &ndash benefit from significant opportunities to increase their revenues with Ubuntu.
       </p>
-      <p>We operate a range of partner programmes, from essential product certification to close collaboration, help with QA and long-term strategic alliances.</p>
+      <p>We operate a range of partner programmes, from essential product certification to strategic collaboration, help with QA and long-term strategic alliances.</p>
       <h2>Benefits of working with us</h2>
       <h3 class="p-muted-heading">Partnering with Canonical gives you:</h3>
       <hr />
@@ -96,7 +97,7 @@
         <li class="p-list__item is-ticked">Access to engineers who develop Ubuntu, equipping you to use it as a platform for innovation in your market</li>
         <li class="p-list__item is-ticked">Custom engineering covering any device enablement or platform customisation your ideas require</li>
         <li class="p-list__item is-ticked">Management of all third party licence fees and distribution agreements for content provided through Ubuntu</li>
-        <li class="p-list__item is-ticked">Substantial marketing benefits – Ubuntu has more than 20 million client users and it is an established leader in the cloud. By working with us, you’ll get to share in this growth</li>
+        <li class="p-list__item is-ticked">Substantial marketing benefits &ndash; Ubuntu has more than 20 million client users and it is an established leader in the cloud. By working with us, you’ll get to share in this growth.</li>
       </ul>
     </div>
     <div class="col-6 col-start-large-7">

--- a/templates/partners/thank-you.html
+++ b/templates/partners/thank-you.html
@@ -1,0 +1,21 @@
+{% extends 'base_index.html' %}
+
+{% block title %}Become a partner - Thank you{% endblock %}
+
+{% block meta_description %}Thank you for your interest in partnering with Ubuntu.{% endblock %}
+
+{% block content %}
+<section class="p-strip is-deep is-bordered">
+  <div class="row u-extra-space">
+    <div class="col-6">
+      <h1>Thank you!</h1>
+      <p>We’re really excited about your interest in partnering with Ubuntu.</p>
+      <p>A member of our team will contact you shortly.</p>
+      <p>In the meantime, you can read more information about our <a href="/partners">partner programmes</a> and our existing <a href="/partners/find-a-partner ">partners</a>.</p>
+    </div>
+    <div class="col-6">
+      <img src="https://assets.ubuntu.com/v1/0049554c-contact-us.svg" width="352" height="250" alt="Smile pictogram">
+    </div>
+  </div>
+</section>
+{% endblock %}


### PR DESCRIPTION
## Done

- Update become a partner page
- Add `/partners/thank-you` page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/partners/become-a-partner
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to [copy doc](https://docs.google.com/document/d/1Ihh9s3i72saCYaheXRVRn1Meg5lYN5U1gFbdvLMdWcc/edit)
- Go to `/partners/thank-you` and see the thank-you page. Note that the links on this page won't work properly as we have redirects to partners.ubuntu.com


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/2569
