### PR TITLE
SEO fixes for job listings

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -27,7 +27,7 @@
     <!-- Google optomise -->
     <script async src="https://www.googleoptimize.com/optimize.js?id=OPT-KMJNW6P"></script>
 
-    <title>Canonical | {% block title %}Publisher of Ubuntu{% endblock %}</title>
+    <title>{% block title %}Publisher of Ubuntu{% endblock %} | Canonical</title>
     {% if self.title() %}
     <meta name="twitter:title" content="{{ self.title() }} | Canonical">
     <meta property="og:title" content="{{ self.title() }} | Canonical">

--- a/templates/careers/admin.html
+++ b/templates/careers/admin.html
@@ -2,7 +2,7 @@
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1LRQrvgLlNnaBsW1RD7WLlNLZbn6-zj0EUtXr2jtMh3M/edit{% endblock %}
 
-{% block title %}Admin{% endblock %}
+{% block title %}Admin | Careers{% endblock %}
 
 {% block meta_description %}Canonical is a global distributed company with many offices and hundreds of remote workers.  This means the admin team a complex and rewarding role to help the company work effectively as possible.{% endblock %}
 

--- a/templates/careers/all.html
+++ b/templates/careers/all.html
@@ -2,7 +2,7 @@
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1adoe3jR-_O3EC4LECotKiPo2SsC_Ht5YPTR0wr-BhH0{% endblock meta_copydoc %}
 
-{% block title %}All job roles{% endblock %}
+{% block title %}All job roles | Careers{% endblock %}
 
 {% block meta_description %}Canonical publishes Ubuntu, provides commercial services and solutions for Ubuntu, and works with hardware manufacturers, software vendors and public.{% endblock %}
 

--- a/templates/careers/apply.html
+++ b/templates/careers/apply.html
@@ -1,6 +1,6 @@
 {% extends '/careers/base.html' %}
 
-{% block title %}Apply now{% endblock %}
+{% block title %}Apply now | Careers{% endblock %}
 
 {% block meta_description %}Apply for a role at Canonical.{% endblock %}
 

--- a/templates/careers/diversity.html
+++ b/templates/careers/diversity.html
@@ -2,7 +2,7 @@
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1L8z8Np75JN2wJa72iVrv-eRFzGiqiGW4HZiD8muPOAQ{% endblock meta_copydoc %}
 
-{% block title %}Diversity{% endblock %}
+{% block title %}Diversity | Careers{% endblock %}
 
 {% block meta_description %}Canonical proactively promotes leaders who represent new kinds of diversity, to grow the confidence of colleagues from every walk of life. We seek to create an environment that is welcoming to outstanding technology and business professionals committed to teamwork and open source.{% endblock %}
 

--- a/templates/careers/engineering.html
+++ b/templates/careers/engineering.html
@@ -2,7 +2,7 @@
 
 {% block meta_copydoc %}https://docs.google.com/document/d/14gNX9sCgQUM1H0Hfl46R3Wvw0E91XjsuyStMV4KvKME{% endblock meta_copydoc %}
 
-{% block title %}Engineering{% endblock %}
+{% block title %}Engineering | Careers{% endblock %}
 
 {% block meta_description %}Open source is transforming the entire stack. This is your chance to be right at the center of that revolution, to shape the platforms and tools that millions use to invent our global technology future.{% endblock %}
 

--- a/templates/careers/ethics.html
+++ b/templates/careers/ethics.html
@@ -2,7 +2,7 @@
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1K2pY9lFlKvdL3jZ6Ih5sgritIP23z_KQS3DVMlZxbqw{% endblock meta_copydoc %}
 
-{% block title %}Trust{% endblock %}
+{% block title %}Trust | Careers{% endblock %}
 
 {% block meta_description %}Trust in Canonical’s Ubuntu and other products is well-earned and critical to our future. We have a very high expectation of ethical behaviour at the company and in particular among leaders of any sort.{% endblock %}
 

