### PR TITLE
Add location filter to careers pages

### DIFF
--- a/static/js/careers-filter-and-sort.js
+++ b/static/js/careers-filter-and-sort.js
@@ -98,7 +98,7 @@
 
     if (domList) {
       var jobList = Array.from(domList.children);
-
+/*
       if (filterSelect) {
 
         Array.from(filterSelect.options).forEach(function (el) {
@@ -149,6 +149,54 @@
       if(filterSelect || locationSelect)
       {
         filterJobs(filterBy, jobList);
+      }
+*/
+
+      if(filterSelect && locationSelect) {
+        getOptions(filters);
+        getOptions(locationFilters);
+        
+        if(queryFilter && locationFilter)
+        {
+          updateOptions(filterSelect, filters, "filter");
+          updateOptions(locationSelect, locationFilters, "location");
+          filterJobs(filterBy, jobList);
+          getEventListener(filterSelect, sortSelect, "filter", filterBy, jobList);
+          getEventListener(locationSelect, sortSelect, "location", filterBy, jobList);
+        }
+        else if(queryFilter && !locationFilter)
+        {
+          updateOptions(filterSelect, filters, "filter");
+          filterJobs(filterBy, jobList);
+          getEventListener(filterSelect, sortSelect, "filter", filterBy, jobList);
+
+        }
+        else if(!queryFilter && locationFilter)
+        {
+          updateOptions(locationSelect, locationFilters, "location");
+          filterJobs(filterBy, jobList);
+          getEventListener(locationSelect, sortSelect, "location", filterBy, jobList);
+        }
+      }
+      else if(filterSelect && !locationSelect) {
+        getOptions(filters);
+
+        if(queryFilter)
+        {
+          updateOptions(filterSelect, filters, "filter");
+          filterJobs(filterBy, jobList);
+          getEventListener(filterSelect, sortSelect, "filter", filterBy, jobList);
+        }
+      }
+      else if(!filterSelect && locationSelect) {
+        getOptions(locationFilters);
+
+        if(locationFilter)
+        {
+          updateOptions(locationSelect, locationFilters, "location");
+          filterJobs(filterBy, jobList);
+          getEventListener(locationSelect, sortSelect, "location", filterBy, jobList);
+        }
       }
 
       if (sortSelect) {
@@ -286,6 +334,48 @@
     var url = baseURL + '?' + urlParams.toString() + '#available-roles';
 
     window.history.pushState({}, "", url);
+  }
+
+  function getOptions(array)
+  {
+    Array.from(filterSelect.options).forEach(function (el) {
+      array.push(el.value);
+    });
+  }
+
+  function updateOptions(filterSelect, filters, type)
+  {
+    filterSelect.options.selectedIndex = filters.indexOf(queryFilter);
+    if(type === "filter")
+    {
+      updateFilterBy(filterSelect.options[filterSelect.options.selectedIndex].value);
+    }
+    else if(type === "location")
+    {
+      updateLocationFilterBy(filterSelect.options[filterSelect.options.selectedIndex].value);
+    }
+    //filterJobs(filterBy, jobList);
+    updateNoResultsMessage();
+  }
+
+  function getEventListener(filterSelect, sortSelect, type, filterBy, jobList)
+  {
+    filterSelect.addEventListener("change", function () {
+    if (!(sortSelect.options.selectedIndex === 0)) {
+      sortSelect.options.selectedIndex = 0;
+    }
+    if(type === "filter")
+    {
+      updateFilterBy(filterSelect.options[filterSelect.options.selectedIndex].value);
+    }
+    else if(type === "location")
+    {
+      updateLocationFilterBy(filterSelect.options[filterSelect.options.selectedIndex].value);
+    }
+    filterJobs(filterBy, jobList);
+    updateURL(filterBy);
+    updateNoResultsMessage();
+    });
   }
 
   init();

--- a/static/js/careers-filter-and-sort.js
+++ b/static/js/careers-filter-and-sort.js
@@ -76,15 +76,11 @@
         }
       }
 
-      if(locationsList.length === 0)
-      {
-        jobsList[n].setAttribute("location-filter", "europe americas asia middle-east africa oceania");
-      }
-      else
+      if(locationsList.length > 0)
       {
         locationsList = locationsList.slice(0, locationsList.length-1);
-        jobsList[n].setAttribute("location-filter", locationsList);
       }
+      jobsList[n].setAttribute("location-filter", locationsList);
     }
   }
 
@@ -96,61 +92,6 @@
 
     if (domList) {
       var jobList = Array.from(domList.children);
-/*
-      if (filterSelect) {
-
-        Array.from(filterSelect.options).forEach(function (el) {
-          filters.push(el.value);
-      });
-
-        if (queryFilter) {
-          filterSelect.options.selectedIndex = filters.indexOf(queryFilter);
-          updateFilterBy(filterSelect.options[filterSelect.options.selectedIndex].value);
-          //filterJobs(filterBy, jobList);
-          updateNoResultsMessage();
-        }
-        
-        filterSelect.addEventListener("change", function () {
-          if (!(sortSelect.options.selectedIndex === 0)) {
-            sortSelect.options.selectedIndex = 0;
-          }
-          updateFilterBy(filterSelect.options[filterSelect.options.selectedIndex].value);
-          //filterJobs(filterBy, jobList);
-          updateURL(filterBy);
-          updateNoResultsMessage();
-        });
-
-      }
-
-      if (locationSelect) {
-        Array.from(locationSelect.options).forEach(function (el) {
-          locationFilters.push(el.value);
-        });
-
-        if (locationFilter) {
-          locationSelect.options.selectedIndex = filters.indexOf(locationFilter);
-          updateLocationFilterBy(locationSelect.options[locationSelect.options.selectedIndex].value);
-          updateNoResultsMessage();
-        }
-
-        locationSelect.addEventListener("change", function () {
-          if (!(sortSelect.options.selectedIndex === 0)) {
-            sortSelect.options.selectedIndex = 0;
-          }
-          updateLocationFilterBy(locationSelect.options[locationSelect.options.selectedIndex].value);
-          ///filterJobs(filterBy, jobList);
-          updateURL(filterBy);
-          updateNoResultsMessage();
-        });
-      }
-
-      if(filterSelect || locationSelect)
-      {
-        filterJobs(filterBy, jobList);
-      }
-*/  
-
-      
 
       if(filterSelect)
       {
@@ -167,11 +108,22 @@
             if(filterOptions[n] === filterValue)
             {
               filterSelect.options.selectedIndex = n;
-              updateFilterBy(filterValue);
               break;
             }
           }
         }
