### PR TITLE
Add meta keywords for jobs to get core skills

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -36,8 +36,9 @@
     <meta name="twitter:description" content="{{ self.meta_description() }}">
     <meta property="og:description" content="{{ self.meta_description() }}">
     {% endif %}
-    {% if meta_keywords %}
-    <meta property="keywords" content="{% block meta_keywords %}{% endblock %}">
+    {% if self.meta_keywords() %}
+    <!-- added for internal helps -->
+    <meta property="keywords" content="{{ self.meta_keywords() }}">
     {% endif %}
 
     {# Define the required meta_image block #}

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -36,9 +36,12 @@
     <meta name="twitter:description" content="{{ self.meta_description() }}">
     <meta property="og:description" content="{{ self.meta_description() }}">
     {% endif %}
+
+    {# Define the required meta_keywords block #}
+    <!-- Meta keywords: {% block meta_keywords %}{% endblock %} -->
     {% if self.meta_keywords() %}
     <!-- added for internal helps -->
-    <meta property="keywords" content="{{ self.meta_keywords() }}">
+    <meta name="keywords" content="{{ self.meta_keywords() }}">
     {% endif %}
 
     {# Define the required meta_image block #}

--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -36,6 +36,9 @@
     <meta name="twitter:description" content="{{ self.meta_description() }}">
     <meta property="og:description" content="{{ self.meta_description() }}">
     {% endif %}
+    {% if meta_keywords %}
+    <meta property="keywords" content="{% block meta_keywords %}{% endblock %}">
+    {% endif %}
 
     {# Define the required meta_image block #}
     <!-- Meta image: {% block meta_image %}{% endblock %} -->

--- a/templates/careers/job-detail.html
+++ b/templates/careers/job-detail.html
@@ -4,7 +4,7 @@
 
 {% block meta_description %}{% if job.description %}{{ job.description }}{% else %}Canonical offers a truly distributed workplace for exceptional colleagues who are self-motivated, organised. Maintain a home office and experience the top of global technology strategy and engineering. Travel regularly to interesting destinations for team, conference and customer engagements.{% endif %}{% endblock %}
 
-{% block meta_keywords %}{{ job.core_skills }}{% endblock %}
+{% block meta_keywords %}{{ job.skills | join(', ') }}{% endblock %}
 
 {% block hero %}
 <section class="p-strip--image is-dark is-deep u-no-padding--top u-no-padding--bottom u-extra-space">

--- a/templates/careers/job-detail.html
+++ b/templates/careers/job-detail.html
@@ -4,6 +4,8 @@
 
 {% block meta_description %}{% if job.description %}{{ job.description }}{% else %}Canonical offers a truly distributed workplace for exceptional colleagues who are self-motivated, organised. Maintain a home office and experience the top of global technology strategy and engineering. Travel regularly to interesting destinations for team, conference and customer engagements.{% endif %}{% endblock %}
 
+{% block meta_keywords %}{{ job.core_skills }}{% endblock %}
+
 {% block hero %}
 <section class="p-strip--image is-dark is-deep u-no-padding--top u-no-padding--bottom u-extra-space">
   <div class="p-strip--suru-background">


### PR DESCRIPTION
## Done

- Added core skills to the job listing's meta data

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: view-source:http://0.0.0.0:8002/careers/2114847/apparmor-security-engineer-remote
- See that core skills appear `<meta property="keywords" content="Contributor, Developer, Fixer, Inventor, Problem Solver">`
- Go to another non-job page and see that they do not.