### PR TITLE
Fixed add button on empty game card careers

### DIFF
--- a/static/js/careers-game.js
+++ b/static/js/careers-game.js
@@ -14,17 +14,19 @@ function initCareersGame() {
 
   function handleCardClick() {
     selectableCards = document.querySelectorAll(".p-card--game");
-
+    
     [].forEach.call(selectableCards, function (selectableCard) {
       selectableCard.addEventListener("click", function (e) {
         var expandedCard = document.querySelector(".p-card--game.is-grey");
         var targetCard = e.currentTarget;
-
+        
         if (expandedCard) {
           expandedCard.classList.remove("is-grey");
         }
 
-        targetCard.classList.add("is-grey");
+        if (!targetCard.classList.contains("is-empty")) {
+          targetCard.classList.add("is-grey");
+        }
       });
     });
   }


### PR DESCRIPTION
## Done
Hide `that's me` button on empty game card

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/careers/start
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [EDIT: ] Oops! missed one step. select some cards and now click the empty cards.

## Screenshots
Actual Behavior on click after card selected. see the empty button 2nd card
![Screenshot from 2021-04-03 13-02-24](https://user-images.githubusercontent.com/44097148/113471873-edb74a80-947c-11eb-8bde-8afd897b02e9.png)

Fixed to no button display at all.
![Screenshot from 2021-04-03 13-07-42](https://user-images.githubusercontent.com/44097148/113471979-a54c5c80-947d-11eb-9f30-9bdaefcfaacb.png)
