### PR TITLE
Make /career filters fit on one row

### DIFF
--- a/static/sass/_pattern_forms.scss
+++ b/static/sass/_pattern_forms.scss
@@ -29,8 +29,8 @@
 
         .p-form__label {
           flex-shrink: 0;
-          padding-right: $sph-inner;
-          width: 6rem;
+          padding-right: $sph-inner/4;
+          width: 4rem;
         }
 
         .p-form__control {


### PR DESCRIPTION
## Done

Make /career filters fit on one row

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/careers/all
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the filters fit on 1 row


## Issue / Card

Fixes #322

## Screenshots

![image](https://user-images.githubusercontent.com/441217/106896933-27244180-66ea-11eb-903b-d1f88509412e.png)
