### PR TITLE
Fix link to gsi partners on /partners/gsi

### DIFF
--- a/templates/partners/gsi.html
+++ b/templates/partners/gsi.html
@@ -34,7 +34,7 @@
       </li>
       {% endfor %}
     </ul>
-    <p class="u-align-text--center"><a href="/partners/find-a-partner?filters=gsi">See all of our gsi partners&nbsp;&rsaquo;</a></p>
+    <p class="u-align-text--center"><a href="/partners/find-a-partner?filters=global-system-integrators">See all of our gsi partners&nbsp;&rsaquo;</a></p>
   </div>
 </section>
 {% endif %}


### PR DESCRIPTION
## Done

-Fix link to gsi partners on /partners/gsi

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/partners/gsi
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the link to all partners is now correct `/partners/find-a-partner?filters=global-system-integrators`

