### PR TITLE
Stop squishing and better align /partners/find-a-partner logos

### DIFF
--- a/templates/partners/find-a-partner.html
+++ b/templates/partners/find-a-partner.html
@@ -142,8 +142,7 @@
             <a href="/{{ partner['slug'] }}">
             {% endif %}
             {% if partner['logo'] %}
-              <div style="height: 5rem;display: flex;
-align-items: flex-end;">
+              <div style="height: 5rem; display: flex; align-items: flex-end;">
                 <img src="{{ partner['logo'] }}" alt="image for {{ partner['name'] }}" style="max-height: 5rem; max-width: 10rem;" loading="lazy">
               </div>
             {% endif %}

--- a/templates/partners/find-a-partner.html
+++ b/templates/partners/find-a-partner.html
@@ -142,8 +142,10 @@
             <a href="/{{ partner['slug'] }}">
             {% endif %}
             {% if partner['logo'] %}
-              <img src="{{ partner['logo'] }}" alt="image for {{ partner['name'] }}" style="max-height: 3rem; max-width: 15rem; min-width: 5rem;" loading="lazy">
-
+              <div style="height: 5rem;display: flex;
+align-items: flex-end;">
+                <img src="{{ partner['logo'] }}" alt="image for {{ partner['name'] }}" style="max-height: 5rem; max-width: 10rem;" loading="lazy">
+              </div>
             {% endif %}
             </a>
             <p>


### PR DESCRIPTION
## Done

- Stop squishing and better align /partners/find-a-partner logos as reported by @zprood

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/partners/find-a-partner logos
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare HP or Hwawei's logos on live to this branch