--- a/templates/careers/finance.html
+++ b/templates/careers/finance.html
@@ -2,7 +2,7 @@
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1R4i26Ov-ccfrXm8uSdSRApxgXDH3HwZVY8qWQqPpIjg{% endblock meta_copydoc %}
 
-{% block title %}Finance{% endblock %}
+{% block title %}Finance | Careers{% endblock %}
 
 {% block meta_description %}Finance at Canonical isn’t just about numbers. It’s about connecting with people across the business, helping them to understand the value they bring, as well as promoting the commercial focus that will grow our brand.{% endblock %}
 

--- a/templates/careers/human-resources.html
+++ b/templates/careers/human-resources.html
@@ -2,7 +2,7 @@
 
 {% block meta_copydoc %}https://docs.google.com/document/d/14YcOjgNRr6k4JQCSB-Qs5MxVO-JNd2P-HjxzGFDvZkY{% endblock meta_copydoc %}
 
-{% block title %}Human Resources{% endblock %}
+{% block title %}Human Resources | Careers{% endblock %}
 
 
 {% block meta_description %}Canonical provides a unique window into the world of 21st-century digital business. We work with smart individuals from a wide range of professional backgrounds in more than 40 countries worldwide, bringing together.{% endblock %}

--- a/templates/careers/job-detail.html
+++ b/templates/careers/job-detail.html
@@ -1,6 +1,6 @@
 {% extends '/careers/base.html' %}
 
-{% block title %}Jobs | {{ job.title }}{% if "Home" in job.location %}, remote{% else %} at {{ job.location }}{% endif %}{% endblock %}
+{% block title %}{{ job.metatitle }} | Careers{% endblock %}
 
 {% block meta_description %}{% if job.description %}{{ job.description }}{% else %}Canonical offers a truly distributed workplace for exceptional colleagues who are self-motivated, organised. Maintain a home office and experience the top of global technology strategy and engineering. Travel regularly to interesting destinations for team, conference and customer engagements.{% endif %}{% endblock %}
 

--- a/templates/careers/job-detail.html
+++ b/templates/careers/job-detail.html
@@ -1,8 +1,8 @@
 {% extends '/careers/base.html' %}
 
-{% block title %}Job details{% endblock %}
+{% block title %}Jobs | {{ job.title }}{% if "Home" in job.location %}, remote{% else %} at {{ job.location }}{% endif %}{% endblock %}
 
-{% block meta_description %}Canonical offers a truly distributed workplace for exceptional colleagues who are self-motivated, organised. Maintain a home office and experience the top of global technology strategy and engineering. Travel regularly to interesting destinations for team, conference and customer engagements.{% endblock %}
+{% block meta_description %}{% if job.description %}{{ job.description }}{% else %}Canonical offers a truly distributed workplace for exceptional colleagues who are self-motivated, organised. Maintain a home office and experience the top of global technology strategy and engineering. Travel regularly to interesting destinations for team, conference and customer engagements.{% endif %}{% endblock %}
 
 {% block hero %}
 <section class="p-strip--image is-dark is-deep u-no-padding--top u-no-padding--bottom u-extra-space">

--- a/templates/careers/legal.html
+++ b/templates/careers/legal.html
@@ -2,7 +2,7 @@
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1aZSmg1coz5QKm-NLgzU0BwQbqIaGlwDzPGVH3Yju66k{% endblock meta_copydoc %}
 
-{% block title %}Legal{% endblock %}
+{% block title %}Legal | Careers{% endblock %}
 
 {% block meta_description %}Canonical works at the forefront of global digital trends and the legal, licensing and regulatory frameworks that support them. We are a tight-knit team of professionals that enjoy playing a part in the rapid change.{% endblock %}
 

--- a/templates/careers/lifestyle.html
+++ b/templates/careers/lifestyle.html
@@ -2,7 +2,7 @@
 
 {% block meta_copydoc %}https://docs.google.com/document/d/15Ofb6vRUXbQ3evcWmrOu9ymuY37ayg4M_xZ2QXQyIts{% endblock meta_copydoc %}
 
