### PR TITLE
Fix logo cloud min-width

### DIFF
--- a/templates/partners/channel-and-reseller.html
+++ b/templates/partners/channel-and-reseller.html
@@ -34,7 +34,7 @@
   </div>
 </section>
 
-{% if not partners %}
+{% if partners %}
 <section class="p-strip is-deep">
   <div class="u-fixed-width u-align--center">
     <h4 class="p-muted-heading u-no-max-width">Meet some of our channel/reseller partners</h4>
@@ -43,7 +43,7 @@
     <ul class="p-inline-images u-no-margin--bottom">
       {% for partner in partners %}
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logo" src="{{ partner.logo }}" style="min-width: 145px;" alt="{{ partner.slug}}">
+        <img class="p-inline-images__logo" src="{{ partner.logo }}" style="min-width: 5rem;" alt="{{ partner.slug}}">
       </li>
       {% endfor %}
     </ul>

--- a/templates/partners/desktop.html
+++ b/templates/partners/desktop.html
@@ -19,7 +19,7 @@
         <ul class="p-inline-images">
           {% for partner in partners %}
           <li class="p-inline-images__item">
-            <img class="p-inline-images__logo" src="{{ partner.logo }}" style="min-width: 145px;" alt="{{ partner.slug}}">
+            <img class="p-inline-images__logo" src="{{ partner.logo }}" style="min-width: 5rem;" alt="{{ partner.slug}}">
           </li>
           {% endfor %}
         </ul>

--- a/templates/partners/devices-and-iot.html
+++ b/templates/partners/devices-and-iot.html
@@ -27,7 +27,7 @@
       <ul class="p-inline-images">
         {% for partner in partners %}
         <li class="p-inline-images__item">
-          <img class="p-inline-images__logo" src="{{ partner.logo }}" style="min-width: 145px;" alt="{{ partner.slug}}">
+          <img class="p-inline-images__logo" src="{{ partner.logo }}" style="min-width: 5rem;" alt="{{ partner.slug}}">
         </li>
         {% endfor %}
       </ul>

--- a/templates/partners/find-a-partner.html
+++ b/templates/partners/find-a-partner.html
@@ -142,7 +142,7 @@
             <a href="/{{ partner['slug'] }}">
             {% endif %}
             {% if partner['logo'] %}
-              <img src="{{ partner['logo'] }}" alt="image for {{ partner['name'] }}" style="max-height: 3rem; max-width: 15rem; min-width: 145px;" loading="lazy">
+              <img src="{{ partner['logo'] }}" alt="image for {{ partner['name'] }}" style="max-height: 3rem; max-width: 15rem; min-width: 5rem;" loading="lazy">
 
             {% endif %}
             </a>

--- a/templates/partners/gsi.html
+++ b/templates/partners/gsi.html
@@ -21,7 +21,7 @@
   </div>
 </section>
 
-{% if not partners %}
+{% if partners %}
 <section class="p-strip is-deep">
   <div class="u-fixed-width u-align--center">
     <h4 class="p-muted-heading u-no-max-width">Meet some of our global system integrator partners</h4>
@@ -30,7 +30,7 @@
     <ul class="p-inline-images u-no-margin--bottom">
       {% for partner in partners %}
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logo" src="{{ partner.logo }}" style="min-width: 145px;" alt="{{ partner.slug}}">
+        <img class="p-inline-images__logo" src="{{ partner.logo }}" style="min-width: 5rem;" alt="{{ partner.slug}}">
       </li>
       {% endfor %}
     </ul>

--- a/templates/partners/ihv-and-oem.html
+++ b/templates/partners/ihv-and-oem.html
@@ -58,7 +58,7 @@
     <ul class="p-inline-images u-no-margin--bottom">
     {% for partner in partners %}
       <li class="p-inline-images__item">
-        <img class="p-inline-images__logo" src="{{ partner.logo }}" style="min-width: 145px;" alt="{{ partner.slug}}">
+        <img class="p-inline-images__logo" src="{{ partner.logo }}" style="min-width: 5rem;" alt="{{ partner.slug}}">
       </li>
     {% endfor %}
     </ul>


### PR DESCRIPTION
## Done

- Fix logo cloud min-width
- Fix logic hiding some clouds

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/partners/channel-and-reseller
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the logos appear and are mostly visible - cannot get all right as b systems is poor quality
