### PR TITLE
Update gsi partner page with webinars and resources

### DIFF
--- a/templates/partners/gsi.html
+++ b/templates/partners/gsi.html
@@ -41,6 +41,44 @@
 
 <section class="p-strip--light is-deep">
   <div class="u-fixed-width">
+    <h2>Building powerful customer solutions together</h2>
+  </div>
+  <div class="row">
+    <div class="col-7">
+      <p>
+        Join our webinars created specifically for Global System Integrators who are overcoming difficult technological challenges to build solutions and platforms for their customers. We will talk about scaleable, automated and repeatable deployments that will help your customers meet their digital transformation needs.
+      </p>
+    </div>
+    <div class="col-5 u-hide--small u-align--center u-vertically-center">
+      <img src="https://assets.ubuntu.com/v1/58442bcb-business-promo-webinar.png" width="200" height="125" alt="">
+    </div>
+    </div>
+    <div class="row">
+      <h4>
+        Watch the webinars
+      </h4>
+      <div class="p-divider">
+        <div class="col-5 p-divider__block">
+          <p>
+            <a class="p-link--external" href="https://www.google.com/url?q=https://www.brighttalk.com/webcast/6793/427943?utm_source%3DCanonical%26utm_medium%3Dbrighttalk%26utm_campaign%3D427943&sa=D&ust=1595580692587000&usg=AFQjCNHorVYPYanRnfGnfyPfjCqRANubcg">
+              How to create a private cloud with your data centre: provisioning servers in minutes
+              </a>
+          </p>
+        </div>
+        <div class="col-5 p-divider__block">
+          <p>
+            <a class="p-link--external" href="https://www.google.com/url?q=https://www.brighttalk.com/webcast/6793/427958?utm_source%3DCanonical%26utm_medium%3Dbrighttalk%26utm_campaign%3D427958&sa=D&ust=1595580692588000&usg=AFQjCNFqlfVSgFJNuycNeE6Ehb3XB-WkYw">
+            Streamlined Kubernetes from cloud to edge: open source, cloud-native container orchestration for innovation and scaling
+            </a>
+          </p>
+        </div>
+      </div>
+    </div>
+</section>
+
+
+<section class="p-strip is-deep">
+  <div class="u-fixed-width">
     <h2>Grow with Canonical</h2>
   </div>
   <div class="row p-divider">
@@ -63,7 +101,9 @@
     </div>
   </div>
 </section>
-
+<div class="u-fixed-width">
+    <hr class="p-separator">
+  </div>
 <section class="p-strip is-deep">
   <div class="row">
     <div class="col-8">
@@ -80,6 +120,57 @@
     <div class="col-4">
       <img src="https://assets.ubuntu.com/v1/a544a3b0-partner_portal_sml.png" alt="">
     </div>
+  </div>
+<div class="u-fixed-width">
+    <hr class="p-separator">
+  </div>
+  <div class="row">
+    <div class="col-7">
+      <h2>
+        Learn more about our solutions
+      </h2>
+      <ul class="p-list">
+        <li class="p-list__item is-ticked">
+          <a class="p-link--external" href="https://ubuntu.com/engage/private-cloud-build-webinar">
+            Lessons learned from 100+ private cloud builds
+          </a>
+        </li>
+        <li class="p-list__item is-ticked">
+          <a class="p-link--external" href="https://ubuntu.com/engage/moving-to-opensource-whitepaper?utm_source=personal">
+            Embracing the open source mandate
+          </a>
+        </li>
+        <li class="p-list__item is-ticked">
+          <a class="p-link--external" href="https://ubuntu.com/tco-calculator">
+            Private cloud TCO calculator
+          </a>
+        </li>
+        <li class="p-list__item is-ticked">
+          <a class="p-link--external" href="https://ubuntu.com/engage/k8s-allan-gray">
+            How Allan Gray uses Charmed Kubernetes to boost efficiency and availability
+          </a>
+        </li>
+        <li class="p-list__item is-ticked">
+          <a class="p-link--external" href="https://ubuntu.com/engage/enterprise-snap-management">
+            Managing snaps in the enterprise environment
+          </a>
+        </li>
+        <li class="p-list__item is-ticked">
+          <a class="p-link--external" href="https://ubuntu.com/engage/evolving-software">
+            How Juju can help solve software management complexity
+          </a>
+        </li>
+        <li class="p-list__item is-ticked">
+          <a class="p-link--external" href="https://www.brighttalk.com/webcast/6793/385799">
+            Accelerating IoT device time to market
+          </a>
+        </li>
+      </ul>
+    </div>
+    <div class="col-5 u-hide--small u-align--center u-vertically-center">
+      <img src="https://assets.ubuntu.com/v1/5d8aa78b-1+Discovery.svg" width="335" height="200" alt="">
+    </div>
+
   </div>
 </section>
 

