### PR TITLE
Add IHV and OEM partners page

### DIFF
--- a/templates/partners/ihv-and-oem.html
+++ b/templates/partners/ihv-and-oem.html
@@ -1,0 +1,157 @@
+{% extends 'base_index.html' %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1p8Et43R14AGiFn9g7ro9VLXZh26gph9Kk5K6_lc8W8U{% endblock %}
+
+{% block title %}IHV and OEM Programme{% endblock %}
+
+{% block meta_description %}Pioneering open source for the modern data center. For nearly two decades, Canonical and our enterprise partners have provided market-leading solutions for customers seeking alternatives to complex and costly proprietary operating environments.{% endblock %}
+
+{% block content %}
+<section class="p-strip--image is-dark">
+  <div class="p-strip--suru-top">
+    <div class="row">
+      <div class="col-8">
+        <h1>IHV and OEM Programme</h1>
+        <p>Pioneering open source for the modern data center.</p>
+        <p>For nearly two decades, Canonical and our enterprise partners have provided market&dash;leading solutions for customers seeking alternatives to complex and costly proprietary operating environments. Along the way, we have pioneered open source technologies for modern data centers. Whether you&rsquo;re building physical, virtual, or cloud environments, you can be confident in our tested and certified joint partner solutions.</p>
+        <a href="/partners/become-a-partner" class="p-button--positive">Get in touch</a>
+      </div>
+      <div class="col-4 u-hide--small u-align--center u-vertically-center">
+        <img src="https://assets.ubuntu.com/v1/0cf81aee-servers-wht.svg" alt="">
+      </div>
+    </div>
+  </div>
+</section>
+<style>
+  .p-strip--suru-top {
+    background-image:
+      linear-gradient(to top right, #fff 0%, #fff 49%, transparent 50%),
+      linear-gradient(to top right, rgba(74, 24, 60, 0) 0%, rgba(74, 24, 60, 0) 49.9%, rgba(74, 24, 60, 0.3) 50%, rgba(74, 24, 60, 0.3) 100%),
+      linear-gradient(to bottom right, rgba(210, 180, 202, 0.05) 0%, rgba(210, 180, 202, 0.05) 49.9%, rgba(210, 180, 202, 0) 50%, rgba(210, 180, 202, 0) 100%),
+      linear-gradient(216deg, #E95420 0%, #5E2750 33%, #2C001E 71%);
+    background-repeat: no-repeat;
+    background-size: 110% 10%, 70% 100%, 100% 40%, 100% 100%;
+    background-position: bottom -0.2px left, top right, top left;
+    padding-bottom: 6rem;
+    padding-top: 3rem;
+  }
+
+  @media (max-width: 772px) {
+    .p-strip--suru-top {
+      background-image:
+        linear-gradient(to top right, #fff 0%, #fff 49%, transparent 50%),
+        linear-gradient(to top right, rgba(74, 24, 60, 0) 0%, rgba(74, 24, 60, 0) 49.9%, rgba(74, 24, 60, 0.3) 50%, rgba(74, 24, 60, 0.3) 100%),
+        linear-gradient(to bottom right, rgba(210, 180, 202, 0.05) 0%, rgba(210, 180, 202, 0.05) 49.9%, rgba(210, 180, 202, 0) 50%, rgba(210, 180, 202, 0) 100%),
+        linear-gradient(216deg, #E95420 0%, #5E2750 33%, #2C001E 71%);
+      background-repeat: no-repeat;
+      background-size: 105% 5%, 70% 100%, 100% 40%, 100% 100%;
+      background-position: bottom -1px left, top right, top left;
+    }
+  }
+</style>
+
+<section class="p-strip is-deep">
+  <div class="u-fixed-width u-align--center">
+    <h4 class="p-muted-heading u-no-max-width">A selection of our Hardware partners</h4>
+  </div>
+  <div class="u-fixed-width">
+    <ul class="p-inline-images u-no-margin--bottom">
+    {% for partner in partners %}
+      <li class="p-inline-images__item">
+        <img class="p-inline-images__logo" src="{{ partner.logo }}" alt="{{ partner.slug}}">
+      </li>
+    {% endfor %}
+    </ul>
+    <p class="u-align-text--center"><a href="/partners/find-a-partner?filters=hardware">See all Hardware partners&nbsp;&rsaquo;</a></p>
+  </div>
+</section>
+
+<section class="p-strip--light is-deep">
+  <div class="u-fixed-width u-sv3">
+    <h2>Benefits of the IHV and OEM Partner Programme</h2>
+  </div>
+  <div class="row">
+    <div class="col-4 p-card--highlighted">
+      <h3 class="p-card__title p-heading--four">Certification</h3>
+      <ul class="p-list">
+        <li class="p-list__item is-ticked">Promote your hardware as ‘Ubuntu Certified’</li>
+        <li class="p-list__item is-ticked">Assistance to test, review, and configure machines to be Ubuntu Certified</li>
+        <li class="p-list__item is-ticked">Public postings on our Ubuntu Certified hardware page</li>
+      </ul>
+    </div>
+    <div class="col-4 p-card--highlighted">
+      <h3 class="p-card__title p-heading--four">Sales enablement access</h3>
+      <ul class="p-list">
+        <li class="p-list__item is-ticked">Opportunity registration</li>
+        <li class="p-list__item is-ticked">Sales assets</li>
+        <li class="p-list__item is-ticked">Pricing and packaging lists</li>
+        <li class="p-list__item is-ticked">Sales training</li>
+      </ul>
+    </div>
+    <div class="col-4 p-card--highlighted">
+      <h3 class="p-card__title p-heading--four">Joint marketing</h3>
+      <ul class="p-list">
+        <li class="p-list__item is-ticked">Tailored campaigns</li>
+        <li class="p-list__item is-ticked">Access technical guides to enhance team’s knowledge</li>
+        <li class="p-list__item is-ticked">Marketing funding for joint events</li>
+        <li class="p-list__item is-ticked">Logos and joint branding</li>
+      </ul>
+    </div>
+    <div class="col-4 p-card--highlighted">
+      <h3 class="p-card__title p-heading--four">Dedicated partner team</h3>
+      <ul class="p-list">
+        <li class="p-list__item is-ticked">Named resources within Canonical for alliances, sales, technical training, marketing and certification</li>
+      </ul>
+    </div>
+    <div class="col-4 p-card--highlighted">
+      <h3 class="p-card__title p-heading--four">Reference architecture</h3>
+      <ul class="p-list">
+        <li class="p-list__item is-ticked">Develop joint hardware based reference architectures for predictable and repeatable customer deployments</li>
+      </ul>
+    </div>
+    <div class="col-4 p-card--highlighted">
+      <h3 class="p-card__title p-heading--four">Roadmap alignment</h3>
+      <ul class="p-list">
+        <li class="p-list__item is-ticked">Weekly alignment calls with alliances and certification team</li>
+        <li class="p-list__item is-ticked">Bi-annual product roadmap review sessions to plan for upcoming releases</li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip is-deep is-bordered">
+  <div class="row">
+    <div class="col-6 u-vertically-center">
+      <img src="https://assets.ubuntu.com/v1/729c18b3-certificates.svg" alt="Certified Ubuntu">
+    </div>
+    <div class="col-6">
+      <h2>Increase your sales by becoming Ubuntu Certified</h2>
+      <p>
+        Our users have a high level of expectation in their experience with Ubuntu. Whether at home, in development, or production, an easy and predictable user experience is important to us. To ensure this success, we partner closely with server vendors worldwide to test, validate, and certify their portfolios.
+      </p>
+      <p>
+        The top 7 servers manufacturers in the world are all regularly engaged with Canonical on promoting their platforms as Ubuntu Certified.
+      </p>
+      <a href="https://certification.ubuntu.com/certification" class="p-link--external">Learn more about Ubuntu certified hardware&nbsp;&rsaquo;</a>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip is-deep">
+  <div class="u-fixed-width">
+    <h2>Co-sell with Canonical through the partner portal</h2>
+  </div>
+  <div class="row">
+    <div class="col-6">
+      <p>Open source technology is growing in demand. We want you to benefit from this unique opportunity, and take advantage of the investment Canonical is making in its partner community. We are committed to giving you the tools and programs to succeed, from discounts and financial incentives, to sales and technical support teams.</p>
+      <p><a href="/partners">Find out more about our partners&nbsp;&rsaquo;</a></p>
+    </div>
+    <div class="col-5 col-start-large-8 u-vertically-center u-hide--small">
+      <img src="https://assets.ubuntu.com/v1/da448671-laptop-find-partner-sml2.png" alt="Photo of laptop running Ubuntu" width="413" height="256">
+    </div>
+  </div>
+</section>
+
+{% include 'partial/_partners-footer.html' %}
+
+{% endblock %}

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -37,6 +37,16 @@ class TestRoutes(unittest.TestCase):
 
         self.assertEqual(self.client.get("/careers/foo").status_code, 404)
 
+    def test_partners_detail_pages(self):
+        """
+        When given the URL of a valid parters detail page,
+        we should return a 200 status code
+        """
+
+        self.assertEqual(
+            self.client.get("/partners/ihv-and-oem").status_code, 200
+        )
+
     def test_not_found(self):
         """
         When given a non-existent URL,

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -153,6 +153,16 @@ def find_a_partner():
     )
 
 
+@app.route("/partners/ihv-and-oem")
+def partner_details():
+    partners = partners_api._get(
+        partners_api.partner_page_map[flask.request.path.split("/")[2]]
+    )
+    return flask.render_template(
+        "/partners/ihv-and-oem.html", partners=partners
+    )
+
+
 # Template finder
 template_finder_view = TemplateFinder.as_view("template_finder")
 app.add_url_rule("/<path:subpath>", view_func=template_finder_view)

--- a/webapp/partners.py
+++ b/webapp/partners.py
@@ -1,6 +1,8 @@
 class Partners:
     base_url = "https://partners.ubuntu.com/partners.json"
 
+    partner_page_map = {"ihv-and-oem": "programme__name=IHV"}
+
     def __init__(self, session):
         self.session = session
 


### PR DESCRIPTION
## Done

- Add IHV and OEM partners page
## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/partners/ihv-and-oem
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to [copy doc](https://docs.google.com/document/d/1p8Et43R14AGiFn9g7ro9VLXZh26gph9Kk5K6_lc8W8U/edit#)


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/2565

## Screenshots

[if relevant, include a screenshot]