### PR TITLE
Fix "All roles" count

### DIFF
--- a/templates/partial/_careers-navigation.html
+++ b/templates/partial/_careers-navigation.html
@@ -29,8 +29,8 @@
         <a href="/careers/all" class="p-link--soft">All roles</a>
         <span class="u-text--muted u-float-right" style="padding-right: 0.5rem;">
           {% set vacancies = namespace(counter = 0) %}
-          {% for key in nav_vacancy_count %}
-            {% set vacancies.counter = vacancies.counter + nav_vacancy_count[key] %}
+          {% for department in all_departments.values() %}
+            {% set vacancies.counter = vacancies.counter + (department.vacancies | length) %}
           {% endfor %}
           {{ vacancies.counter }}
         </span>


### PR DESCRIPTION
## Done

Fixed the count next to the "All roles" link, which was previously always showing 0.

## QA

- Check out this feature branch
- Run the site using the command `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8002/careers/all
- Check that the count shown next to the "All roles" link in the careers navigation sidebar is not zero (it should be equal to the sum of the count for each department)

## Issue / Card

Fixes #396 

## Screenshots

![Screenshot from 2021-07-15 17-33-30](https://user-images.githubusercontent.com/995051/125815698-7b1cec60-8127-4f66-a6be-07a6b062f25c.png)
