### PR TITLE
Shorten heros

### DIFF
--- a/static/sass/_pattern_strip.scss
+++ b/static/sass/_pattern_strip.scss
@@ -95,8 +95,8 @@
     background-position: left top, right top, right 101%;
     background-repeat: no-repeat;
     background-size: 70% 80%, 70% 100%, 110% 20%, 100% 100%;
-    padding-bottom: 6rem;
-    padding-top: 6rem;
+    padding-bottom: 4rem;
+    padding-top: 2rem;
 
     @media only screen and (max-width: $breakpoint-small) {
       background-image: linear-gradient(

--- a/templates/careers/all.html
+++ b/templates/careers/all.html
@@ -11,7 +11,7 @@
     <div class="p-strip--suru-background">
       <div class="row">
         <div class="col-6">
-          <h1>All roles</h1>
+          <h1 class="u-no-margin--bottom">All roles</h1>
         </div>
       </div>
     </div>

--- a/templates/careers/base-tabs.html
+++ b/templates/careers/base-tabs.html
@@ -4,7 +4,7 @@
   <div class="p-strip--suru-background">
     <div class="row">
       <div class="col-6">
-        <h1>{% block title %}{% endblock %}</h1>
+        <h1 class="u-no-margin--bottom">{% block title %}{% endblock %}</h1>
       </div>
     </div>
   </div>

--- a/templates/careers/base-template.html
+++ b/templates/careers/base-template.html
@@ -13,7 +13,7 @@
     <div class="p-strip--suru-background">
       <div class="row">
         <div class="col-6">
-          <h1>{{ department.name }}</h1>
+          <h1 class="u-no-margin--bottom">{{ department.name }}</h1>
         </div>
       </div>
     </div>

--- a/templates/careers/diversity.html
+++ b/templates/careers/diversity.html
@@ -11,7 +11,7 @@
     <div class="p-strip--suru-background">
       <div class="row">
         <div class="col-6">
-          <h1>Diversity</h1>
+          <h1 class="u-no-margin--bottom">Diversity</h1>
         </div>
       </div>
     </div>

--- a/templates/careers/ethics.html
+++ b/templates/careers/ethics.html
@@ -13,7 +13,7 @@
     <div class="p-strip--suru-background">
       <div class="row">
         <div class="col-6">
-          <h1>Ethics</h1>
+          <h1 class="u-no-margin--bottom">Ethics</h1>
         </div>
       </div>
     </div>

--- a/templates/careers/progression.html
+++ b/templates/careers/progression.html
@@ -11,8 +11,8 @@
     <div class="p-strip--suru-background">
       <div class="row">
         <div class="col-6 p-heading-icon--h1">
-          <h1>Progression</h1>
-          <img src="https://assets.ubuntu.com/v1/1c95d556-canonical-progression.svg">
+          <h1 class="u-no-margin--bottom">Progression</h1>
+          <img src="https://assets.ubuntu.com/v1/1c95d556-canonical-progression.svg" alt="">
         </div>
       </div>
     </div>

--- a/templates/careers/results.html
+++ b/templates/careers/results.html
@@ -25,8 +25,8 @@ Travel regularly to interesting destinations for team, conference and customer e
       linear-gradient(140deg, #E95420 0%, #772953 33%, #2C001E 72%);
     background-position: left top, right top, left 101%;
     background-size: 80% 100%, 70% 80%, 110% 20%, 100% 100%;
-    padding-bottom: 6rem;
-    padding-top: 6rem;
+    padding-bottom: 4rem;
+    padding-top: 2rem;
   }
 </style>
 {% endblock %}

--- a/templates/careers/results.html
+++ b/templates/careers/results.html
@@ -11,7 +11,7 @@ Travel regularly to interesting destinations for team, conference and customer e
   <div class="p-strip--suru-background">
     <div class="row">
       <div class="col-6">
-        <h1>Careers</h1>
+        <h1 class="u-no-margin--bottom">Careers</h1>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Done

Made the hero's a bit smaller top: 2rem, bottom: 4rem (from 6rem) per tooling meeting

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See the smaller heros


## Screenshots

![image](https://user-images.githubusercontent.com/441217/111868766-b4a6b280-8973-11eb-9f04-b900b4d336cb.png)
