### PR TITLE
Update cookie policy to 3.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test-python": "python3 -m unittest discover tests"
   },
   "dependencies": {
-    "@canonical/cookie-policy": "3.0.4",
+    "@canonical/cookie-policy": "3.0.5",
     "autoprefixer": "10.0.1",
     "concurrently": "5.3.0",
     "node-sass": "4.14.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -230,10 +230,10 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@canonical/cookie-policy@3.0.4":
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/@canonical/cookie-policy/-/cookie-policy-3.0.4.tgz#c2d6d990dc0993344a9bf5c244374e3f51fe34f1"
-  integrity sha512-pI65cRFh9xU2xo3d9R8ifGbQoH72tk3p8xh/4ANuj9kREeh9G/gcim/iHQS7IffSocHT9l6ZtUXBcQ12m/CBMw==
+"@canonical/cookie-policy@3.0.5":
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/@canonical/cookie-policy/-/cookie-policy-3.0.5.tgz#99e6d873832016c698534abda10f1ac17df65a3a"
+  integrity sha512-LLb4LnjPSdpR8fNywxpOLsmL5Fm7KbxmpTiJ8Syj+4LqHzB7WPAgR9UsmLebJ8G4BjFx92IHribWUFfOJAD20g==
 
 "@nodelib/fs.scandir@2.1.3":
   version "2.1.3"


### PR DESCRIPTION
## Done

- Add cookie policy module

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/partners
- Check you see the cookie policy module panel
- Open the manager and make a selection
- The panel should disappear and the `_cookies_accepted` cookie should be set
- See that the cookie's path is set to '/'