-{% block title %}Lifestyle{% endblock %}
+{% block title %}Lifestyle | Careers{% endblock %}
 
 {% block meta_description %}Canonical offers a truly distributed workplace for exceptional colleagues who are self-motivated, organised. Maintain a home office and experience the top of global technology strategy and engineering. Travel regularly to interesting destinations for team, conference and customer engagements.{% endblock %}
 

--- a/templates/careers/marketing.html
+++ b/templates/careers/marketing.html
@@ -2,7 +2,7 @@
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1e35Ux74NQ5s4XCUqLFnRAukCJca7AvWDZWofHz1Y2go{% endblock meta_copydoc %}
 
-{% block title %}Marketing{% endblock %}
+{% block title %}Marketing | Careers{% endblock %}
 
 {% block meta_description %}We deliver the right technology message to a highly competent audience, at exactly the right moment. Success depends on having good instincts for tech trends and topics and a natural inclination to leadership.{% endblock %}
 

--- a/templates/careers/operations.html
+++ b/templates/careers/operations.html
@@ -3,7 +3,7 @@
 {% block meta_copydoc %}https://docs.google.com/document/d/1y2bqWcHW2rRrb5gA7XTt8_A0q6zPOLkkOIwCIaNLpTk/edit
 {% endblock %}
 
-{% block title %}Operations{% endblock %}
+{% block title %}Operations | Careers{% endblock %}
 
 {% block meta_description %}Excellence in operations enables Canonical to scale efficiently. We look for people who are passionate about tools and efficiency.{% endblock %}
 

--- a/templates/careers/progression.html
+++ b/templates/careers/progression.html
@@ -2,7 +2,7 @@
 
 {% block meta_copydoc %}https://docs.google.com/document/d/13lzdbhQ2mmNPuwBdajOubNyRxXAXTt5lRq0iUk5HfuQ{% endblock meta_copydoc %}
 
-{% block title %}Progression{% endblock %}
+{% block title %}Progression | Careers{% endblock %}
 
 {% block meta_description %}Canonical prefers internal promotion and encourages high-performing colleagues to pursue diverse roles at the company over the course of their career, to develop a well-rounded perspective.{% endblock %}
 

--- a/templates/careers/project-management.html
+++ b/templates/careers/project-management.html
@@ -1,6 +1,6 @@
 {% extends '/careers/base-tabs.html' %}
 
-{% block title %}Project Management{% endblock %}
+{% block title %}Project Management | Careers{% endblock %}
 
 {% block meta_description %}Canonical’s Engagement Project Management Office team owns, drives and communicates delivery excellence by providing strong Project process guidelines,  project continuity and data analytics.{% endblock %}
 

--- a/templates/careers/sales.html
+++ b/templates/careers/sales.html
@@ -2,7 +2,7 @@
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1fGBFiIfy7C58UXcJ0Q7q6VKxClxBfPyeWBSyO9GrStI{% endblock meta_copydoc %}
 
-{% block title %}Sales{% endblock %}
+{% block title %}Sales | Careers{% endblock %}
 
 {% block meta_description %}Canonical is looking for Sales Professionals that are Trusted Advisors which bring confidence to our customers that we understand their transformation to multi-cloud, and we can bring the right solutions to the table in order to solve those problems.{% endblock %}
 

--- a/templates/careers/techops.html
+++ b/templates/careers/techops.html
@@ -2,7 +2,7 @@
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1wzuu4pnd2Sx2BDONaaR9EaYUSjx7diTu6PzvYYwbMA8{% endblock meta_copydoc %}
 
-{% block title %}TechOps{% endblock %}
+{% block title %}TechOps | Careers{% endblock %}
 
 {% block meta_description %}Getting it done right is the best feeling in the world. Whether it’s running complex technical infrastructure or challenging projects, your consistent focus on data, organisation and teamwork means you’re a force for good in the battle against entropy.{% endblock %}
 

