### PR TITLE
Make available roles first

### DIFF
--- a/templates/careers/base-tabs.html
+++ b/templates/careers/base-tabs.html
@@ -29,21 +29,22 @@
       <nav class="p-tabs">
         <ul class="p-tabs__list" role="tablist">
           <li class="p-tabs__item" role="presentation">
-            <a href="#overview" class="p-tabs__link" tabindex="0" role="tab" aria-controls="overview" aria-selected="true">Overview</a>
+            <a href="#available-roles" class="p-tabs__link" tabindex="0" role="tab" aria-controls="available-roles" aria-selected="true">Available roles</a>
           </li>
           <li class="p-tabs__item" role="presentation">
-            <a href="#available-roles" class="p-tabs__link" tabindex="-1" role="tab" aria-controls="available-roles">Available roles</a>
+            <a href="#overview" class="p-tabs__link" tabindex="-1" role="tab" aria-controls="overview" aria-selected="false">Department overview</a>
           </li>
         </ul>
       </nav>
+
+      <div class="p-strip p-tabs__content is-shallow u-extra-space" id="overview">
+        {% block overview %}{% endblock %}
+      </div>
 
       <div class="p-strip p-tabs__content is-shallow u-extra-space" id="available-roles">
         {% include 'partial/_careers-available-roles.html' %}
       </div>
 
-      <div class="p-strip p-tabs__content is-shallow u-extra-space" id="overview">
-        {% block overview %}{% endblock %}
-      </div>
     </div>
   </div>
 </section>

--- a/templates/careers/base-tabs.html
+++ b/templates/careers/base-tabs.html
@@ -32,7 +32,7 @@
             <a href="#available-roles" class="p-tabs__link" tabindex="0" role="tab" aria-controls="available-roles" aria-selected="true">Available roles</a>
           </li>
           <li class="p-tabs__item" role="presentation">
-            <a href="#overview" class="p-tabs__link" tabindex="-1" role="tab" aria-controls="overview" aria-selected="false">Department overview</a>
+            <a href="#overview" class="p-tabs__link" tabindex="-1" role="tab" aria-controls="overview">Department overview</a>
           </li>
         </ul>
       </nav>


### PR DESCRIPTION
## Done

- Make available roles first
- Rename 'Overview' to 'Department overviews'

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/careers/web-and-design
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that the roles show on load and click 'Department overivew' and see that this loads
 
## Issue / Card

Fixes #354

## Screenshots

![image](https://user-images.githubusercontent.com/441217/111867928-16185280-896f-11eb-9ca8-913a3fa07510.png)
