### PR TITLE
Change GTM tag

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -17,6 +17,13 @@
     <meta property="og:url" content="{{ request.url }}">
     <meta property="og:site_name" content="Canonical">
 
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-M5BPGQ6');</script>
+
     <title>Canonical | {% block title %}Publisher of Ubuntu{% endblock %}</title>
     {% if self.title() %}
     <meta name="twitter:title" content="{{ self.title() }} | Canonical">
@@ -64,15 +71,9 @@
   </head>
 
   <body>
-    <!-- Google Tag Manager -->
-    <noscript><iframe src="//www.googletagmanager.com/ns.html?id=GTM-K92JCQ"
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-M5BPGQ6"
     height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-    '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-    })(window,document,'script','dataLayer','GTM-K92JCQ');</script>
-    <!-- End Google Tag Manager -->
 
     <div id="main-content">
       {% include "partial/_navigation.html" %}


### PR DESCRIPTION
## Done

- To migrate to the new cookie policy, it is safer to move canonical.com out of the ubuntu.com GTM container - this is that move.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- See that it is correctly using the new `GTM-M5BPGQ6` container

## Issue / Card

Fixes #284 