--- a/templates/careers/travel.html
+++ b/templates/careers/travel.html
@@ -2,7 +2,7 @@
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1H2ILhAUckOWyah_6V69ImwLWOSRlXkaYnIhOHkUjclc{% endblock meta_copydoc %}
 
-{% block title %}Travel{% endblock %}
+{% block title %}Travel | Careers{% endblock %}
 
 {% block meta_description %}Travel is central to Canonical’s global, distributed workplace. All teams participate in regular team and cross-team events. We spread locations across time zones and look for interesting and diverse cultural places. Many employees return to these destinations with friends and family.{% endblock %}
 

--- a/templates/careers/web-and-design.html
+++ b/templates/careers/web-and-design.html
@@ -2,7 +2,7 @@
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1V8SzuqyJEqXAXf_FrobdNn5-OLzTvKWcRlfBXjI9oBo{% endblock meta_copydoc %}
 
-{% block title %}Web & design{% endblock %}
+{% block title %}Web & design | Careers{% endblock %}
 
 {% block meta_description %}The design team at Canonical crafts and builds the user-experience for sophisticated technical specialists across a wide range of industries and geographies.{% endblock %}
 

--- a/templates/partial/_careers-job-list.html
+++ b/templates/partial/_careers-job-list.html
@@ -1,12 +1,12 @@
 <ul class="p-list--divided js-job-list">
   {% for job in vacancies %}
-  <li 
-    class="p-list__item" 
-    data-office="{{ job.office }}" 
-    data-employment="{{ job.employment }}" 
-    data-date="{{ job.date }}" 
-    data-location="{{ job.location }}" 
-    data-management="{{ job.management}}" 
+  <li
+    class="p-list__item"
+    data-office="{{ job.office }}"
+    data-employment="{{ job.employment }}"
+    data-date="{{ job.date }}"
+    data-location="{{ job.location }}"
+    data-management="{{ job.management}}"
     data-sector="{{ job.department }}"
   >
     <p class="u-no-margin--bottom u-sv1">
@@ -20,9 +20,12 @@
     <input type="checkbox" name="roles" id="{{ job.id }}" value="{{ job.id }}" />
     <label class="p-checkbox-label--h2 u-no-padding--top" for="{{ job.id }}">
     {% endif %}
-      <h2 class="p-heading--three {% if checkbox %}u-sv3{% else %}u-no-padding--top u-sv1{% endif %}">
-        <a class="p-link--soft" href="/careers/{{ job.id }}">{{ job.title }}&nbsp;&rsaquo;</a>
+      <h2 class="p-heading--three {% if checkbox %}u-sv3{% else %}u-no-padding--top{% endif %}{% if job.description %} u-no-margin--bottom{% else %} u-sv1{% endif %}">
+        <a class="p-link--soft" href="/careers/{{ job.id }}/{{ job.title | replace(" ","-") | replace("---", "-") | replace("&", "and") | lower | urlencode }}-{% if "Home" in job.location %}remote{% else %}{{ job.location | lower | replace(" ", "-") | replace("---", "-") | replace("&", "and") | urlencode }}{% endif %}">{{ job.title }}&nbsp;&rsaquo;</a>
       </h2>
+      {% if job.description %}
+      <p clss="u-sv1">{{ job.description }}</p>
+      {% endif %}
     {% if checkbox %}
     </label>
     {% endif %}

--- a/templates/partial/_careers-job-list.html
+++ b/templates/partial/_careers-job-list.html
@@ -21,7 +21,7 @@
     <label class="p-checkbox-label--h2 u-no-padding--top" for="{{ job.id }}">
     {% endif %}
       <h2 class="p-heading--three {% if checkbox %}u-sv3{% else %}u-no-padding--top{% endif %}{% if job.description %} u-no-margin--bottom{% else %} u-sv1{% endif %}">
-        <a class="p-link--soft" href="/careers/{{ job.id }}/{{ job.joburl }}">{{ job.title }}&nbsp;&rsaquo;</a>
+        <a class="p-link--soft" href="/careers/{{ job.id }}/{{ job.url_suffix }}">{{ job.title }}&nbsp;&rsaquo;</a>
       </h2>
       {% if job.description %}
       <p clss="u-sv1">{{ job.description }}</p>

