### PR TITLE
Swap Yahoo! Japan with Huawei logo

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -289,7 +289,7 @@
           <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/a78cad70-china-telecom.svg" width="135" height="38" alt="China Telecom logo">
         </li>
         <li class="p-inline-images__item">
-          <img class="p-inline-images__logo" src="https://assets.ubuntu.com/v1/5d403409-2018-logo-yahoo-japan.svg" width="144" height="37" alt="Yahoo Japan logo">
+          <img src="https://assets.ubuntu.com/v1/80fe0ebe-Huawei-logo.svg" width="167" height="38" alt="Huawei logo">
         </li>
       </ul>
     </div>


### PR DESCRIPTION
## Done

- Swap Yahoo! Japan with Huawei logo

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See Huawie's logo and no Yahoo! Japan


## Issue / Card

Fixes #313

## Screenshots

![image](https://user-images.githubusercontent.com/441217/99907707-36dcde00-2cd6-11eb-8383-1b1af4b69410.png)
