### PR TITLE
Fix up channel and gsi logo clouds

### DIFF
--- a/static/sass/_pattern_strip.scss
+++ b/static/sass/_pattern_strip.scss
@@ -9,6 +9,7 @@
   @include canonical-p-strip-suru-bottomed;
   @include canonical-p-strip-suru-half-and-half-reversed;
   @include canonical-p-strip-suru-topped;
+  @include canonical-p-strip-suru-top;
 
   .p-strip {
     background-color: $color-x-light;
@@ -263,5 +264,33 @@
     background-size: 39.4% 6rem, 54% 4rem, 63% 4rem, 62.6% 4rem;
     padding-bottom: 4rem;
     padding-top: 6rem;
+  }
+}
+
+@mixin canonical-p-strip-suru-top {
+  .p-strip--suru-top {
+    background-image:
+      linear-gradient(to bottom right, rgba(210, 180, 202, 0.05) 0%, rgba(210, 180, 202, 0.05) 49.9%, rgba(210, 180, 202, 0) 50%, rgba(210, 180, 202, 0) 100%),
+      linear-gradient(to top right, rgba(74, 24, 60, 0) 0%, rgba(74, 24, 60, 0) 49.9%, rgba(74, 24, 60, 0.34) 50%, rgba(74, 24, 60, 0.34) 100%),
+      linear-gradient(to top left, #f7f7f7 0%, #f7f7f7 49%, transparent 50%),
+      linear-gradient(230deg, #E95420 0%, #772953 33%, #2C001E 72%);
+    background-position: left top, right top, right bottom;
+    background-repeat: no-repeat;
+    background-size: 70% 80%, 70% 100%, 110% 20%, 100% 100%;
+    padding-bottom: 6rem;
+    padding-top: 3rem;
+  }
+
+  @media (max-width: 620px) {
+    .p-strip--suru-top {
+      background-image:
+        linear-gradient(to top right, rgba(74, 24, 60, 0) 0%, rgba(74, 24, 60, 0) 49.9%, rgba(74, 24, 60, 0.4) 50%, rgba(74, 24, 60, 0.4) 100%),
+        linear-gradient(to top left, #f7f7f7 0%, #f7f7f7 49%, transparent 50%),
+        linear-gradient(to bottom right, rgba(210, 180, 202, 0.05) 0%, rgba(210, 180, 202, 0.05) 49.9%, rgba(210, 180, 202, 0) 50%, rgba(210, 180, 202, 0) 100%),
+        linear-gradient(120deg, #2c001e 4%, #4c193e 100%);
+      background-position: right top, bottom right, top left, top left, center right;
+      background-repeat: no-repeat;
+      background-size: 100% 100%, 105% 25%, 70% 80%, 100% 100%;
+    }
   }
 }

--- a/static/sass/_pattern_strip.scss
+++ b/static/sass/_pattern_strip.scss
@@ -273,7 +273,7 @@
       linear-gradient(to bottom right, rgba(210, 180, 202, 0.05) 0%, rgba(210, 180, 202, 0.05) 49.9%, rgba(210, 180, 202, 0) 50%, rgba(210, 180, 202, 0) 100%),
       linear-gradient(to top right, rgba(74, 24, 60, 0) 0%, rgba(74, 24, 60, 0) 49.9%, rgba(74, 24, 60, 0.34) 50%, rgba(74, 24, 60, 0.34) 100%),
       linear-gradient(to top left, #f7f7f7 0%, #f7f7f7 49%, transparent 50%),
-      linear-gradient(230deg, #E95420 0%, #772953 33%, #2C001E 72%);
+      linear-gradient(230deg, #e95420 0%, #772953 33%, #2c001e 72%);
     background-position: left top, right top, right bottom;
     background-repeat: no-repeat;
     background-size: 70% 80%, 70% 100%, 110% 20%, 100% 100%;

--- a/templates/partners/channel-and-reseller.html
+++ b/templates/partners/channel-and-reseller.html
@@ -43,7 +43,7 @@
     <ul class="p-inline-images u-no-margin--bottom">
       {% for partner in partners %}
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logo" src="{{ partner.logo }}" alt="{{ partner.slug}}">
+        <img class="p-inline-images__logo" src="{{ partner.logo }}" style="min-width: 145px;" alt="{{ partner.slug}}">
       </li>
       {% endfor %}
     </ul>

--- a/templates/partners/channel-and-reseller.html
+++ b/templates/partners/channel-and-reseller.html
@@ -22,33 +22,7 @@
     </div>
   </div>
 </section>
-<style>
-  .p-strip--suru-top {
-    background-image:
-      linear-gradient(to bottom right, rgba(210, 180, 202, 0.05) 0%, rgba(210, 180, 202, 0.05) 49.9%, rgba(210, 180, 202, 0) 50%, rgba(210, 180, 202, 0) 100%),
-      linear-gradient(to top right, rgba(74, 24, 60, 0) 0%, rgba(74, 24, 60, 0) 49.9%, rgba(74, 24, 60, 0.34) 50%, rgba(74, 24, 60, 0.34) 100%),
-      linear-gradient(to top left, #f7f7f7 0%, #f7f7f7 49%, transparent 50%),
-      linear-gradient(230deg, #E95420 0%, #772953 33%, #2C001E 72%);
-    background-position: left top, right top, right bottom;
-    background-repeat: no-repeat;
-    background-size: 70% 80%, 70% 100%, 110% 20%, 100% 100%;
-    padding-bottom: 6rem;
-    padding-top: 3rem;
-  }
 
-  @media (max-width: 620px) {
-    .p-strip--suru-top {
-      background-image:
-        linear-gradient(to top right, rgba(74, 24, 60, 0) 0%, rgba(74, 24, 60, 0) 49.9%, rgba(74, 24, 60, 0.4) 50%, rgba(74, 24, 60, 0.4) 100%),
-        linear-gradient(to top left, #f7f7f7 0%, #f7f7f7 49%, transparent 50%),
-        linear-gradient(to bottom right, rgba(210, 180, 202, 0.05) 0%, rgba(210, 180, 202, 0.05) 49.9%, rgba(210, 180, 202, 0) 50%, rgba(210, 180, 202, 0) 100%),
-        linear-gradient(120deg, #2c001e 4%, #4c193e 100%);
-      background-position: right top, bottom right, top left, top left, center right;
-      background-repeat: no-repeat;
-      background-size: 100% 100%, 105% 25%, 70% 80%, 100% 100%;
-    }
-  }
-</style>
 <section class="p-strip--light is-shallow" style="margin-top: -1px;">
   <div class="row">
     <div class="col-8">
@@ -60,6 +34,7 @@
   </div>
 </section>
 
+{% if not partners %}
 <section class="p-strip is-deep">
   <div class="u-fixed-width u-align--center">
     <h4 class="p-muted-heading u-no-max-width">Meet some of our channel/reseller partners</h4>
@@ -75,6 +50,7 @@
     <p class="u-align-text--center"><a href="/partners/find-a-partner?filters=channel-reseller">See all of our channel/reseller partners&nbsp;&rsaquo;</a></p>
   </div>
 </section>
+{% endif %}
 
 <section class="p-strip--light is-deep">
   <div class="u-fixed-width u-sv3">

--- a/templates/partners/gsi.html
+++ b/templates/partners/gsi.html
@@ -21,6 +21,24 @@
   </div>
 </section>
 
+{% if not partners %}
+<section class="p-strip is-deep">
+  <div class="u-fixed-width u-align--center">
+    <h4 class="p-muted-heading u-no-max-width">Meet some of our global system integrator partners</h4>
+  </div>
+  <div class="u-fixed-width">
+    <ul class="p-inline-images u-no-margin--bottom">
+      {% for partner in partners %}
+      <li class="p-inline-images__item">
+        <img class="p-inline-images__logo" src="{{ partner.logo }}" alt="{{ partner.slug}}">
+      </li>
+      {% endfor %}
+    </ul>
+    <p class="u-align-text--center"><a href="/partners/find-a-partner?filters=gsi">See all of our gsi partners&nbsp;&rsaquo;</a></p>
+  </div>
+</section>
+{% endif %}
+
 <section class="p-strip--light is-deep">
   <div class="u-fixed-width">
     <h2>Grow with Canonical</h2>

--- a/templates/partners/gsi.html
+++ b/templates/partners/gsi.html
@@ -30,7 +30,7 @@
     <ul class="p-inline-images u-no-margin--bottom">
       {% for partner in partners %}
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logo" src="{{ partner.logo }}" alt="{{ partner.slug}}">
+        <img class="p-inline-images__logo" src="{{ partner.logo }}" style="min-width: 145px;" alt="{{ partner.slug}}">
       </li>
       {% endfor %}
     </ul>

--- a/webapp/partners.py
+++ b/webapp/partners.py
@@ -2,7 +2,8 @@ class Partners:
     base_url = "https://partners.ubuntu.com/partners.json"
 
     partner_page_map = {
-        "channel-and-reseller": "programme__name=Channel%20/%20Reseller&featured=true",
+        "channel-and-reseller": "programme__name=Channel%20/%20Reseller"
+        "&featured=true",
         "desktop": "programme__name=Desktop&featured=true",
         "devices-and-iot": "programme__name=Internet%20of%20Things"
         "&featured=true",

--- a/webapp/partners.py
+++ b/webapp/partners.py
@@ -2,7 +2,7 @@ class Partners:
     base_url = "https://partners.ubuntu.com/partners.json"
 
     partner_page_map = {
-        "channel-and-reseller": "programme__name=Channel%20/%20Reseller",
+        "channel-and-reseller": "programme__name=Channel%20/%20Reseller&featured=true",
         "desktop": "programme__name=Desktop&featured=true",
         "devices-and-iot": "programme__name=Internet%20of%20Things"
         "&featured=true",


### PR DESCRIPTION
## Done

- Logo clouds only appear if there are 2 or more featured partners.  For channel-and-reseller and gsi I hid the strip if there are no partners
- I moved the suru css into the scss strip file


## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/partners/channel-and-reseller
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that http://0.0.0.0:8002/partners/channel-and-reseller and http://0.0.0.0:8002/partners/gsi have no logo clouds or empty ones


## Issue / Card

Fixes #238

