### PR TITLE
Refactor API access of metadata to be more resilient

### DIFF
--- a/static/js/careers-filter-and-sort.js
+++ b/static/js/careers-filter-and-sort.js
@@ -29,7 +29,7 @@
           filterJobs(filterBy, jobList);
           updateNoResultsMessage();
         }
-        
+
         filterSelect.addEventListener("change", function () {
           if (!(sortSelect.options.selectedIndex === 0)) {
             sortSelect.options.selectedIndex = 0;
@@ -81,7 +81,7 @@
         }
         numberOfJobsDisplayed = domList.childElementCount;
       } else {
-        if (filterBy.filterText === node.dataset[filterBy.filterName]) {
+        if (node.dataset[filterBy.filterName].includes(filterBy.filterText)) {
           if (node.classList.contains("u-hide")) {
             node.classList.remove("u-hide");
           }
@@ -109,7 +109,7 @@
         break;
       case "management":
         filterBy.filterName = "management";
-        filterBy.filterText = "Management";
+        filterBy.filterText = "True";
         filterBy.filterValue = "management";
         break;
       case "full-time":
@@ -144,7 +144,7 @@
 
   function updateURL(filterBy) {
     var baseURL = window.location.origin + window.location.pathname;
-    
+
     urlParams.set('filter', filterBy.filterValue);
 
     var url = baseURL + '?' + urlParams.toString() + '#available-roles';

--- a/webapp/greenhouse.py
+++ b/webapp/greenhouse.py
@@ -8,6 +8,13 @@ from html import unescape
 
 base_url = "https://boards-api.greenhouse.io/v1/boards/Canonical/jobs"
 
+metadata_map = {
+    "management": 186225,
+    "employment": 149021,
+    "department": 155450,
+    "skills": 675557,
+}
+
 
 def _parse_feed_department(feed_department):
     field = {
@@ -33,11 +40,14 @@ class Greenhouse:
         path_department = department.replace("-", "")
         vacancies = []
         for job in feed["jobs"]:
-            if job["metadata"][2]["value"]:
+            if job["metadata"][2]["value"] and job["offices"]:
                 feed_department = _parse_feed_department(
                     job["metadata"][2]["value"].replace("-", "")
                 )
-                if path_department.lower() == "all":
+                if (
+                    path_department.lower() == "all"
+                    or path_department.lower() == feed_department.lower()
+                ):
                     vacancies.append(
                         {
                             "title": job["title"],
@@ -45,25 +55,16 @@ class Greenhouse:
                             "url": job["absolute_url"],
                             "location": job["location"]["name"],
                             "id": job["id"],
-                            "employment": job["metadata"][0]["value"],
-                            "date": job["metadata"][1]["value"],
-                            "department": job["metadata"][2]["value"],
-                            "management": job["metadata"][3]["value"],
-                            "office": job["offices"][0]["name"],
-                        }
-                    )
-                elif path_department.lower() == feed_department.lower():
-                    vacancies.append(
-                        {
-                            "title": job["title"],
-                            "content": unescape(job["content"]),
-                            "url": job["absolute_url"],
-                            "location": job["location"]["name"],
-                            "id": job["id"],
-                            "employment": job["metadata"][0]["value"],
-                            "date": job["metadata"][1]["value"],
-                            "department": job["metadata"][2]["value"],
-                            "management": job["metadata"][3]["value"],
+                            "employment": self.get_metadata_value(
+                                job["metadata"], "employment"
+                            ),
+                            "date": job["updated_at"],
+                            "department": self.get_metadata_value(
+                                job["metadata"], "department"
+                            ),
+                            "management": self.get_metadata_value(
+                                job["metadata"], "management"
+                            ),
                             "office": job["offices"][0]["name"],
                         }
                     )
@@ -73,9 +74,15 @@ class Greenhouse:
         feed = self.session.get(f"{base_url}?content=true").json()
         vacancies = []
         for job in feed["jobs"]:
+            job_core_skills = self.get_metadata_value(
+                job["metadata"], "skills"
+            )
+            job_offices = ""
+            if job["offices"]:
+                job_offices = job["offices"][0]["name"]
             for skill in core_skills:
-                if job["metadata"][5]["value"]:
-                    if skill in job["metadata"][5]["value"]:
+                if job_core_skills:
+                    if skill in job_core_skills:
                         vacancies.append(
                             {
                                 "title": job["title"],
@@ -83,17 +90,29 @@ class Greenhouse:
                                 "url": job["absolute_url"],
                                 "location": job["location"]["name"],
                                 "id": job["id"],
-                                "employment": job["metadata"][0]["value"],
-                                "date": job["metadata"][1]["value"],
-                                "department": job["metadata"][2]["value"],
-                                "management": job["metadata"][3]["value"],
-                                "office": job["offices"][0]["name"],
-                                "core_skills": job["metadata"][5]["value"],
+                                "employment": self.get_metadata_value(
+                                    job["metadata"], "employment"
+                                ),
+                                "date": job["updated_at"],
+                                "department": self.get_metadata_value(
+                                    job["metadata"], "department"
+                                ),
+                                "management": self.get_metadata_value(
+                                    job["metadata"], "management"
+                                ),
+                                "office": job_offices,
+                                "core_skills": job_core_skills,
                             }
                         )
                         break
 
         return vacancies
+
+    def get_metadata_value(self, job_metadata, metadata_key):
+        for data in job_metadata:
+            if data["id"] == metadata_map[metadata_key]:
+                return data["value"]
+        return None
 
     def get_vacancy(self, job_id):
         feed = self.session.get(f"{base_url}/{job_id}?questions=true").json()


### PR DESCRIPTION
## Done
Made the access to the metadata object query by id instead of index in the returned payload. If the id is not found `None` is returned instead of index out of bounds which causes a 500.

Also, fixed all the filters in the job listing view.

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/careers
- Click through all the departments and check the roles list works for all of them
- Then try the All roles at the bottom and check that renders ok
- Use the filter and sort options and check they do what you expect
- Click on Careers in the main navigation then click "Explore a career at Canonical"
- Play the game and see the resulting list of jobs is rendered without 500
- Check filters and sort work here too.

## Issue / Card
Fixes https://github.com/canonical-web-and-design/canonical.com/issues/222
