### PR TITLE
Remove side nav and add "Apply" buttons to job details page

### DIFF
--- a/templates/careers/base_job-details.html
+++ b/templates/careers/base_job-details.html
@@ -1,0 +1,15 @@
+{% extends 'base_index.html' %} {% block content %}
+
+{% block hero %}{% endblock %}
+
+<section class="p-strip u-extra-space">
+  <div class="row">
+    <div class="col-8">
+      {% block careers_content %}{% endblock %}
+    </div>
+  </div>
+</section>
+
+<script defer src="/static/js/careers-filter-and-sort.js"></script>
+
+{% endblock %}

--- a/templates/careers/job-detail.html
+++ b/templates/careers/job-detail.html
@@ -1,4 +1,4 @@
-{% extends '/careers/base.html' %}
+{% extends '/careers/base_job-details.html' %}
 
 {% block title %}{{ job.meta_title }} | Careers{% endblock %}
 

--- a/templates/careers/job-detail.html
+++ b/templates/careers/job-detail.html
@@ -44,7 +44,13 @@
 </div>
 {% endif %}
 <div class="row">
-  <a href="{% if request.referrer %}{{ request.referrer }}{% else %}/careers/all{% endif %}" class="u-sv2">&lsaquo;&nbsp;Back to list</a>
+  <div class="col-6">
+    <a href="{% if request.referrer %}{{ request.referrer }}{% else %}/careers/all{% endif %}" class="u-sv2">&lsaquo;&nbsp;Back to list</a>
+  </div>
+  <div class="col-6 u-align--right">
+    <a class="p-button--positive" href="#apply">Apply</a>
+  </div>
+
   <h2 class="u-no-margin--bottom u-sv1">{{ job.title }}</h2>
   <p class="p-muted-heading">{{ job.location }}</p>
   <div class="job-desc">
@@ -57,7 +63,7 @@
 <div class="row u-sv2">
   <hr />
 </div>
-<div class="row u-extra-space js-roles-apply--container">
+<div class="row u-extra-space js-roles-apply--container" id="apply">
   <div class="col-8">
     <div class="p-card--strip u-no-margin--bottom">
       <h3>Apply for this role</h3>


### PR DESCRIPTION
## Done

- Remove side nav 
- Add "Apply" buttons to job details page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/careers/2948002/commercial-director-hpc-remote
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that there is no navigaton on the side
- See that there is an 'Apply' button and see that it moves you down the page

## Issue / Card

Fixes [#3819](https://github.com/canonical-web-and-design/web-squad/issues/3819)

## Screenshots

[if relevant, include a screenshot]
![image](https://user-images.githubusercontent.com/441217/111868289-000b9180-8971-11eb-8046-d2a3eb5d4ab9.png)