--- a/templates/partial/_careers-job-list.html
+++ b/templates/partial/_careers-job-list.html
@@ -21,7 +21,7 @@
     <label class="p-checkbox-label--h2 u-no-padding--top" for="{{ job.id }}">
     {% endif %}
       <h2 class="p-heading--three {% if checkbox %}u-sv3{% else %}u-no-padding--top{% endif %}{% if job.description %} u-no-margin--bottom{% else %} u-sv1{% endif %}">
-        <a class="p-link--soft" href="/careers/{{ job.id }}/{{ job.title | replace(" ","-") | replace("---", "-") | replace("&", "and") | replace("(","") | replace(")","") | lower | urlencode }}-{% if "Home" in job.location %}remote{% else %}{{ job.location | replace(" ","-") | replace("---", "-") | replace("&", "and") | replace("(","") | replace(")","") | lower | urlencode }}{% endif %}">{{ job.title }}&nbsp;&rsaquo;</a>
+        <a class="p-link--soft" href="/careers/{{ job.id }}/{{ job.joburl }}">{{ job.title }}&nbsp;&rsaquo;</a>
       </h2>
       {% if job.description %}
       <p clss="u-sv1">{{ job.description }}</p>

--- a/templates/partial/_careers-job-list.html
+++ b/templates/partial/_careers-job-list.html
@@ -21,7 +21,7 @@
     <label class="p-checkbox-label--h2 u-no-padding--top" for="{{ job.id }}">
     {% endif %}
       <h2 class="p-heading--three {% if checkbox %}u-sv3{% else %}u-no-padding--top{% endif %}{% if job.description %} u-no-margin--bottom{% else %} u-sv1{% endif %}">
-        <a class="p-link--soft" href="/careers/{{ job.id }}/{{ job.title | replace(" ","-") | replace("---", "-") | replace("&", "and") | lower | urlencode }}-{% if "Home" in job.location %}remote{% else %}{{ job.location | lower | replace(" ", "-") | replace("---", "-") | replace("&", "and") | urlencode }}{% endif %}">{{ job.title }}&nbsp;&rsaquo;</a>
+        <a class="p-link--soft" href="/careers/{{ job.id }}/{{ job.title | replace(" ","-") | replace("---", "-") | replace("&", "and") | replace("(","") | replace(")","") | lower | urlencode }}-{% if "Home" in job.location %}remote{% else %}{{ job.location | replace(" ","-") | replace("---", "-") | replace("&", "and") | replace("(","") | replace(")","") | lower | urlencode }}{% endif %}">{{ job.title }}&nbsp;&rsaquo;</a>
       </h2>
       {% if job.description %}
       <p clss="u-sv1">{{ job.description }}</p>

--- a/templates/partners/become-a-partner.html
+++ b/templates/partners/become-a-partner.html
@@ -1,6 +1,6 @@
 {% extends 'base_index.html' %}
 
-{% block title %}Become a partner{% endblock %}
+{% block title %}Become a partner | Partners{% endblock %}
 
 {% block meta_description %}Technology companies, consider partnering with Canonical and increase your revenues with Ubuntu.{% endblock %}
 

--- a/templates/partners/channel-and-reseller.html
+++ b/templates/partners/channel-and-reseller.html
@@ -2,7 +2,7 @@
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1rn2f4wL8wxnILlnmfchkNQV2RzsYUMcRaCfP-d6V_5Q{% endblock %}
 
-{% block title %}Channel / Reseller Programme{% endblock %}
+{% block title %}Channel / Reseller Programme | Partners{% endblock %}
 
 {% block meta_description %}Canonical works with channel and reseller partners around the world to ensure that Canonical offerings are available for their customers.{% endblock %}
 

