### PR TITLE
Fix desktop partners logos

### DIFF
--- a/templates/partners/desktop.html
+++ b/templates/partners/desktop.html
@@ -19,7 +19,7 @@
         <ul class="p-inline-images">
           {% for partner in partners %}
           <li class="p-inline-images__item">
-            <img class="p-inline-images__logo" src="{{ partner.logo }}" alt="{{ partner.slug}}">
+            <img class="p-inline-images__logo" src="{{ partner.logo }}" style="min-width: 145px;" alt="{{ partner.slug}}">
           </li>
           {% endfor %}
         </ul>

--- a/templates/partners/devices-and-iot.html
+++ b/templates/partners/devices-and-iot.html
@@ -27,7 +27,7 @@
       <ul class="p-inline-images">
         {% for partner in partners %}
         <li class="p-inline-images__item">
-          <img class="p-inline-images__logo" src="{{ partner.logo }}" alt="{{ partner.slug}}">
+          <img class="p-inline-images__logo" src="{{ partner.logo }}" style="min-width: 145px;" alt="{{ partner.slug}}">
         </li>
         {% endfor %}
       </ul>

--- a/templates/partners/find-a-partner.html
+++ b/templates/partners/find-a-partner.html
@@ -166,7 +166,7 @@
             <a href="/{{ partner['slug'] }}">
             {% endif %}
             {% if partner['logo'] %}
-              <img src="{{ partner['logo'] }}" alt="image for {{ partner['name'] }}" style="max-height: 3rem; max-width: 15rem;" loading="lazy">
+              <img src="{{ partner['logo'] }}" alt="image for {{ partner['name'] }}" style="max-height: 3rem; max-width: 15rem; min-width: 145px;" loading="lazy">
 
             {% endif %}
             </a>

--- a/templates/partners/ihv-and-oem.html
+++ b/templates/partners/ihv-and-oem.html
@@ -58,7 +58,7 @@
     <ul class="p-inline-images u-no-margin--bottom">
     {% for partner in partners %}
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logo" src="{{ partner.logo }}" alt="{{ partner.slug}}">
+        <img class="p-inline-images__logo" src="{{ partner.logo }}" style="min-width: 145px;" alt="{{ partner.slug}}">
       </li>
     {% endfor %}
     </ul>


### PR DESCRIPTION
## Done

- Fix desktop partners logos
- Add min-width on logo img tags as some svgs have no size and therefore do not appear

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/partners/desktop
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See HP, Dell, Lenovo logos


## Issue / Card

Fixes #237
