### PR TITLE
Add sitemap to site

### DIFF
--- a/templates/careers/sitemap.xml
+++ b/templates/careers/sitemap.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  <url>
+    <loc>https://canonical.com/careers</loc>
+    <changefreq>monthly</changefreq>
+  </url>
+  <url>
+    <loc>https://canonical.com/careers/start</loc>
+    <changefreq>monthly</changefreq>
+  </url>
+  <url>
+    <loc>https://canonical.com/careers/all</loc>
+    <changefreq>weekly</changefreq>
+  </url>
+  <url>
+    <loc>https://canonical.com/careers/lifestyle</loc>
+    <changefreq>monthly</changefreq>
+  </url>
+    <url>
+    <loc>https://canonical.com/careers/ethics</loc>
+    <changefreq>monthly</changefreq>
+  </url>
+  <url>
+    <loc>https://canonical.com/careers/travel</loc>
+    <changefreq>monthly</changefreq>
+  </url>
+  <url>
+    <loc>https://canonical.com/careers/progression</loc>
+    <changefreq>monthly</changefreq>
+  </url>
+  <url>
+    <loc>https://canonical.com/careers/diversity</loc>
+    <changefreq>monthly</changefreq>
+  </url>
+
+  {% for department in departments %}
+  <url>
+    <loc>https://canonical.com/careers/{{ department.slug }}</loc>
+    <changefreq>monthly</changefreq>
+  </url>
+  {% endfor %}
+
+  {% for vacancy in vacancies %}
+  <url>
+    <loc>https://canonical.com/careers/{{ vacancy.id }}/{{ vacancy.slug }}</loc>
+    <lastmod>{{ vacancy.date }}</lastmod>
+    <changefreq>monthly</changefreq>
+  </url>
+  {% endfor %}
+</urlset>

--- a/templates/partners/sitemap.xml
+++ b/templates/partners/sitemap.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  <url>
+    <loc>https://canonical.com/partners</loc>
+    <changefreq>monthly</changefreq>
+  </url>
+  <url>
+    <loc>https://canonical.com/partners/find-a-partner</loc>
+    <changefreq>monthly</changefreq>
+  </url>
+  <url>
+    <loc>https://canonical.com/partners/become-a-partner</loc>
+    <changefreq>monthly</changefreq>
+  </url>
+  <url>
+    <loc>https://canonical.com/partners/channel-and-reseller</loc>
+    <changefreq>monthly</changefreq>
+  </url>
+  <url>
+    <loc>https://canonical.com/partners/desktop</loc>
+    <changefreq>monthly</changefreq>
+  </url>
+  <url>
+    <loc>https://canonical.com/partners/gsi</loc>
+    <changefreq>monthly</changefreq>
+  </url>
+  <url>
+    <loc>https://canonical.com/partners/ihv-and-oem</loc>
+    <changefreq>monthly</changefreq>
+  </url>
+  <url>
+    <loc>https://canonical.com/partners/public-cloud</loc>
+    <changefreq>monthly</changefreq>
+  </url>
+  <url>
+    <loc>https://canonical.com/partners/</loc>
+    <changefreq>monthly</changefreq>
+  </url>
+  <url>
+    <loc>https://canonical.com/partners/</loc>
+    <changefreq>monthly</changefreq>
+  </url>
+  <url>
+    <loc>https://canonical.com/partners/</loc>
+    <changefreq>monthly</changefreq>
+  </url>
+</urlset>

--- a/templates/partners/sitemap.xml
+++ b/templates/partners/sitemap.xml
@@ -32,16 +32,4 @@
     <loc>https://canonical.com/partners/public-cloud</loc>
     <changefreq>monthly</changefreq>
   </url>
-  <url>
-    <loc>https://canonical.com/partners/</loc>
-    <changefreq>monthly</changefreq>
-  </url>
-  <url>
-    <loc>https://canonical.com/partners/</loc>
-    <changefreq>monthly</changefreq>
-  </url>
-  <url>
-    <loc>https://canonical.com/partners/</loc>
-    <changefreq>monthly</changefreq>
-  </url>
 </urlset>

--- a/templates/sitemap-index.xml
+++ b/templates/sitemap-index.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap>
+    <loc>https://canonical.com/sitemap-links.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://canonical.com/careers/sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://canonical.com/partners/sitemap.xml</loc>
+  </sitemap>
+</sitemapindex>

