### PR TITLE
Remove programmes not on the site from the /partners/find-a-partner filter

### DIFF
--- a/templates/partners/find-a-partner.html
+++ b/templates/partners/find-a-partner.html
@@ -81,28 +81,8 @@
           <label for="ihv-oem">IHV / OEM</label>
         </p>
         <p>
-          <input type="checkbox" class="js-find-a-partner__filter" name="internet-of-things" id="internet-of-things">
-          <label for="internet-of-things">Internet of Things</label>
-        </p>
-        <p>
-          <input type="checkbox" class="js-find-a-partner__filter" name="isv" id="isv">
-          <label for="isv">ISV</label>
-        </p>
-        <p>
           <input type="checkbox" class="js-find-a-partner__filter" name="public-cloud" id="public-cloud">
           <label for="public-cloud">Public Cloud</label>
-        </p>
-        <p>
-          <input type="checkbox" class="js-find-a-partner__filter" name="retailer" id="retailer">
-          <label for="retailer">Retailer</label>
-        </p>
-        <p>
-          <input type="checkbox" class="js-find-a-partner__filter" name="silicon" id="silicon">
-          <label for="silicon">Silicon</label>
-        </p>
-        <p>
-          <input type="checkbox" class="js-find-a-partner__filter" name="other" id="other">
-          <label for="other">Other</label>
         </p>
       </div>
       <div class="col-4">
@@ -123,10 +103,6 @@
         <p>
           <input type="checkbox" class="js-find-a-partner__filter" name="hosting-provider" id="hosting-provider">
           <label for="hosting-provider">Hosting provider</label>
-        </p>
-        <p>
-          <input type="checkbox" class="js-find-a-partner__filter" name="hpc" id="hpc">
-          <label for="hpc">HPC</label>
         </p>
         <p>
           <input type="checkbox" class="js-find-a-partner__filter" name="infrastructure-provider" id="infrastructure-provider">


### PR DESCRIPTION
## Done

- Remove programmes not on the site from the /partners/find-a-partner filter
- Removed HPC as well as no companies in the list

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/partners/find-a-partner
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the programme list has only pages on the site

