### PR TITLE
Move skip link above main navigation

### DIFF
--- a/templates/partial/_navigation.html
+++ b/templates/partial/_navigation.html
@@ -1,3 +1,5 @@
+<a href="#main-content" class="p-link--skip">Jump to main content</a>
+
 <header id="navigation"
   class="p-navigation{%if not request.path|get_nav_path == 'partners'%} is-sticky{% endif %}"
   role="banner">
@@ -12,7 +14,6 @@
       </div>
     </div>
     <nav class="p-navigation__nav">
-      <a href="#main-content" class="p-link--skip">Jump to main content</a>
       {% if request.path == '/' %}
       <ul class="p-navigation__links">
         <li class="p-navigation__dropdown-link--no-chevron" role="menuitem">


### PR DESCRIPTION
## Done

Moved the skip link above the main nav so it's the first focussable element on the page

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Press the tab key, if the focus isn't already on the page, it should reveal the skip link on the first press
