### PR TITLE
Clean up typography on job descriptions

### DIFF
--- a/.env
+++ b/.env
@@ -2,4 +2,6 @@ PORT=8002
 FLASK_DEBUG=true
 DEVEL=true
 SECRET_KEY=local_development_fake_key
+
+# https://canonical.greenhouse.io/configure/dev_center/credentials
 HARVEST_API_KEY=

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+bleach==3.3.0
 canonicalwebteam.flask-base==0.7.3
 canonicalwebteam.http==1.0.3
 canonicalwebteam.templatefinder==1.0.0

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -187,3 +187,28 @@ $p-small-lh-diff: map-get($line-heights, default-text) -
     }
   }
 }
+
+// Override h2 in job descriptions to look like h3
+.job-desc {
+  h1 {
+    @extend %vf-heading-2;
+  }
+
+  h2 {
+    @extend %vf-heading-3;
+  }
+
+  h3 {
+    @extend %vf-heading-4;
+  }
+
+  strong {
+    font-weight: 100 !important;
+  }
+
+  // Hide any empty p tags or consecutive breaks
+  p:empty,
+  br + br {
+    display: none;
+  }
+}

--- a/templates/careers/job-detail.html
+++ b/templates/careers/job-detail.html
@@ -45,7 +45,12 @@
   <a href="{% if request.referrer %}{{ request.referrer }}{% else %}/careers/all{% endif %}" class="u-sv2">&lsaquo;&nbsp;Back to list</a>
   <h2 class="u-no-margin--bottom u-sv1">{{ job.title }}</h2>
   <p class="p-muted-heading">{{ job.location }}</p>
-  {{ job.content | safe }}
+  <div class="job-desc">
+    {% set job_content = job.content.replace("<p>&nbsp;</p>", "") %}
+    {% set allowed_tags = ['h2', 'h3', 'h4', 'h5', 'h6', 'p', 'a', 'strong', 'ul', 'ol', 'li', 'i', 'em', 'br'] %}
+
+    {{ bleach.clean(job_content, tags=allowed_tags, strip=True) | safe }}
+  </div>
 </div>
 <div class="row u-sv2">
   <hr />

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -123,7 +123,7 @@ def results():
 @app.route("/careers/<regex('[0-9]+'):job_id>", methods=["GET", "POST"])
 def job_details(job_id):
     context = render_navigation()
-    context['bleach'] = bleach
+    context["bleach"] = bleach
     context["job"] = greenhouse_api.get_vacancy(job_id)
     if not context["job"]:
         flask.abort(404)

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -1,4 +1,5 @@
 # Standard library
+import bleach
 import datetime
 import flask
 import markdown
@@ -122,6 +123,7 @@ def results():
 @app.route("/careers/<regex('[0-9]+'):job_id>", methods=["GET", "POST"])
 def job_details(job_id):
     context = render_navigation()
+    context['bleach'] = bleach
     context["job"] = greenhouse_api.get_vacancy(job_id)
     if not context["job"]:
         flask.abort(404)


### PR DESCRIPTION
## Done

Clean up typography on job descriptions by removing inline styles and empty paragraphs.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Click through different job descriptions
- Ensure typography is consistent