### PR TITLE
Remove extra pasted sentence

### DIFF
--- a/templates/partners/desktop.html
+++ b/templates/partners/desktop.html
@@ -41,7 +41,7 @@
         <h3 class="p-matrix__title">Works out of the box</h3>
         <div class="p-matrix__desc">
           <p>Canonical performs 100s of stringent tests to ensure all Ubuntu functionality works out-of-the-box</p>
-        Information about Canonical. Canonical produces Ubuntu, provides commercial services for enterprise users, and works with industry partners on delivery and certification. </div>
+        </div>
       </div>
       <div class="col-4 p-card--highlighted">
         <h3 class="p-matrix__title">5 years support</h3>


### PR DESCRIPTION
## Done

Remove extra pasted sentence

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/partners/desktop
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that 'Information about Canonical. Canonical produces Ubuntu, provides commercial services for enterprise users, and works with industry partners on delivery and certification.' was removed from the 'Works out of the box' box

## Issue / Card

Fixes #259 