--- a/templates/partners/desktop.html
+++ b/templates/partners/desktop.html
@@ -2,7 +2,7 @@
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1MBVH4kou0Q7yO_Lq6DPQpZL_rc0K1-nVfvg4aF3biSc{% endblock %}
 
-{% block title %}Desktop Programme{% endblock %}
+{% block title %}Desktop Programme | Partners{% endblock %}
 
 {% block meta_description %}Canonical collaborates with the world&rsquo;s leading vendors to optimise and certify Ubuntu on 100s of laptops, desktops and workstations for a secure and constantly updated platform.{% endblock %}
 

--- a/templates/partners/find-a-partner.html
+++ b/templates/partners/find-a-partner.html
@@ -1,5 +1,7 @@
 {% extends 'base_index.html' %}
 
+{% block title %}Find a Canonical partner | Partners{% endblock %}
+
 {% block content %}
   <section class="p-strip--image is-dark">
     <div class="p-strip--suru-top">

--- a/templates/partners/gsi.html
+++ b/templates/partners/gsi.html
@@ -2,7 +2,7 @@
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1PgdZCn16zMVA3LVcLihN03DYFLLqkHIqTqfsgx_LHFg{% endblock %}
 
-{% block title %}Global System Integrator Programme{% endblock %}
+{% block title %}Global System Integrator Programme | Partners{% endblock %}
 
 {% block meta_description %}Together we’ve successfully helped telecom providers, governmental agencies, financial services companies and other industries be relevant in the market by having the most current open source technology available today.{% endblock %}
 

--- a/templates/partners/ihv-and-oem.html
+++ b/templates/partners/ihv-and-oem.html
@@ -2,7 +2,7 @@
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1p8Et43R14AGiFn9g7ro9VLXZh26gph9Kk5K6_lc8W8U{% endblock %}
 
-{% block title %}IHV and OEM Programme{% endblock %}
+{% block title %}IHV and OEM Programme | Partners{% endblock %}
 
 {% block meta_description %}For nearly two decades, Canonical and our enterprise partners have provided market-leading solutions for customers seeking alternatives to complex and costly proprietary operating environments.{% endblock %}
 

--- a/templates/partners/request-login.html
+++ b/templates/partners/request-login.html
@@ -1,6 +1,6 @@
 {% extends 'base_index.html' %}
 
-{% block title %}Request access to Ubuntu's partner portal{% endblock %}
+{% block title %}Request access to Ubuntu's partner portal | Partners{% endblock %}
 
 {% block meta_description %}If you need to gain access to the Ubuntu's partner portal, please fill in your details below and a member of our team will get in touch.{% endblock %}
 

--- a/templates/projects/directory.html
+++ b/templates/projects/directory.html
@@ -1,6 +1,6 @@
 {% extends 'base_index.html' %}
 
-{% block title %}Canonical | Open source projects directory{% endblock %}
+{% block title %}Open source projects directory{% endblock %}
 {% block meta_description %}{% endblock %}
 
 {% block content %}

--- a/templates/projects/index.html
+++ b/templates/projects/index.html
@@ -1,6 +1,6 @@
 {% extends 'base_index.html' %}
 
-{% block title %}Canonical | Projects and technologies{% endblock %}
+{% block title %}Projects and technologies{% endblock %}
 {% block meta_description %}Canonical guides and contributes to the development of many open source projects in addition to Ubuntu. They include MIR, a next-generation display server, and Juju, a leading service orchestration tool.{% endblock %}
 
 {% block extra_body_class %}projects-home{% endblock %}

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -120,8 +120,15 @@ def results():
     return flask.render_template("careers/results.html", **context)
 
 
-@app.route("/careers/<regex('[0-9]+'):job_id>", methods=["GET", "POST"])
-def job_details(job_id):
+@app.route(
+    "/careers/<regex('[0-9]+'):job_id>",
+    methods=["GET", "POST"],
+    defaults={"job_title": None},
+)
+@app.route(
+    "/careers/<regex('[0-9]+'):job_id>/<job_title>", methods=["GET", "POST"]
+)
+def job_details(job_id, job_title):
     context = render_navigation()
     context["bleach"] = bleach
     context["job"] = greenhouse_api.get_vacancy(job_id)