--- a/templates/sitemap-links.xml
+++ b/templates/sitemap-links.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  <url>
+    <loc>https://canonical.com/</loc>
+    <changefreq>monthly</changefreq>
+  </url>
+  <url>
+    <loc>https://canonical.com/contact-us</loc>
+    <changefreq>monthly</changefreq>
+  </url>
+  <url>
+    <loc>https://canonical.com/projects</loc>
+    <changefreq>monthly</changefreq>
+  </url>
+  <url>
+    <loc>https://canonical.com/projects/directory</loc>
+    <changefreq>monthly</changefreq>
+  </url>
+</urlset>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -39,6 +39,26 @@ def index():
     return flask.render_template("index.html", partner_groups=partner_groups)
 
 
+@app.route("/sitemap.xml")
+def index_sitemap():
+    xml_sitemap = flask.render_template("sitemap-index.xml")
+    response = flask.make_response(xml_sitemap)
+    response.headers["Content-Type"] = "application/xml"
+    response.headers["Cache-Control"] = "public, max-age=43200"
+
+    return response
+
+
+@app.route("/sitemap-links.xml")
+def home_sitemap():
+    xml_sitemap = flask.render_template("sitemap-links.xml")
+    response = flask.make_response(xml_sitemap)
+    response.headers["Content-Type"] = "application/xml"
+    response.headers["Cache-Control"] = "public, max-age=43200"
+
+    return response
+
+
 @app.route("/secure-boot-master-ca.crl")
 def secure_boot():
     return flask.send_from_directory(
@@ -96,6 +116,19 @@ def results():
 
     return flask.render_template("careers/results.html", **context)
 
+@app.route("/careers/sitemap.xml")
+def careers_sitemap():
+    context = {
+        "vacancies": greenhouse.get_vacancies(),
+        "departments": harvest.get_departments()
+    }
+
+    xml_sitemap = flask.render_template("careers/sitemap.xml", **context)
+    response = flask.make_response(xml_sitemap)
+    response.headers["Content-Type"] = "application/xml"
+    response.headers["Cache-Control"] = "public, max-age=43200"
+
+    return response
 
 @app.route(
     "/careers/<regex('[0-9]+'):job_id>",
@@ -225,6 +258,14 @@ def partner_details():
         f"{flask.request.path}.html", partners=partners
     )
 
+@app.route("/partners/sitemap.xml")
+def partners_sitemap():
+    xml_sitemap = flask.render_template("partners/sitemap.xml")
+    response = flask.make_response(xml_sitemap)
+    response.headers["Content-Type"] = "application/xml"
+    response.headers["Cache-Control"] = "public, max-age=43200"
+
+    return response
 
 # Template finder
 template_finder_view = TemplateFinder.as_view("template_finder")

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -116,11 +116,12 @@ def results():
 
     return flask.render_template("careers/results.html", **context)
 
+
 @app.route("/careers/sitemap.xml")
 def careers_sitemap():
     context = {
         "vacancies": greenhouse.get_vacancies(),
-        "departments": harvest.get_departments()
+        "departments": harvest.get_departments(),
     }
 
     xml_sitemap = flask.render_template("careers/sitemap.xml", **context)
@@ -129,6 +130,7 @@ def careers_sitemap():
     response.headers["Cache-Control"] = "public, max-age=43200"
 
     return response
+
 
 @app.route(
     "/careers/<regex('[0-9]+'):job_id>",
@@ -258,6 +260,7 @@ def partner_details():
         f"{flask.request.path}.html", partners=partners
     )
 
+
 @app.route("/partners/sitemap.xml")
 def partners_sitemap():
     xml_sitemap = flask.render_template("partners/sitemap.xml")
@@ -266,6 +269,7 @@ def partners_sitemap():
     response.headers["Cache-Control"] = "public, max-age=43200"
 
     return response
+
 
 # Template finder
 template_finder_view = TemplateFinder.as_view("template_finder")


### PR DESCRIPTION
## Done

Add sitemap generated for careers, partners and the rest

## QA

- `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8002/sitemap.xml
- Make sure the links actually exist
- You will have to replace: https://canonical.com/ with http://0.0.0.0:8002/
