### PR TITLE
Fix links in career mega-menu

### DIFF
--- a/templates/partial/navigation-careers.html
+++ b/templates/partial/navigation-careers.html
@@ -9,7 +9,7 @@
           <p>You love to make software work perfectly and efficiently. Your analytical approach, your intellect, your teamwork and your work ethic put you at the top of your game. You are self-motivated and organised. And you really care to work on a platform that is freely available to everybody on the planet.</p>
           <p><a href="/careers/engineering">More&hellip;</a></p>
           <div class="u-hide u-show--small">
-            <small>Europe | Americas | Asia-Pacific | Middle East | Africa</small>
+            <small><a class="p-link--soft" href="/careers/engineering?filter=all&location=europe#available-roles">Europe</a> | <a class="p-link--soft" href="/careers/engineering?filter=all&location=americas#available-roles">Americas</a> | <a class="p-link--soft" href="/careers/engineering?filter=all&location=asia#available-roles">Asia-Pacific</a> | <a class="p-link--soft" href="/careers/engineering?filter=all&location=middle-east#available-roles">Middle East</a> | <a class="p-link--soft" href="/careers/engineering?filter=all&location=africa#available-roles">Africa</a></small>
             <p><a href="/careers/engineering#apply">Apply now&nbsp;&rsaquo;</a></p>
             <hr />
           </div>
@@ -22,7 +22,7 @@
           <p>You are also passionate about message and language, and strive to find the best way to share a powerful idea that drives action.</p>
           <p><a href="/careers/marketing">More&hellip;</a></p>
           <div class="u-hide u-show--small">
-            <small>Europe | Americas</small>
+            <small><a class="p-link--soft" href="/careers/marketing?filter=all&location=europe#available-roles">Europe</a> | <a class="p-link--soft" href="/careers/marketing?filter=all&location=americas#available-roles">Americas</a></small>
             <p><a href="/careers/marketing#apply">Apply now&nbsp;&rsaquo;</a></p>
             <hr />
           </div>
@@ -33,7 +33,7 @@
           <p>Your approach is consultative, you are results and goal oriented, and you know how to invest your time. Most importantly, you care that the customer gets the best result &mdash; every time. You know that long term relationships require commitment and continuity, patience and precision. That’s what makes you different.</p>
           <p><a href="/careers/sales">More&hellip;</a></p>
           <div class="u-hide u-show--small">
-            <small>Europe | Americas | Asia-Pacific | Middle East | Africa</small>
+            <small><a class="p-link--soft" href="/careers/sales?filter=all&location=europe#available-roles">Europe</a> | <a class="p-link--soft" href="/careers/sales?filter=all&location=americas#available-roles">Americas</a> | <a class="p-link--soft" href="/careers/sales?filter=all&location=asia#available-roles">Asia-Pacific</a> | <a class="p-link--soft" href="/careers/sales?filter=all&location=middle-east#available-roles">Middle East</a> | <a class="p-link--soft" href="/careers/sales?filter=all&location=africa#available-roles">Africa</a></small>
             <p><a href="/careers/sales#apply">Apply now&nbsp;&rsaquo;</a></p>
             <hr />
           </div>
@@ -60,17 +60,17 @@
       <div class="row u-hide--small">
         <div class="col-3">
           <hr />
-          <small>Europe | Americas | Asia-Pacific | Middle East | Africa</small>
+          <small><a class="p-link--soft" href="/careers/engineering?filter=all&location=europe#available-roles">Europe</a> | <a class="p-link--soft" href="/careers/engineering?filter=all&location=americas#available-roles">Americas</a> | <a class="p-link--soft" href="/careers/engineering?filter=all&location=asia#available-roles">Asia-Pacific</a> | <a class="p-link--soft" href="/careers/engineering?filter=all&location=middle-east#available-roles">Middle East</a> | <a class="p-link--soft" href="/careers/engineering?filter=all&location=africa#available-roles">Africa</a></small>
           <p><a href="/careers/engineering#apply">Apply now&nbsp;&rsaquo;</a></p>
         </div>
         <div class="col-3">
           <hr />
-          <small>Europe | Americas</small>
+          <small><a class="p-link--soft" href="/careers/marketing?filter=all&location=europe#available-roles">Europe</a> | <a class="p-link--soft" href="/careers/marketing?filter=all&location=americas#available-roles">Americas</a></small>
           <p><a href="/careers/marketing#apply">Apply now&nbsp;&rsaquo;</a></p>
         </div>
         <div class="col-3">
           <hr />
-          <small>Europe | Americas | Asia-Pacific | Middle East | Africa</small>
+          <small><a class="p-link--soft" href="/careers/sales?filter=all&location=europe#available-roles">Europe</a> | <a class="p-link--soft" href="/careers/sales?filter=all&location=americas#available-roles">Americas</a> | <a class="p-link--soft" href="/careers/sales?filter=all&location=asia#available-roles">Asia-Pacific</a> | <a class="p-link--soft" href="/careers/sales?filter=all&location=middle-east#available-roles">Middle East</a> | <a class="p-link--soft" href="/careers/sales?filter=all&location=africa#available-roles">Africa</a></small>
           <p><a href="/careers/sales#apply">Apply now&nbsp;&rsaquo;</a></p>
         </div>
         <div class="col-3">
@@ -83,11 +83,11 @@
       <div class="row">
         <div class="col-10">
           <ul class="p-inline-list--middot is-x-dense">
-            <li class="p-inline-list__item"><a href="/career/lifestyle">Lifestyle</a></li>
-            <li class="p-inline-list__item"><a href="/career/ethics">Ethics</a></li>
-            <li class="p-inline-list__item"><a href="/career/travel">Travel</a></li>
-            <li class="p-inline-list__item"><a href="/career/progression">Progression</a></li>
-            <li class="p-inline-list__item"><a href="/career/diversity">Diversity</a></li>
+            <li class="p-inline-list__item"><a href="/careers/lifestyle">Lifestyle</a></li>
+            <li class="p-inline-list__item"><a href="/careers/ethics">Ethics</a></li>
+            <li class="p-inline-list__item"><a href="/careers/travel">Travel</a></li>
+            <li class="p-inline-list__item"><a href="/careers/progression">Progression</a></li>
+            <li class="p-inline-list__item"><a href="/careers/diversity">Diversity</a></li>
           </ul>
         </div>
       </div>


### PR DESCRIPTION
## Done

Fix links in career mega-menu

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/projects and click on the careers menu item and look at the links for regions and 
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that all the region and 'Lifestyle Ethics Travel Progression Diversity' work, both large and small screens


## Issue / Card

Fixes #301 

## Screenshots

![image](https://user-images.githubusercontent.com/441217/97468346-128f1b00-193d-11eb-9918-c3e83e0e109d.png)