--- a/webapp/greenhouse.py
+++ b/webapp/greenhouse.py
@@ -126,7 +126,7 @@ class Greenhouse:
     def get_job_url_suffix(self, job_title, job_location):
         url_suffix = job_title.strip()
         if "Home" in job_location:
-            url_suffix += "_remote"
+            url_suffix += "-remote"
         else:
             url_suffix += "_" + job_location.replace("Office Based - ", "")
         url_suffix = url_suffix.encode("ascii", "ignore").decode()

--- a/webapp/greenhouse.py
+++ b/webapp/greenhouse.py
@@ -14,7 +14,9 @@ metadata_map = {
     "management": 186225,
     "employment": 149021,
     "department": 155450,
+    "departments": 2739136,
     "skills": 675557,
+    "description": 2739137,
 }
 
 
@@ -67,6 +69,9 @@ class Greenhouse:
                                 job["metadata"], "management"
                             ),
                             "office": job["offices"][0]["name"],
+                            "description": self.get_metadata_value(
+                                job["metadata"], "description"
+                            ),
                         }
                     )
         return vacancies
@@ -103,6 +108,9 @@ class Greenhouse:
                                 ),
                                 "office": job_offices,
                                 "core_skills": job_core_skills,
+                                "description": self.get_metadata_value(
+                                    job["metadata"], "description"
+                                ),
                             }
                         )
                         break
@@ -127,7 +135,9 @@ class Greenhouse:
                 "content": unescape(feed["content"]),
                 "location": feed["location"]["name"],
                 "department": feed["metadata"][2]["value"],
+                "departments": feed["metadata"][4]["value"],
                 "questions": feed["questions"],
+                "description": feed["metadata"][5]["value"],
             }
             return job
 

--- a/webapp/greenhouse.py
+++ b/webapp/greenhouse.py
@@ -72,7 +72,7 @@ class Greenhouse:
                             "description": self.get_metadata_value(
                                 job["metadata"], "description"
                             ),
-                            "joburl": self.get_job_url(
+                            "url_suffix": self.get_job_url_suffix(
                                 job["title"], job["location"]["name"]
                             ),
                         }
@@ -114,7 +114,7 @@ class Greenhouse:
                                 "description": self.get_metadata_value(
                                     job["metadata"], "description"
                                 ),
-                                "joburl": self.get_job_url(
+                                "url_suffix": self.get_job_url_suffix(
                                     job["title"], job["location"]["name"]
                                 ),
                             }
@@ -123,15 +123,15 @@ class Greenhouse:
 
         return vacancies
 
-    def get_job_url(self, job_title, job_location):
-        job_url = job_title.strip()
+    def get_job_url_suffix(self, job_title, job_location):
+        url_suffix = job_title.strip()
         if "Home" in job_location:
-            job_url += "_remote"
+            url_suffix += "_remote"
         else:
