### PR TITLE
Add channel-and-reseller page

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "concurrently": "5.1.0",
     "node-sass": "4.13.1",
     "postcss-cli": "7.1.0",
-    "vanilla-framework": "2.9.0",
+    "vanilla-framework": "2.9.1",
     "watch-cli": "0.2.3"
   },
   "devDependencies": {

--- a/static/sass/_pattern_strip.scss
+++ b/static/sass/_pattern_strip.scss
@@ -253,6 +253,11 @@
     background-blend-mode: multiply, multiply, normal, normal;
     // sass-lint:disable-block no-color-literals
     background-image: linear-gradient(to bottom left, rgba(228, 228, 228, 0.5) 0%, rgba(228, 228, 228, 0.5) 49%, rgba(228, 228, 228, 0) 50%, rgba(228, 228, 228, 0) 100%), linear-gradient(to bottom left, rgba(119, 41, 83, 0.16) 0%, rgba(119, 41, 83, 0.16) 49%, rgba(119, 41, 83, 0) 50%, rgba(119, 41, 83, 0) 100%), linear-gradient(to bottom right, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0) 49%, rgba(255, 255, 255, 1) 50%, rgba(255, 255, 255, 1) 100%), linear-gradient(90deg, rgba(60, 0, 30, 1) 4%, rgba(119, 41, 83, 1) 50%, rgba(233, 84, 32, 1) 88%);
+
+    @supports not (background-blend-mode: multiply) {
+      background-image: linear-gradient(to bottom left, rgba(228, 228, 228, 0.5) 0%, rgba(228, 228, 228, 0.5) 49%, rgba(228, 228, 228, 0) 50%, rgba(228, 228, 228, 0) 100%), linear-gradient(to bottom left, rgba(119, 41, 83, 0.16) 0%, rgba(119, 41, 83, 0.16) 49%, rgba(119, 41, 83, 0) 50%, rgba(119, 41, 83, 0) 100%), linear-gradient(to bottom right, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 0) 49%, rgba(255, 255, 255, 1) 50%, rgba(255, 255, 255, 1) 100%), linear-gradient(90deg, rgba(60, 0, 30, 1) 4%, rgba(119, 41, 83, 1) 50%, rgba(233, 84, 32, 1) 88%);
+    }
+
     background-position: top right, top right, top left, top left;
     background-repeat: no-repeat;
     background-size: 39.4% 6rem, 54% 4rem, 63% 4rem, 62.6% 4rem;