+
+        updateFilterBy(filterSelect.options[filterSelect.options.selectedIndex].value);
+
+        filterSelect.addEventListener("change", function () {
+          if (!(sortSelect.options.selectedIndex === 0)) {
+            sortSelect.options.selectedIndex = 0;
+          }
+          updateFilterBy(filterSelect.options[filterSelect.options.selectedIndex].value);
+          filterJobs(filterBy, jobList);
+          updateURL(filterBy);
+          updateNoResultsMessage();
+        });
       }
 
       if(locationSelect)
@@ -189,11 +141,22 @@
             if(locationOptions[n] === locationValue)
             {
               locationSelect.options.selectedIndex = n;
-              updateLocationFilterBy(locationValue);
               break;
             }
           }
         }
+
+        updateLocationFilterBy(locationSelect.options[locationSelect.options.selectedIndex].value);
+
+        locationSelect.addEventListener("change", function () {
+          if (!(sortSelect.options.selectedIndex === 0)) {
+            sortSelect.options.selectedIndex = 0;
+          }
+          updateLocationFilterBy(locationSelect.options[locationSelect.options.selectedIndex].value);
+          filterJobs(filterBy, jobList);
+          updateURL(filterBy);
+          updateNoResultsMessage();
+        });
       }
 
       filterJobs(filterBy, jobList);
@@ -238,7 +201,36 @@
           node.classList.remove("u-hide");
         }
         numberOfJobsDisplayed = domList.childElementCount;