-            job_url += "_" + job_location.replace("Office Based - ", "")
-        job_url = job_url.encode("ascii", "ignore").decode()
-        job_url = (
-            job_url.replace(" ", "-")
+            url_suffix += "_" + job_location.replace("Office Based - ", "")
+        url_suffix = url_suffix.encode("ascii", "ignore").decode()
+        url_suffix = (
+            url_suffix.replace(" ", "-")
             .replace("/", "-")
             .replace("---", "-")
             .replace("--", "-")
@@ -142,7 +142,7 @@ class Greenhouse:
             .replace("-Remote", "")
             .lower()
         )
-        return job_url
+        return url_suffix
 
     def get_job_title(self, job_title, job_location):
         metatitle = job_title.strip()

--- a/webapp/greenhouse.py
+++ b/webapp/greenhouse.py
@@ -124,11 +124,11 @@ class Greenhouse:
         return vacancies
 
     def get_job_url(self, job_title, job_location):
-        job_url = job_title
+        job_url = job_title.strip()
         if "Home" in job_location:
             job_url += "_remote"
         else:
-            job_url += "_" + job_location
+            job_url += "_" + job_location.replace("Office Based - ", "")
         job_url = job_url.encode("ascii", "ignore").decode()
         job_url = (
             job_url.replace(" ", "-")
@@ -143,6 +143,14 @@ class Greenhouse:
             .lower()
         )
         return job_url
+
+    def get_job_title(self, job_title, job_location):
+        metatitle = job_title.strip()
+        if "Home" in job_location:
+            metatitle += " - remote"
+        else:
+            metatitle += " in " + job_location
+        return metatitle.replace("Office Based - ", "")
 
     def get_metadata_value(self, job_metadata, metadata_key):
         for data in job_metadata:
@@ -165,6 +173,9 @@ class Greenhouse:
                 "departments": feed["metadata"][4]["value"],
                 "questions": feed["questions"],
                 "description": feed["metadata"][5]["value"],
+                "metatitle": self.get_job_title(
+                    feed["title"], feed["location"]["name"]
+                ),
             }
             return job
 

--- a/webapp/greenhouse.py
+++ b/webapp/greenhouse.py
@@ -72,6 +72,9 @@ class Greenhouse:
                             "description": self.get_metadata_value(
                                 job["metadata"], "description"
                             ),
+                            "joburl": self.get_job_url(
+                                job["title"], job["location"]["name"]
+                            ),
                         }
                     )
         return vacancies
@@ -111,11 +114,35 @@ class Greenhouse:
                                 "description": self.get_metadata_value(
                                     job["metadata"], "description"
                                 ),
+                                "joburl": self.get_job_url(
+                                    job["title"], job["location"]["name"]
+                                ),
                             }
                         )
                         break
 
         return vacancies
+
+    def get_job_url(self, job_title, job_location):
+        job_url = job_title
+        if "Home" in job_location:
+            job_url += "_remote"
+        else:
+            job_url += "_" + job_location
+        job_url = job_url.encode("ascii", "ignore").decode()
+        job_url = (
+            job_url.replace(" ", "-")
+            .replace("/", "-")
+            .replace("---", "-")
+            .replace("--", "-")
+            .replace(",", "")
+            .replace("&", "and")
+            .replace("(", "")
+            .replace(")", "")
+            .replace("-Remote", "")
+            .lower()
+        )
+        return job_url
 
     def get_metadata_value(self, job_metadata, metadata_key):
         for data in job_metadata:


### PR DESCRIPTION
## Done

- Updated job details page titles to format: Canonical | Jobs | <job title>, <location> or 'remote' if home
- Update job details meta description to use new one line description
- Update job lists to use the new one line description
- Update job lists to use new url in format:  /job_id/job_title-location (remote if 'Home')
- Update routes to allow new url format

## QA

- Check out this feature branch
- Run the site using the command `./run serve`

- Updated job details page titles to format: Canonical | Jobs | <job title>, <location> or 'remote' if home

on http://0.0.0.0:8002/careers/2544446/senior-ux-designer--remote see `Canonical | Jobs | Senior UX Designer , remote`

- Update job details meta description to use new one line description

on http://0.0.0.0:8002/careers/2544446/senior-ux-designer--remote see `Be part of a team working on web applications for enterprise cloud services, IoT and embedded devices, bringing exciting new projects to life and improving existing ones.`

- Update job lists to use the new one line description

http://0.0.0.0:8002/careers/web-and-design#available-roles

![image](https://user-images.githubusercontent.com/441217/109434168-d8797700-7a0b-11eb-9bd6-a3f1d9271a52.png)

- Update job lists to use new url in format: /job_id/job_title-location (remote if 'Home')
- Update routes to allow new url format

try http://0.0.0.0:8002/careers/2544446/senior-ux-designer--remote and http://0.0.0.0:8002/careers/2544446, see that they both work

## Issue / Card

Fixes #349, #351 Partiall fixes #350