--- a/templates/partners/channel-and-reseller.html
+++ b/templates/partners/channel-and-reseller.html
@@ -1,0 +1,132 @@
+{% extends 'base_index.html' %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1rn2f4wL8wxnILlnmfchkNQV2RzsYUMcRaCfP-d6V_5Q{% endblock %}
+
+{% block title %}Channel&sol;Reseller Programme{% endblock %}
+
+{% block meta_description %}Canonical works with channel and reseller partners around the world to ensure that Canonical offerings are available for their customers.{% endblock %}
+
+{% block content %}
+<section class="p-strip--image is-dark">
+  <div class="p-strip--suru-top">
+    <div class="row">
+      <div class="col-8">
+        <h1>Channel&sol;Reseller Programme</h1>
+        <p>Canonical works with channel and reseller partners around the world to ensure that Canonical offerings are available for their customers. Additionally these partners can both resell services and value-added offerings around our technology enabling them to grow their business.</p>
+        <p>Canonical is an industry leader in OpenStack private clouds, the reference platform for all major public clouds, and the open source software operating system that runs from the desktop and all internet connected things. Our success helps our partners build a business around our technology.</p>
+        <a href="/partners/become-a-partner" class="p-button--positive">Apply to become a partner</a>
+      </div>
+      <div class="col-4 u-hide--small u-align--center u-vertically-center">
+        <img src="https://assets.ubuntu.com/v1/80472358-Canonical-reseller-icon.svg" alt="">
+      </div>
+    </div>
+  </div>
+</section>
+<style>
+  .p-strip--suru-top {
+    background-image:
+      linear-gradient(to bottom right, rgba(210, 180, 202, 0.05) 0%, rgba(210, 180, 202, 0.05) 49.9%, rgba(210, 180, 202, 0) 50%, rgba(210, 180, 202, 0) 100%),
+      linear-gradient(to top right, rgba(74, 24, 60, 0) 0%, rgba(74, 24, 60, 0) 49.9%, rgba(74, 24, 60, 0.34) 50%, rgba(74, 24, 60, 0.34) 100%),
+      linear-gradient(to top left, #f7f7f7 0%, #f7f7f7 49%, transparent 50%),
+      linear-gradient(230deg, #E95420 0%, #772953 33%, #2C001E 72%);
+    background-position: left top, right top, right bottom;
+    background-repeat: no-repeat;
+    background-size: 70% 80%, 70% 100%, 110% 20%, 100% 100%;
+    padding-bottom: 6rem;
+    padding-top: 3rem;
+  }
+
+  @media (max-width: 620px) {
+    .p-strip--suru-top {
+      background-image:
+        linear-gradient(to top right, rgba(74, 24, 60, 0) 0%, rgba(74, 24, 60, 0) 49.9%, rgba(74, 24, 60, 0.4) 50%, rgba(74, 24, 60, 0.4) 100%),
+        linear-gradient(to top left, #f7f7f7 0%, #f7f7f7 49%, transparent 50%),
+        linear-gradient(to bottom right, rgba(210, 180, 202, 0.05) 0%, rgba(210, 180, 202, 0.05) 49.9%, rgba(210, 180, 202, 0) 50%, rgba(210, 180, 202, 0) 100%),
+        linear-gradient(120deg, #2C001E 4%, #4C193E 100%);
+      background-position: right top, bottom right, top left, top left, center right;
+      background-repeat: no-repeat;
+      background-size: 100% 100%, 105% 25%, 70% 80%, 100% 100%;
+    }
+  }
+</style>
+<section class="p-strip--light is-shallow" style="margin-top: -1px;">
+  <div class="row">
+    <div class="col-8">
+      <p>Interested in becoming an Ubuntu partner? Talk to us today to learn more about our programmes.</p>
+    </div>
+    <div class="col-4">
+      <a href="/partners/become-a-partner" class="p-button--positive">Get in touch</a>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip is-deep">
+  <div class="u-fixed-width u-align--center">
+    <h4 class="p-muted-heading u-no-max-width">Meet some of our channel partners</h4>
+  </div>
+  <div class="u-fixed-width">
+    <ul class="p-inline-images u-no-margin--bottom">
+      <li class="p-inline-images__item">
+        <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/cb3fcdfb-lenovo.svg" alt="Lenovo">
+      </li>
+      <li class="p-inline-images__item" style="display: inline; padding-top: 0.5rem;">
+        <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/d258d23b-2018-logo-dell.svg" alt="Dell">
+      </li>
+      <li class="p-inline-images__item">
+        <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/a82add58-profile-aws.svg" alt="Amazon Web Services">
+      </li>
+    </ul>
+    <p class="u-align-text--center"><a href="/partners/find-a-partner?filters=channel">See all Channel partners&nbsp;&rsaquo;</a></p>
+  </div>
+</section>
+
+<section class="p-strip--light is-deep">
+  <div class="u-fixed-width u-sv3">
+    <h2>What does Canonical’s channel partner programme offer?</h2>
+  </div>
+  <div class="row">
+    <div class="col-4 p-card--highlighted">
+      <h3 class="p-card__title p-heading--four">Rich portfolio of products</h3>
+      <p>Resell the full range of Canonical&rsquo;s portfolio of private and public cloud products: Openstack, Kubernetes, IoT, support, security and compliance for Ubuntu.</p>
+    </div>
+    <div class="col-4 p-card--highlighted">
+      <h3 class="p-card__title p-heading--four">Sales enablement</h3>
+      <p>Canonical can help train your field sales and presales teams and provide you with sales collateral and permission to use the Canonical and Ubuntu trademarks in your own materials.</p>
+    </div>
+    <div class="col-4 p-card--highlighted">
+      <h3 class="p-card__title p-heading--four">Access to Canonical partner portal</h3>
+      <p>We host a partner portal with product and solutions collaterals, agreed pricing, incentives and a deal registration system.</p>
+    </div>
+    <div class="col-4 p-card--highlighted">
+      <h3 class="p-card__title p-heading--four">Training and certification</h3>
+      <p>Gain access to technology that is the foundation for digital transformation and expand your business through marketing support and alignment with a trusted brand</p>
+    </div>
+    <div class="col-4 p-card--highlighted">
+      <h3 class="p-card__title p-heading--four">Technical enablement</h3>
+      <p>We provide in depth technical training for your customer engineering teams with access to technical resources for your labs and customer engagements.</p>
+    </div>
+    <div class="col-4 p-card--highlighted">
+      <h3 class="p-card__title p-heading--four">Go to market with Canonical</h3>
+      <p>Working with our dedicated partner team, get new joint marketing opportunities and lead generation.</p>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip is-deep">
+  <div class="u-fixed-width">
+    <h2>Co-sell with Canonical through the partner portal</h2>
+  </div>
+  <div class="row">
+    <div class="col-6">
+      <p>Open source technology is growing in demand. We want you to benefit from this unique opportunity, and take advantage of the investment Canonical is making in its partner community. We are committed to giving you the tools and programs to succeed, from discounts and financial incentives, to sales and technical support teams.</p>
+      <p><a href="/partners">Find out more about our partners&nbsp;&rsaquo;</a></p>
+    </div>
+    <div class="col-5 col-start-large-8 u-vertically-center u-hide--small">
+      <img src="https://assets.ubuntu.com/v1/da448671-laptop-find-partner-sml2.png" alt="Photo of laptop running Ubuntu" width="413" height="256">
+    </div>
+  </div>
+</section>
+
+{% include 'partial/_partners-footer.html' %}
+
+{% endblock %}

--- a/templates/partners/channel-and-reseller.html
+++ b/templates/partners/channel-and-reseller.html
@@ -14,7 +14,6 @@
         <h1>Channel&sol;Reseller Programme</h1>
         <p>Canonical works with channel and reseller partners around the world to ensure that Canonical offerings are available for their customers. Additionally these partners can both resell services and value-added offerings around our technology enabling them to grow their business.</p>
         <p>Canonical is an industry leader in OpenStack private clouds, the reference platform for all major public clouds, and the open source software operating system that runs from the desktop and all internet connected things. Our success helps our partners build a business around our technology.</p>
-        <a href="/partners/become-a-partner" class="p-button--positive">Apply to become a partner</a>
       </div>
       <div class="col-4 u-hide--small u-align--center u-vertically-center">
         <img src="https://assets.ubuntu.com/v1/80472358-Canonical-reseller-icon.svg" alt="">

--- a/templates/partners/cloud.html
+++ b/templates/partners/cloud.html
@@ -42,7 +42,7 @@
   </div>
 
   <div class="u-fixed-width u-align--center">
-    <h4 class="p-muted-heading" style="max-width: none;">A selection of our cloud partners</h4>
+    <h4 class="p-muted-heading u-no-max-width">A selection of our cloud partners</h4>
   </div>
   <div class="u-fixed-width">
     <ul class="p-inline-images u-no-margin--bottom">
@@ -71,7 +71,7 @@
         <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/d4d3cd69-Joyent+logo.svg" alt="Joyent">
       </li>
     </ul>
-    <p class="u-align-text--center"><a href="/partners/find-a-partner?filters=certified-public-cloud">See all public cloud partners&nbsp;&rsaquo;</a></p>
+    <p class="u-align-text--center"><a href="/partners/find-a-partner?filters=certified-public-cloud">See all Public Cloud partners&nbsp;&rsaquo;</a></p>
   </div>
 </section>
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3232,10 +3232,10 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
-vanilla-framework@2.9.0:
-  version "2.9.0"
-  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.9.0.tgz#8ac58ee7623cbad780eced886e43a04776e4595d"
-  integrity sha512-FsKPFt+39roDCgImve3RI0ont2qcQhIigEQpeBdmrYXh/+cgjRTKqigeBbUf7CsR0RUOzbvQJZkQXivRC0QT9g==
+vanilla-framework@2.9.1:
+  version "2.9.1"
+  resolved "https://registry.yarnpkg.com/vanilla-framework/-/vanilla-framework-2.9.1.tgz#d2d0d4b39936651bcf7ce5c32d801aa4a9d3e8fc"
+  integrity sha512-Ax59BOjsoHuZX80vYD0oVRsgUwXWRpQ8y3F7+m+CW6jquHHG6GVdkpnmQL19qNsmp5JuzxHAprDxj3wn28reWA==
 
 verbalize@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
## Done

- Add `/partners/channel-and-reseller` page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/partners/channel-and-reseller
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to [copy doc](https://docs.google.com/document/d/1rn2f4wL8wxnILlnmfchkNQV2RzsYUMcRaCfP-d6V_5Q)


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/2567