-      } else {
+      }
+      else if(filterBy.filterValue !== "all" && filterBy.location === "all")
+      {
+        if(node.dataset[filterBy.filterName].includes(filterBy.filterText))
+        {
+          if (node.classList.contains("u-hide")) {
+            node.classList.remove("u-hide");
+          }
+          } else {
+            if (!node.classList.contains("u-hide")) {
+              node.classList.add("u-hide");
+          }
+          numberOfJobsDisplayed--;
+        }
+      }
+      else if(filterBy.filterValue === "all" && filterBy.location !== "all")
+      {
+        if(node.getAttribute("location-filter").includes(filterBy.location))
+        {
+          if (node.classList.contains("u-hide")) {
+            node.classList.remove("u-hide");
+          }
+          } else {
+            if (!node.classList.contains("u-hide")) {
+              node.classList.add("u-hide");
+          }
+          numberOfJobsDisplayed--;
+        }
+      }
+      else {
         if (node.dataset[filterBy.filterName].includes(filterBy.filterText) && node.getAttribute("location-filter").includes(filterBy.location)) {
           if (node.classList.contains("u-hide")) {
             node.classList.remove("u-hide");
@@ -288,7 +280,7 @@
   }
 
   function updateLocationFilterBy(location) {
-    switch (filter) {
+    switch (location) {
       case "europe":
         filterBy.location = "europe";
         break;

--- a/static/js/careers-filter-and-sort.js
+++ b/static/js/careers-filter-and-sort.js
@@ -5,14 +5,14 @@
   const noResults = document.querySelector(".js-filter__no-results");
   const jobContainer = document.querySelector(".js-filter-jobs-container");
   const sortSelect = document.querySelector(".js-sort");
+  const locationSelect = document.querySelector(".js-filter--location");
 
   var numberOfJobsDisplayed = 0;
   var filters = [];
+  var locationFilters = [];
   var filterBy = {};
 
-
-  function parseLocations()
-  {
+  function parseLocations() {
     const europe = ["emea", "slovakia", "bratislava", "europe", "uk", "germany", "berlin", "london", "worldwide"];
     const americas = ["americas", "southwest", "san francisco", "usa", "austin", "texas", "tx", "brazil", "seattle", "america", "worldwide"];
     const asia = ["apac", "taiwan", "taipei", "beijing", "china", "worldwide"];
@@ -76,10 +76,15 @@
         }
       }
 
-      locastionsList = locationsList.slice(0, locationsList.length-1);
-      jobsList[n].setAttribute("location-filter", locationsList);
-      console.log(location + ": " + jobsList[n].getAttribute("location-filter"));
-
+      if(locationsList.length === 0)
+      {
+        jobsList[n].setAttribute("location-filter", "europe americas asia middle-east africa oceania");
+      }
+      else
+      {
+        locationsList = locationsList.slice(0, locationsList.length-1);
+        jobsList[n].setAttribute("location-filter", locationsList);
+      }
     }
   }
 
@@ -87,6 +92,7 @@
 
   function init() {
     var queryFilter = urlParams.get('filter');
+    var locationFilter = urlParams.get('location');
 
     revealFilters();
 
@@ -94,26 +100,55 @@
       var jobList = Array.from(domList.children);
 
       if (filterSelect) {
+
         Array.from(filterSelect.options).forEach(function (el) {
           filters.push(el.value);
-        });
+      });
 
         if (queryFilter) {
           filterSelect.options.selectedIndex = filters.indexOf(queryFilter);
           updateFilterBy(filterSelect.options[filterSelect.options.selectedIndex].value);
-          filterJobs(filterBy, jobList);
+          //filterJobs(filterBy, jobList);
           updateNoResultsMessage();
         }
-
+        
         filterSelect.addEventListener("change", function () {
           if (!(sortSelect.options.selectedIndex === 0)) {
             sortSelect.options.selectedIndex = 0;
           }
           updateFilterBy(filterSelect.options[filterSelect.options.selectedIndex].value);
-          filterJobs(filterBy, jobList);
+          //filterJobs(filterBy, jobList);
           updateURL(filterBy);
           updateNoResultsMessage();
         });
+
+      }
+
+      if (locationSelect) {
+        Array.from(locationSelect.options).forEach(function (el) {
+          locationFilters.push(el.value);
+        });
+
+        if (locationFilter) {
+          locationSelect.options.selectedIndex = filters.indexOf(locationFilter);
+          updateLocationFilterBy(locationSelect.options[locationSelect.options.selectedIndex].value);
+          updateNoResultsMessage();
+        }
+
+        locationSelect.addEventListener("change", function () {
+          if (!(sortSelect.options.selectedIndex === 0)) {
+            sortSelect.options.selectedIndex = 0;
+          }
+          updateLocationFilterBy(locationSelect.options[locationSelect.options.selectedIndex].value);
+          ///filterJobs(filterBy, jobList);
+          updateURL(filterBy);
+          updateNoResultsMessage();
+        });
+      }
+
+      if(filterSelect || locationSelect)
+      {
+        filterJobs(filterBy, jobList);
       }
 
       if (sortSelect) {
@@ -150,13 +185,13 @@
   function filterJobs(filterBy, jobList) {
     numberOfJobsDisplayed = domList.childElementCount;
     jobList.forEach(function (node) {
-      if (filterBy.filterText === "All") {
+      if (filterBy.filterText === "All" && filterBy.location === "all") {
         if (node.classList.contains("u-hide")) {
           node.classList.remove("u-hide");
         }
         numberOfJobsDisplayed = domList.childElementCount;
       } else {
-        if (node.dataset[filterBy.filterName].includes(filterBy.filterText)) {
+        if (node.dataset[filterBy.filterName].includes(filterBy.filterText) && node.getAttribute("location-filter").includes(filterBy.location)) {
           if (node.classList.contains("u-hide")) {
             node.classList.remove("u-hide");
           }
@@ -204,6 +239,31 @@
     }
   }
 
+  function updateLocationFilterBy(location) {
+    switch (filter) {
+      case "europe":
+        filterBy.location = "europe";
+        break;
+      case "americas":
+        filterBy.location = "americas";
+        break;
+      case "asia":
+        filterBy.location = "asia";
+        break;
+      case "middle-east":
+        filterBy.location = "middle-east";
+        break;
+      case "africa":
+        filterBy.location = "africa";
+        break;
+      case "oceania":
+        filterBy.location = "oceania";
+        break;
+      default:
+        filterBy.location = "all";
+    }
+  }
+
   // Display no reults message
   function updateNoResultsMessage() {
     if (noResults && jobContainer) {
@@ -221,6 +281,7 @@
     var baseURL = window.location.origin + window.location.pathname;
 
     urlParams.set('filter', filterBy.filterValue);
+    urlParams.set('location', filterBy.location);
 
     var url = baseURL + '?' + urlParams.toString() + '#available-roles';
 

--- a/static/js/careers-filter-and-sort.js
+++ b/static/js/careers-filter-and-sort.js
@@ -1,15 +1,13 @@
 (function () {
   const urlParams = new URLSearchParams(window.location.search);
   const domList = document.querySelector(".js-job-list");
-  var filterSelect = document.querySelector(".js-filter");
+  const filterSelect = document.querySelector(".js-filter");
   const noResults = document.querySelector(".js-filter__no-results");
   const jobContainer = document.querySelector(".js-filter-jobs-container");
   const sortSelect = document.querySelector(".js-sort");
-  var locationSelect = document.querySelector(".js-filter--location");
+  const locationSelect = document.querySelector(".js-filter--location");
 
   var numberOfJobsDisplayed = 0;
-  var filters = [];
-  var locationFilters = [];
   var filterBy = {};
 
   // Read data-location property and parse locations into well-defined categories

--- a/static/js/careers-filter-and-sort.js
+++ b/static/js/careers-filter-and-sort.js
@@ -14,7 +14,7 @@
   function parseLocations() {
     const regions = {
       "europe": ["emea", "slovakia", "bratislava", "europe", "uk", "germany", "berlin", "london", "worldwide"],
-      "america": ["americas", "southwest", "san francisco", "usa", "austin", "texas", "tx", "brazil", "seattle", "america", "worldwide"],
+      "americas": ["americas", "southwest", "san francisco", "usa", "austin", "texas", "tx", "brazil", "seattle", "america", "worldwide"],
       "asia": ["apac", "taiwan", "taipei", "beijing", "china", "worldwide"],
       "middle-east": ["emea", "worldwide"],
       "africa": ["emea", "worldwide"],
@@ -23,14 +23,14 @@
 
     const jobsList = document.querySelector(".js-job-list").children;
 
-    for (var n = 0; n < jobsList.length; n++) {
+    for (let n = 0; n < jobsList.length; n++) {
       const location = jobsList[n].getAttribute("data-location");
       var locationsList = "";
 
-      for (var region in regions) {
+      for (let region in regions) {
         const regionalLocations = regions[region];
 
-        for (var i = 0; i < regionalLocations.length; i++) {
+        for (let i = 0; i < regionalLocations.length; i++) {
           if (location.toLowerCase().includes(regionalLocations[i])) {
             locationsList += region + " ";
             break;
@@ -64,7 +64,7 @@
         if (urlParams.has("filter")) {
           // If the page is loaded with inital URL parameters, change the default form selection and filter the results to reflect this
           var filterValue = urlParams.get("filter");
-          for (var n = 0; n < filterOptions.length; n++) {
+          for (let n = 0; n < filterOptions.length; n++) {
             if (filterOptions[n] === filterValue) {
               filterSelect.options.selectedIndex = n;
               break;

--- a/static/js/careers-filter-and-sort.js
+++ b/static/js/careers-filter-and-sort.js
@@ -91,8 +91,6 @@
   parseLocations();
 
   function init() {
-    var queryFilter = urlParams.get('filter');
-    var locationFilter = urlParams.get('location');
 
     revealFilters();
 
@@ -150,54 +148,56 @@
       {
         filterJobs(filterBy, jobList);
       }
-*/
+*/  
 
-      if(filterSelect && locationSelect) {
-        getOptions(filters);
-        getOptions(locationFilters);
-        
-        if(queryFilter && locationFilter)
-        {
-          filterSelect = updateOptions(filterSelect, queryFilter, filters, "filter");
-          locationSelect = updateOptions(locationSelect, locationFilter, locationFilters, "location");
-          filterJobs(filterBy, jobList);
-          filterSelect = getEventListener(filterSelect, sortSelect, "filter", filterBy, jobList);
-          locationSelect = getEventListener(locationSelect, sortSelect, "location", filterBy, jobList);
-        }
-        else if(queryFilter && !locationFilter)
-        {
-          filterSelect = updateOptions(filterSelect, queryFilter, filters, "filter");
-          filterJobs(filterBy, jobList);
-          filterSelect = getEventListener(filterSelect, sortSelect, "filter", filterBy, jobList);
+      
 
-        }
-        else if(!queryFilter && locationFilter)
+      if(filterSelect)
+      {
+        var filterOptions = [];
+        Array.from(filterSelect.options).forEach(function (el) {
+          filterOptions.push(el.value);
+        });
+
+        if(urlParams.has("filter"))
         {
-          locationSelect = updateOptions(locationSelect, locationFilter, locationFilters, "location");
-          filterJobs(filterBy, jobList);
-          locationSelect = getEventListener(locationSelect, sortSelect, "location", filterBy, jobList);
+          var filterValue = urlParams.get("filter");
+          for(var n=0; n<filterOptions.length; n++)
+          {
+            if(filterOptions[n] === filterValue)
+            {
+              filterSelect.options.selectedIndex = n;
+              updateFilterBy(filterValue);
+              break;
+            }
+          }
         }
       }
-      else if(filterSelect && !locationSelect) {
-        getOptions(filters);
 
-        if(queryFilter)
+      if(locationSelect)
+      {
+        var locationOptions = [];
+        Array.from(locationSelect.options).forEach(function (el) {
+          locationOptions.push(el.value);
+        });
+
+        if(urlParams.has("location"))
         {
-          filterSelect = updateOptions(filterSelect, queryFilter, filters, "filter");
-          filterJobs(filterBy, jobList);
-          filterSelect = getEventListener(filterSelect, sortSelect, "filter", filterBy, jobList);
+          var locationValue = urlParams.get("location");
+          for(var n=0; n<locationOptions.length; n++)
+          {
+            if(locationOptions[n] === locationValue)
+            {
+              locationSelect.options.selectedIndex = n;
+              updateLocationFilterBy(locationValue);
+              break;
+            }
+          }
         }
       }
-      else if(!filterSelect && locationSelect) {
-        getOptions(locationFilters);
 
-        if(locationFilter)
-        {
-          locationSelect = updateOptions(locationSelect, locationFilter, locationFilters, "location");
-          filterJobs(filterBy, jobList);
-          locationSelect = getEventListener(locationSelect, sortSelect, "location", filterBy, jobList);
-        }
-      }
+      filterJobs(filterBy, jobList);
+      updateNoResultsMessage();
 
       if (sortSelect) {
         sortSelect.addEventListener("change", function (e) {
@@ -334,50 +334,6 @@
     var url = baseURL + '?' + urlParams.toString() + '#available-roles';
 
     window.history.pushState({}, "", url);
-  }
-
-  function getOptions(array)
-  {
-    Array.from(filterSelect.options).forEach(function (el) {
-      array.push(el.value);
-    });
-  }
-
-  function updateOptions(filterSelect, queryFilter, filters, type)
-  {
-    filterSelect.options.selectedIndex = filters.indexOf(queryFilter);
-    if(type === "filter")
-    {
-      updateFilterBy(filterSelect.options[filterSelect.options.selectedIndex].value);
-    }
-    else if(type === "location")
-    {
-      updateLocationFilterBy(filterSelect.options[filterSelect.options.selectedIndex].value);
-    }
-    //filterJobs(filterBy, jobList);
-    updateNoResultsMessage();
-    return filterSelect;
-  }
-
-  function getEventListener(filterSelect, sortSelect, type, filterBy, jobList)
-  {
-    filterSelect.addEventListener("change", function () {
-    if (!(sortSelect.options.selectedIndex === 0)) {
-      sortSelect.options.selectedIndex = 0;
-    }
-    if(type === "filter")
-    {
-      updateFilterBy(filterSelect.options[filterSelect.options.selectedIndex].value);
-    }
-    else if(type === "location")
-    {
-      updateLocationFilterBy(filterSelect.options[filterSelect.options.selectedIndex].value);
-    }
-    filterJobs(filterBy, jobList);
-    updateURL(filterBy);
-    updateNoResultsMessage();
-    return filterSelect;
-    });
   }
 
   init();

--- a/static/js/careers-filter-and-sort.js
+++ b/static/js/careers-filter-and-sort.js
@@ -165,9 +165,9 @@
           if (node.classList.contains("u-hide")) {
             node.classList.remove("u-hide");
           }
-          } else {
-            if (!node.classList.contains("u-hide")) {
-              node.classList.add("u-hide");
+        } else {
+          if (!node.classList.contains("u-hide")) {
+            node.classList.add("u-hide");
           }
           numberOfJobsDisplayed--;
         }
@@ -176,9 +176,9 @@
           if (node.classList.contains("u-hide")) {
             node.classList.remove("u-hide");
           }
-          } else {
-            if (!node.classList.contains("u-hide")) {
-              node.classList.add("u-hide");
+        } else {
+          if (!node.classList.contains("u-hide")) {
+            node.classList.add("u-hide");
           }
           numberOfJobsDisplayed--;
         }

--- a/static/js/careers-filter-and-sort.js
+++ b/static/js/careers-filter-and-sort.js
@@ -10,40 +10,80 @@
   var filters = [];
   var filterBy = {};
 
-  function initialiseLocationList()
+
+  function parseLocations()
   {
+    const europe = ["emea", "slovakia", "bratislava", "europe", "uk", "germany", "berlin", "london", "worldwide"];
+    const americas = ["americas", "southwest", "san francisco", "usa", "austin", "texas", "tx", "brazil", "seattle", "america", "worldwide"];
+    const asia = ["apac", "taiwan", "taipei", "beijing", "china", "worldwide"];
+    const middleEast = ["emea", "worldwide"];
+    const africa = ["emea", "worldwide"];
+    const oceania = ["apac", "worldwide"];
+
     const jobsList = document.querySelector(".js-job-list").children;
-    var locationList = [];
-    for(let n = 0; n<jobsList.length; n++)
+
+    for(var n=0; n<jobsList.length; n++)
     {
-      var duplicate = false;
-      //var location = jobsList[n].getAttribute("data-location");
-      for(let x = 0; x<locationList.length; x++)
+      const location = jobsList[n].getAttribute("data-location");
+      var locationsList = "";
+
+      for(var x=0; x<europe.length; x++)
       {
-        if(locationList[x] === jobsList[n].getAttribute("data-location"))
+        if(location.toLowerCase().includes(europe[x]))
         {
-          duplicate = true;
+          locationsList += "europe ";
           break;
         }
       }
-      if(!duplicate)
+      for(var x=0; x<americas.length; x++)
       {
-        locationList.push(jobsList[n].getAttribute("data-location"));
+        if(location.toLowerCase().includes(americas[x]))
+        {
+          locationsList += "americas ";
+          break;
+        }
       }
-    }
-    const target = document.querySelector(".js-filter--location");
-    for(var n=0; n<locationList.length; n++)
-    {
-      var fragment = document.createDocumentFragment();
-      var option = document.createElement("option");
-      //option.setAttribute(value; )
-      var text = document.createTextNode(locationList[n]);
-      option.appendChild(text);
-      target.appendChild(option);
+      for(var x=0; x<asia.length; x++)
+      {
+        if(location.toLowerCase().includes(asia[x]))
+        {
+          locationsList += "asia ";
+          break;
+        }
+      }
+      for(var x=0; x<middleEast.length; x++)
+      {
+        if(location.toLowerCase().includes(middleEast[x]))
+        {
+          locationsList += "middle-east ";
+          break;
+        }
+      }
+      for(var x=0; x<africa.length; x++)
+      {
+        if(location.toLowerCase().includes(africa[x]))
+        {
+          locationsList += "africa ";
+          break;
+        }
+      }
+      for(var x=0; x<oceania.length; x++)
+      {
+        if(location.toLowerCase().includes(oceania[x]))
+        {
+          locationsList += "oceania ";
+          break;
+        }
+      }
+
+      locastionsList = locationsList.slice(0, locationsList.length-1);
+      jobsList[n].setAttribute("location-filter", locationsList);
+      console.log(location + ": " + jobsList[n].getAttribute("location-filter"));
+
     }
   }
 
-  initialiseLocationList();
+  parseLocations();
 
   function init() {
     var queryFilter = urlParams.get('filter');

--- a/static/js/careers-filter-and-sort.js
+++ b/static/js/careers-filter-and-sort.js
@@ -10,6 +10,41 @@
   var filters = [];
   var filterBy = {};
 
+  function initialiseLocationList()
+  {
+    const jobsList = document.querySelector(".js-job-list").children;
+    var locationList = [];
+    for(let n = 0; n<jobsList.length; n++)
+    {
+      var duplicate = false;
+      //var location = jobsList[n].getAttribute("data-location");
+      for(let x = 0; x<locationList.length; x++)
+      {
+        if(locationList[x] === jobsList[n].getAttribute("data-location"))
+        {
+          duplicate = true;
+          break;
+        }
+      }
+      if(!duplicate)
+      {
+        locationList.push(jobsList[n].getAttribute("data-location"));
+      }
+    }
+    const target = document.querySelector(".js-filter--location");
+    for(var n=0; n<locationList.length; n++)
+    {
+      var fragment = document.createDocumentFragment();
+      var option = document.createElement("option");
+      //option.setAttribute(value; )
+      var text = document.createTextNode(locationList[n]);
+      option.appendChild(text);
+      target.appendChild(option);
+    }
+  }
+
+  initialiseLocationList();
+
   function init() {
     var queryFilter = urlParams.get('filter');
 

--- a/static/js/careers-filter-and-sort.js
+++ b/static/js/careers-filter-and-sort.js
@@ -12,71 +12,33 @@
 
   // Read data-location property and parse locations into well-defined categories
   function parseLocations() {
-    const europe = ["emea", "slovakia", "bratislava", "europe", "uk", "germany", "berlin", "london", "worldwide"];
-    const americas = ["americas", "southwest", "san francisco", "usa", "austin", "texas", "tx", "brazil", "seattle", "america", "worldwide"];
-    const asia = ["apac", "taiwan", "taipei", "beijing", "china", "worldwide"];
-    const middleEast = ["emea", "worldwide"];
-    const africa = ["emea", "worldwide"];
-    const oceania = ["apac", "worldwide"];
+    const regions = {
+      "europe": ["emea", "slovakia", "bratislava", "europe", "uk", "germany", "berlin", "london", "worldwide"],
+      "america": ["americas", "southwest", "san francisco", "usa", "austin", "texas", "tx", "brazil", "seattle", "america", "worldwide"],
+      "asia": ["apac", "taiwan", "taipei", "beijing", "china", "worldwide"],
+      "middle-east": ["emea", "worldwide"],
+      "africa": ["emea", "worldwide"],
+      "oceania": ["apac", "worldwide"]
+  };
 
     const jobsList = document.querySelector(".js-job-list").children;
 
-    for(var n=0; n<jobsList.length; n++)
-    {
+    for (var n = 0; n < jobsList.length; n++) {
       const location = jobsList[n].getAttribute("data-location");
       var locationsList = "";
 
-      for(var x=0; x<europe.length; x++)
-      {
-        if(location.toLowerCase().includes(europe[x]))
-        {
-          locationsList += "europe ";
-          break;
-        }
-      }
-      for(var x=0; x<americas.length; x++)
-      {
-        if(location.toLowerCase().includes(americas[x]))
-        {
-          locationsList += "americas ";
-          break;
-        }
-      }
-      for(var x=0; x<asia.length; x++)
-      {
-        if(location.toLowerCase().includes(asia[x]))
-        {
-          locationsList += "asia ";
-          break;
-        }
-      }
-      for(var x=0; x<middleEast.length; x++)
-      {
-        if(location.toLowerCase().includes(middleEast[x]))
-        {
-          locationsList += "middle-east ";
-          break;
-        }
-      }
-      for(var x=0; x<africa.length; x++)
-      {
-        if(location.toLowerCase().includes(africa[x]))
-        {
-          locationsList += "africa ";
-          break;
-        }
-      }
-      for(var x=0; x<oceania.length; x++)
-      {
-        if(location.toLowerCase().includes(oceania[x]))
-        {
-          locationsList += "oceania ";
-          break;
+      for (var region in regions) {
+        const regionalLocations = regions[region];
+
+        for (var i = 0; i < regionalLocations.length; i++) {
+          if (location.toLowerCase().includes(regionalLocations[i])) {
+            locationsList += region + " ";
+            break;
+          }
         }
       }
 
-      if(locationsList.length > 0)
-      {
+      if (locationsList.length > 0) {
         locationsList = locationsList.slice(0, locationsList.length-1);
       }
       jobsList[n].setAttribute("location-filter", locationsList);
@@ -92,22 +54,18 @@
     if (domList) {
       var jobList = Array.from(domList.children);
 
-      if(filterSelect)
-      {
+      if (filterSelect) {
         // Get list of options from the HTML form
         var filterOptions = [];
         Array.from(filterSelect.options).forEach(function (el) {
           filterOptions.push(el.value);
         });
 
-        if(urlParams.has("filter"))
-        {
+        if (urlParams.has("filter")) {
           // If the page is loaded with inital URL parameters, change the default form selection and filter the results to reflect this
           var filterValue = urlParams.get("filter");
-          for(var n=0; n<filterOptions.length; n++)
-          {
-            if(filterOptions[n] === filterValue)
-            {
+          for (var n = 0; n < filterOptions.length; n++) {
+            if (filterOptions[n] === filterValue) {
               filterSelect.options.selectedIndex = n;
               break;
             }
@@ -128,22 +86,18 @@
         });
       }
 
-      if(locationSelect)
-      {
+      if (locationSelect) {
         // Get list of options from the HTML form
         var locationOptions = [];
         Array.from(locationSelect.options).forEach(function (el) {
           locationOptions.push(el.value);
         });
 
-        if(urlParams.has("location"))
-        {
+        if (urlParams.has("location")) {
           // If the page is loaded with inital URL parameters, change the default form selection and filter the results to reflect this
           var locationValue = urlParams.get("location");
-          for(var n=0; n<locationOptions.length; n++)
-          {
-            if(locationOptions[n] === locationValue)
-            {
+          for (var n = 0; n < locationOptions.length; n++) {
+            if (locationOptions[n] === locationValue) {
               locationSelect.options.selectedIndex = n;
               break;
             }
@@ -206,11 +160,8 @@
           node.classList.remove("u-hide");
         }
         numberOfJobsDisplayed = domList.childElementCount;
-      }
-      else if(filterBy.filterValue !== "all" && filterBy.location === "all")
-      {
-        if(node.dataset[filterBy.filterName].includes(filterBy.filterText))
-        {
+      } else if (filterBy.filterValue !== "all" && filterBy.location === "all") {
+        if (node.dataset[filterBy.filterName].includes(filterBy.filterText)) {
           if (node.classList.contains("u-hide")) {
             node.classList.remove("u-hide");
           }
@@ -220,11 +171,8 @@
           }
           numberOfJobsDisplayed--;
         }
-      }
-      else if(filterBy.filterValue === "all" && filterBy.location !== "all")
-      {
-        if(node.getAttribute("location-filter").includes(filterBy.location))
-        {
+      } else if (filterBy.filterValue === "all" && filterBy.location !== "all") {
+        if (node.getAttribute("location-filter").includes(filterBy.location)) {
           if (node.classList.contains("u-hide")) {
             node.classList.remove("u-hide");
           }
@@ -234,8 +182,7 @@
           }
           numberOfJobsDisplayed--;
         }
-      }
-      else {
+      } else {
         if (node.dataset[filterBy.filterName].includes(filterBy.filterText) && node.getAttribute("location-filter").includes(filterBy.location)) {
           if (node.classList.contains("u-hide")) {
             node.classList.remove("u-hide");

--- a/static/js/careers-filter-and-sort.js
+++ b/static/js/careers-filter-and-sort.js
@@ -12,6 +12,7 @@
   var locationFilters = [];
   var filterBy = {};
 
+  // Read data-location property and parse locations into well-defined categories
   function parseLocations() {
     const europe = ["emea", "slovakia", "bratislava", "europe", "uk", "germany", "berlin", "london", "worldwide"];
     const americas = ["americas", "southwest", "san francisco", "usa", "austin", "texas", "tx", "brazil", "seattle", "america", "worldwide"];
@@ -95,6 +96,7 @@
 
       if(filterSelect)
       {
+        // Get list of options from the HTML form
         var filterOptions = [];
         Array.from(filterSelect.options).forEach(function (el) {
           filterOptions.push(el.value);
@@ -102,6 +104,7 @@
 
         if(urlParams.has("filter"))
         {
+          // If the page is loaded with inital URL parameters, change the default form selection and filter the results to reflect this
           var filterValue = urlParams.get("filter");
           for(var n=0; n<filterOptions.length; n++)
           {
@@ -115,6 +118,7 @@
 
         updateFilterBy(filterSelect.options[filterSelect.options.selectedIndex].value);
 
+        // Add event listener that will update the URL and filter the results if the selected option is changed
         filterSelect.addEventListener("change", function () {
           if (!(sortSelect.options.selectedIndex === 0)) {
             sortSelect.options.selectedIndex = 0;
@@ -128,6 +132,7 @@
 
       if(locationSelect)
       {
+        // Get list of options from the HTML form
         var locationOptions = [];
         Array.from(locationSelect.options).forEach(function (el) {
           locationOptions.push(el.value);
@@ -135,6 +140,7 @@
 
         if(urlParams.has("location"))
         {
+          // If the page is loaded with inital URL parameters, change the default form selection and filter the results to reflect this
           var locationValue = urlParams.get("location");
           for(var n=0; n<locationOptions.length; n++)
           {
@@ -148,6 +154,7 @@
 
         updateLocationFilterBy(locationSelect.options[locationSelect.options.selectedIndex].value);
 
+        // Add event listener that will update the URL and filter the results if the selected option is changed
         locationSelect.addEventListener("change", function () {
           if (!(sortSelect.options.selectedIndex === 0)) {
             sortSelect.options.selectedIndex = 0;

--- a/static/js/careers-filter-and-sort.js
+++ b/static/js/careers-filter-and-sort.js
@@ -1,11 +1,11 @@
 (function () {
   const urlParams = new URLSearchParams(window.location.search);
   const domList = document.querySelector(".js-job-list");
-  const filterSelect = document.querySelector(".js-filter");
+  var filterSelect = document.querySelector(".js-filter");
   const noResults = document.querySelector(".js-filter__no-results");
   const jobContainer = document.querySelector(".js-filter-jobs-container");
   const sortSelect = document.querySelector(".js-sort");
-  const locationSelect = document.querySelector(".js-filter--location");
+  var locationSelect = document.querySelector(".js-filter--location");
 
   var numberOfJobsDisplayed = 0;
   var filters = [];
@@ -158,24 +158,24 @@
         
         if(queryFilter && locationFilter)
         {
-          updateOptions(filterSelect, filters, "filter");
-          updateOptions(locationSelect, locationFilters, "location");
+          filterSelect = updateOptions(filterSelect, queryFilter, filters, "filter");
+          locationSelect = updateOptions(locationSelect, locationFilter, locationFilters, "location");
           filterJobs(filterBy, jobList);
-          getEventListener(filterSelect, sortSelect, "filter", filterBy, jobList);
-          getEventListener(locationSelect, sortSelect, "location", filterBy, jobList);
+          filterSelect = getEventListener(filterSelect, sortSelect, "filter", filterBy, jobList);
+          locationSelect = getEventListener(locationSelect, sortSelect, "location", filterBy, jobList);
         }
         else if(queryFilter && !locationFilter)
         {
-          updateOptions(filterSelect, filters, "filter");
+          filterSelect = updateOptions(filterSelect, queryFilter, filters, "filter");
           filterJobs(filterBy, jobList);
-          getEventListener(filterSelect, sortSelect, "filter", filterBy, jobList);
+          filterSelect = getEventListener(filterSelect, sortSelect, "filter", filterBy, jobList);
 
         }
         else if(!queryFilter && locationFilter)
         {
-          updateOptions(locationSelect, locationFilters, "location");
+          locationSelect = updateOptions(locationSelect, locationFilter, locationFilters, "location");
           filterJobs(filterBy, jobList);
-          getEventListener(locationSelect, sortSelect, "location", filterBy, jobList);
+          locationSelect = getEventListener(locationSelect, sortSelect, "location", filterBy, jobList);
         }
       }
       else if(filterSelect && !locationSelect) {
@@ -183,9 +183,9 @@
 
         if(queryFilter)
         {
-          updateOptions(filterSelect, filters, "filter");
+          filterSelect = updateOptions(filterSelect, queryFilter, filters, "filter");
           filterJobs(filterBy, jobList);
-          getEventListener(filterSelect, sortSelect, "filter", filterBy, jobList);
+          filterSelect = getEventListener(filterSelect, sortSelect, "filter", filterBy, jobList);
         }
       }
       else if(!filterSelect && locationSelect) {
@@ -193,9 +193,9 @@
 
         if(locationFilter)
         {
-          updateOptions(locationSelect, locationFilters, "location");
+          locationSelect = updateOptions(locationSelect, locationFilter, locationFilters, "location");
           filterJobs(filterBy, jobList);
-          getEventListener(locationSelect, sortSelect, "location", filterBy, jobList);
+          locationSelect = getEventListener(locationSelect, sortSelect, "location", filterBy, jobList);
         }
       }
 
@@ -343,7 +343,7 @@
     });
   }
 
-  function updateOptions(filterSelect, filters, type)
+  function updateOptions(filterSelect, queryFilter, filters, type)
   {
     filterSelect.options.selectedIndex = filters.indexOf(queryFilter);
     if(type === "filter")
@@ -356,6 +356,7 @@
     }
     //filterJobs(filterBy, jobList);
     updateNoResultsMessage();
+    return filterSelect;
   }
 
   function getEventListener(filterSelect, sortSelect, type, filterBy, jobList)
@@ -375,6 +376,7 @@
     filterJobs(filterBy, jobList);
     updateURL(filterBy);
     updateNoResultsMessage();
+    return filterSelect;
     });
   }
 

--- a/templates/careers/_filters.html
+++ b/templates/careers/_filters.html
@@ -23,8 +23,8 @@
   </div>
   <div class="p-form__group">
     <label for="filter" aria-label="Filter by job location" class="p-form__label">Location</label>
-    <select class="js-filter p-form__control" id="filter" name="filter" aria-label="Filter by job location">
-      <option value="americas">All</option>
+    <select class="js-filter--location p-form__control" id="filter" name="filter" aria-label="Filter by job location">
+      <option value="all">All</option>
     </select>
   </div>
 </form>

--- a/templates/careers/_filters.html
+++ b/templates/careers/_filters.html
@@ -21,6 +21,13 @@
       {% endif %}
     </select>
   </div>
+  <div class="p-form__group">
+    <label for="filter" aria-label="Filter by job location" class="p-form__label">Location</label>
+    <select class="js-filter p-form__control" id="filter" name="filter" aria-label="Filter by job location">
+      <option value="americas">Americas</option>
+      <option value=""
+    </select>
+  </div>
 </form>
 
 <hr />

--- a/templates/careers/_filters.html
+++ b/templates/careers/_filters.html
@@ -12,16 +12,6 @@
     </select>
   </div>
   <div class="p-form__group">
-    <label for="sort" aria-label="Sort resources" class="p-form__label">Sort by</label>
-    <select class="js-sort p-form__control" id="sort" name="sort" aria-label="Sort resources">
-      <option value="date">Date</option value="">
-      <option value="location">Location</option>
-      {% if request.path == "/careers/all"%}
-      <option value="sector">Job sector</option>
-      {% endif %}
-    </select>
-  </div>
-  <div class="p-form__group">
     <label for="filter" aria-label="Filter by job location" class="p-form__label">Location</label>
     <select class="js-filter--location p-form__control" id="location-filter" name="filter" aria-label="Filter by job location">
       <option value="all">All</option>
@@ -31,6 +21,16 @@
       <option value="middle-east">Middle East</option>
       <option value="africa">Africa</option>
       <option value="oceania">Oceania</option>
+    </select>
+  </div>
+  <div class="p-form__group">
+    <label for="sort" aria-label="Sort resources" class="p-form__label">Sort by</label>
+    <select class="js-sort p-form__control" id="sort" name="sort" aria-label="Sort resources">
+      <option value="date">Date</option value="">
+      <option value="location">Location</option>
+      {% if request.path == "/careers/all"%}
+      <option value="sector">Job sector</option>
+      {% endif %}
     </select>
   </div>
 </form>

--- a/templates/careers/_filters.html
+++ b/templates/careers/_filters.html
@@ -23,8 +23,14 @@
   </div>
   <div class="p-form__group">
     <label for="filter" aria-label="Filter by job location" class="p-form__label">Location</label>
-    <select class="js-filter--location p-form__control" id="filter" name="filter" aria-label="Filter by job location">
+    <select class="js-filter--location p-form__control" id="location-filter" name="filter" aria-label="Filter by job location">
       <option value="all">All</option>
+      <option value="europe">Europe</option>
+      <option value="americas">Americas</option>
+      <option value="asia">Asia</option>
+      <option value="middle-east">Middle East</option>
+      <option value="africa">Africa</option>
+      <option value="oceania">Oceania</option>
     </select>
   </div>
 </form>

--- a/templates/careers/_filters.html
+++ b/templates/careers/_filters.html
@@ -24,8 +24,7 @@
   <div class="p-form__group">
     <label for="filter" aria-label="Filter by job location" class="p-form__label">Location</label>
     <select class="js-filter p-form__control" id="filter" name="filter" aria-label="Filter by job location">
-      <option value="americas">Americas</option>
-      <option value=""
+      <option value="americas">All</option>
     </select>
   </div>
 </form>


### PR DESCRIPTION
## Done

Added the ability to filter jobs by location on the careers pages

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/careers/all
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Ensure that jobs are properly filtered by location, and that the new field is compatible with the existing "Filter by" and "Sort by" fields.
- Ensure that the code is sensible and in line with any Canonical style guides

## Issue / Card

Fixes #189 