### PR TITLE
Update homepage partner logos

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -238,7 +238,7 @@
           <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/c873297d-hp-enterprise.svg" width="130" height="54" alt="HP Enterprise logo">
         </li>
         <li class="p-inline-images__item">
-          <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/75521214-Google-cloud-platform.svg" width="144" height="16" alt="Google Cloud logo" style="max-width: 275px;">
+          <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/bb3de557-Supermicro_GreenC_NewLogo_WhiteBackground.svg" width="144" height="79" alt="Super Micro Computer logo" style="width: 144px;">
         </li>
         <li class="p-inline-images__item">
           <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/e6e2deaf-oracle.svg" width="144" height="25" alt="Oracle logo">
@@ -256,7 +256,7 @@
           <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/1a0f2422-sandisk.svg" width="144" height="30" alt="Sandisk logo">
         </li>
         <li class="p-inline-images__item">
-          <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/ae6e3e91-AmazonWS.svg" width="132" height="51" alt="AWS logo">
+          <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/a82add58-profile-aws.svg" width="85" height="50" style="height:50px;" alt="AWS logo">
         </li>
         <li class="p-inline-images__item">
           <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/5ddba83a-logo-dell.svg" width="70" height="70" alt="Dell logo" style="max-width: 70px;">
@@ -284,9 +284,6 @@
         </li>
         <li class="p-inline-images__item">
           <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/b32990e3-verizon.svg" width="121" height="38" alt="Verizon logo">
-        </li>
-        <li class="p-inline-images__item">
-          <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/e3914def-partner-logo-azure.svg" width="144" height="42" alt="Microsoft Azure logo">
         </li>
         <li class="p-inline-images__item">
           <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/a78cad70-china-telecom.svg" width="135" height="38" alt="China Telecom logo">


### PR DESCRIPTION
## Done

- Update homepage partner logos

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that aws has a new logos, super micro is there, google is not there and azure is not there


## Issue / Card

Fixes #236

## Screenshots

![image](https://user-images.githubusercontent.com/441217/83331289-1e42bc80-a28d-11ea-9059-4e5b7884d35c.png)
