### PR TITLE
Update partner-portal link

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -301,7 +301,7 @@
         <a href="/partners/become-a-partner">Become a partner&nbsp;&rsaquo;</a>
       </div>
       <div class="col-3 p-divider__block">
-        <a href="https://canonical.partnerprm.com" class="p-link--external">Partner portal login</a>
+        <a href="https://partner-portal.canonical.com" class="p-link--external">Partner portal login</a>
       </div>
       <div class="col-3 p-divider__block">
         <a href="/partners">All partner programmes&nbsp;&rsaquo;</a>

--- a/templates/partners/_secondary-navigation.html
+++ b/templates/partners/_secondary-navigation.html
@@ -28,7 +28,7 @@
           <a class="breadcrumbs__link {% if request.path|get_secondary_nav_path == 'find-a-partner' %}p-link--active{% else %}p-link--soft{% endif %}" href="/partners/find-a-partner">Find a partner</a>
         </li>
         <li class="breadcrumbs__item">
-          <a class="breadcrumbs__link p-link--soft p-link--external" href="https://canonical.partnerprm.com">Partner portal</a>
+          <a class="breadcrumbs__link p-link--soft p-link--external" href="https://partner-portal.canonical.com">Partner portal</a>
         </li>
       </ul>
     </div>

--- a/templates/partners/channel-and-reseller.html
+++ b/templates/partners/channel-and-reseller.html
@@ -14,7 +14,7 @@
         <h1>Channel&sol;Reseller Programme</h1>
         <p>Canonical works with channel and reseller partners around the world to ensure that Canonical offerings are available for their customers. Additionally these partners can both resell services and value-added offerings around our technology enabling them to grow their business.</p>
         <p>Canonical is an industry leader in OpenStack private clouds, the reference platform for all major public clouds, and the open source software operating system that runs from the desktop and all internet connected things. Our success helps our partners build a business around our technology.</p>
-        <a href="https://canonical.partnerprm.com" class="p-button--neutral"><span class="p-link--external">Login to the partner portal</span></a>
+        <a href="https://partner-portal.canonical.com" class="p-button--neutral"><span class="p-link--external">Login to the partner portal</span></a>
       </div>
       <div class="col-4 u-hide--small u-align--center u-vertically-center">
         <img src="https://assets.ubuntu.com/v1/80472358-Canonical-reseller-icon.svg" alt="">
@@ -91,7 +91,7 @@
   <div class="row">
     <div class="col-6">
       <p>Open source technology is growing in demand. We want you to benefit from this unique opportunity, and take advantage of the investment Canonical is making in its partner community. We are committed to giving you the tools and programs to succeed, from discounts and financial incentives to sales and technical support teams.</p>
-      <p><a href="https://canonical.partnerprm.com" class="p-link--external">Login to the partner portal</a></p>
+      <p><a href="https://partner-portal.canonical.com" class="p-link--external">Login to the partner portal</a></p>
     </div>
     <div class="col-5 col-start-large-8 u-vertically-center u-hide--small">
       <img src="https://assets.ubuntu.com/v1/a544a3b0-partner_portal_sml.png" alt="Photo of laptop running Ubuntu" width="413" height="256">

--- a/templates/partners/gsi.html
+++ b/templates/partners/gsi.html
@@ -13,7 +13,7 @@
       <h1>Global System Integrator Programme</h1>
       <p>Canonical works with Global System Integrators around the world to build solutions that help our joint customers be successful in their business.</p>
       <p>Together we’ve successfully helped telecom providers, governmental agencies, financial services companies and other industry leaders overcome their toughest technological challenges. We help Global System Integrators build solutions and platforms on top of open, secure, reliable and professionally-supported foundations. </p>
-      <a href="/partners/become-a-partner" class="p-button--positive">Become a partner</a>
+      <a href="/contact-us" class="p-button--positive">Get in touch</a>
     </div>
     <div class="col-6 u-align--center u-vertically-center u-hide--small">
       <img src="https://assets.ubuntu.com/v1/c0244599-latest-ubuntu-download.svg" width="350" height="314" alt="">
@@ -72,7 +72,7 @@
         Open source technology is growing in demand. We want you to benefit from this unique opportunity, and take advantage of the investment Canonical is making in its partner community. We are committed to giving you the tools and programs to succeed, from discounts and financial incentives, to sales and technical support teams.
       </p>
       <p>
-        <a href="https://canonical.partnerprm.com" class="p-link--external">
+        <a href="https://partner-portal.canonical.com" class="p-link--external">
           Login to the partner portal
         </a>
       </p>

--- a/templates/partners/ihv-and-oem.html
+++ b/templates/partners/ihv-and-oem.html
@@ -144,7 +144,7 @@
   <div class="row">
     <div class="col-6">
       <p>Open source technology is growing in demand. We want you to benefit from this unique opportunity, and take advantage of the investment Canonical is making in its partner community. We are committed to giving you the tools and programs to succeed, from discounts and financial incentives, to sales and technical support teams.</p>
-      <p><a href="https://canonical.partnerprm.com/" class="p-link--external">Login to the partner portal</a></p>
+      <p><a href="https://partner-portal.canonical.com/" class="p-link--external">Login to the partner portal</a></p>
     </div>
     <div class="col-5 col-start-large-8 u-vertically-center u-hide--small">
       <img src="https://assets.ubuntu.com/v1/a544a3b0-partner_portal_sml.png" alt="Photo of laptop running Ubuntu" width="413" height="256">

--- a/templates/partners/index.html
+++ b/templates/partners/index.html
@@ -12,7 +12,7 @@
 <section class="p-strip--light is-shallow" style="margin-top: -1px;">
   <div class="row">
     <div class="col-8 u-vertically-center">
-      <p>Are you an existing partner? <a href="https://canonical.partnerprm.com" class="p-link--external">Login to the partner portal</a></p>
+      <p>Are you an existing partner? <a href="https://partner-portal.canonical.com" class="p-link--external">Login to the partner portal</a></p>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

- Update partner-portal link per Katie
- Changed the CTA on the /partners/gsi page
- **NOTE** blocked on portal getting ssl certs

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/partners/gsi
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the link to the partner portal is now https://partner-portal.canonical.com
- See that the gsi banner cta is to contact us