--- a/templates/partners/gsi.html
+++ b/templates/partners/gsi.html
@@ -52,28 +52,28 @@
     <div class="col-5 u-hide--small u-align--center u-vertically-center">
       <img src="https://assets.ubuntu.com/v1/58442bcb-business-promo-webinar.png" width="200" height="125" alt="">
     </div>
-    </div>
-    <div class="row">
-      <h4>
-        Watch the webinars
-      </h4>
-      <div class="p-divider">
-        <div class="col-5 p-divider__block">
-          <p>
-            <a class="p-link--external" href="https://www.google.com/url?q=https://www.brighttalk.com/webcast/6793/427943?utm_source%3DCanonical%26utm_medium%3Dbrighttalk%26utm_campaign%3D427943&sa=D&ust=1595580692587000&usg=AFQjCNHorVYPYanRnfGnfyPfjCqRANubcg">
-              How to create a private cloud with your data centre: provisioning servers in minutes
-              </a>
-          </p>
-        </div>
-        <div class="col-5 p-divider__block">
-          <p>
-            <a class="p-link--external" href="https://www.google.com/url?q=https://www.brighttalk.com/webcast/6793/427958?utm_source%3DCanonical%26utm_medium%3Dbrighttalk%26utm_campaign%3D427958&sa=D&ust=1595580692588000&usg=AFQjCNFqlfVSgFJNuycNeE6Ehb3XB-WkYw">
+  </div>
+  <div class="row">
+    <h4>
+      Watch the webinars
+    </h4>
+    <div class="p-divider">
+      <div class="col-5 p-divider__block">
+        <p>
+          <a class="p-link--external" href="https://www.google.com/url?q=https://www.brighttalk.com/webcast/6793/427943?utm_source%3DCanonical%26utm_medium%3Dbrighttalk%26utm_campaign%3D427943&sa=D&ust=1595580692587000&usg=AFQjCNHorVYPYanRnfGnfyPfjCqRANubcg">
+            How to create a private cloud with your data centre: provisioning servers in minutes
+          </a>
+        </p>
+      </div>
+      <div class="col-5 p-divider__block">
+        <p>
+          <a class="p-link--external" href="https://www.google.com/url?q=https://www.brighttalk.com/webcast/6793/427958?utm_source%3DCanonical%26utm_medium%3Dbrighttalk%26utm_campaign%3D427958&sa=D&ust=1595580692588000&usg=AFQjCNFqlfVSgFJNuycNeE6Ehb3XB-WkYw">
             Streamlined Kubernetes from cloud to edge: open source, cloud-native container orchestration for innovation and scaling
-            </a>
-          </p>
-        </div>
+          </a>
+        </p>
       </div>
     </div>
+  </div>
 </section>
 
 
@@ -102,8 +102,8 @@
   </div>
 </section>
 <div class="u-fixed-width">
-    <hr class="p-separator">
-  </div>
+  <hr class="p-separator">
+</div>
 <section class="p-strip is-deep">
   <div class="row">
     <div class="col-8">
@@ -121,7 +121,7 @@
       <img src="https://assets.ubuntu.com/v1/a544a3b0-partner_portal_sml.png" alt="">
     </div>
   </div>
-<div class="u-fixed-width">
+  <div class="u-fixed-width">
     <hr class="p-separator">
   </div>
   <div class="row">
@@ -170,7 +170,6 @@
     <div class="col-5 u-hide--small u-align--center u-vertically-center">
       <img src="https://assets.ubuntu.com/v1/5d8aa78b-1+Discovery.svg" width="335" height="200" alt="">
     </div>
-
   </div>
 </section>
 


### PR DESCRIPTION
## Done

Update gsi partner page with webinars and resources

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/partners/gsi
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare to and resolve the [copy doc](https://docs.google.com/document/d/1PgdZCn16zMVA3LVcLihN03DYFLLqkHIqTqfsgx_LHFg/edit#)

## Issue / Card

Fixes #261
