### PR TITLE
Add Rich structure data for career pages

### DIFF
--- a/templates/base_index.html
+++ b/templates/base_index.html
@@ -52,6 +52,9 @@
     <meta property="og:image" content="{% if 'http' not in self.meta_image() %}https://assets.ubuntu.com/v1/{% endif %}{{ self.meta_image() }}">
     {% endif %}
 
+
+    {% block extra_metatags %}{% endblock %}
+
     <link rel="shortcut icon" href="https://assets.ubuntu.com/v1/0843d517-favicon.ico" type="image/x-icon" />
     <link rel="apple-touch-icon-precomposed" sizes="144x144"
       href="https://assets.ubuntu.com/v1/9864667f-apple-touch-icon-144x144-precomposed.png">

--- a/templates/careers/job-detail.html
+++ b/templates/careers/job-detail.html
@@ -8,6 +8,43 @@
 
 {% block meta_image %}ceed7655-Canonical-Careers-image.jpg{% endblock %}
 
+{% block extra_metatags %}
+<script type="application/ld+json">
+  {
+    "@context" : "https://schema.org/",
+    "@type" : "JobPosting",
+    "title" : "{{ job.title }}",
+    "description" : "{% if job.description %}{{ job.description }}{% else %}Canonical offers a truly distributed workplace for exceptional colleagues who are self-motivated, organised. Maintain a home office and experience the top of global technology strategy and engineering. Travel regularly to interesting destinations for team, conference and customer engagements.{% endif %}",
+    "identifier": {
+      "@type": "PropertyValue",
+      "name": "Canonical",
+      "value": "{{ job.id }}"
+    },
+    "datePosted" : "{{ job.date }}",
+    {% if job.employment_type == "Full-time" %}
+    "employmentType" : "FULL_TIME",
+    {% endif %}
+    {% if job.is_remote %}
+    "jobLocationType": "TELECOMMUTE",
+    {% else %}
+    "jobLocation": {
+      "@type": "Place",
+      "address": {
+      "@type": "PostalAddress",
+      "addressLocality": "{{ job.location }}"
+      }
+    },
+    {% endif %}
+    "hiringOrganization" : {
+      "@type" : "Organization",
+      "name" : "Canonical",
+      "sameAs" : "https://canonical.com",
+      "logo" : "https://assets.ubuntu.com/v1/b3b72cb2-canonical-logo-166.png"
+    }
+  }
+</script>
+{% endblock %}
+
 {% block hero %}
 <section class="p-strip--suru-topped u-no-padding--bottom">
   <div class="row">

--- a/webapp/greenhouse.py
+++ b/webapp/greenhouse.py
@@ -14,6 +14,7 @@ def _get_metadata(job, name):
         "departments": 2739136,
         "skills": 675557,
         "description": 2739137,
+        "employment_type": 149021,
     }
 
     for data in job["metadata"]:
@@ -90,8 +91,10 @@ class Vacancy:
         self.management: str = _get_metadata(job, "management")
         self.office: str = job["offices"][0]["name"]
         self.description: str = _get_metadata(job, "description")
+        self.employment_type: str = _get_metadata(job, "employment_type")
         self.slug: str = _get_job_slug(job)
         self.skills: list = _get_metadata(job, "skills") or []
+        self.is_remote: bool = False if job["offices"][0]["location"] else True
 
 
 class Greenhouse:


### PR DESCRIPTION
## Done

- Add rich structure data for career pages
- https://developers.google.com/search/docs/data-types/job-posting
- This should help us to integrate our jobs posting in Google job pages

## QA

- `dotrun`
- http://0.0.0.0:8002/careers/2948052/commercial-director-automotive-remote
- This is a remote job:
  - Make sure the structured is well parsed in https://search.google.com/test/rich-results
  - Make sure that the data has full-time and remote
- http://0.0.0.0:8002/careers/2593748/iot-sales-director-Office%20Based%20-%20Taipei,%20Taiwan
  - This is an office based job
  - Make sure the structured is well parsed in https://search.google.com/test/rich-results
  - Make sure in the JSON there is an address
