### PR TITLE
Add rss feed for career section

### DIFF
--- a/templates/careers/rss.xml
+++ b/templates/careers/rss.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<rss version="2.0">
+
+<channel>
+  {% for vacancy in vacancies %}
+  <item>
+    <title>{{ vacancy.title }}</title>
+    <link>https://canonical.com/careers/{{ vacancy.id }}/{{ vacancy.slug }}</link>
+    <description>{{ vacancy.description }}</description>
+  </item>
+  {% endfor %}
+</channel>
+
+</rss> 

--- a/templates/careers/rss.xml
+++ b/templates/careers/rss.xml
@@ -2,10 +2,14 @@
 <rss version="2.0">
 
 <channel>
+  <title>All job roles | Canonical Careers</title>
+  <link>https://canonical.com/careers/all</link>
+  <description>Canonical publishes Ubuntu, provides commercial services and solutions for Ubuntu, and works with hardware manufacturers, software vendors and public.</description>
+
   {% for vacancy in vacancies %}
   <item>
     <title>{{ vacancy.title }}</title>
-    <link>https://canonical.com/careers/{{ vacancy.id }}/{{ vacancy.slug }}</link>
+    <link>https://canonical.com/careers/{{ vacancy.id }}</link>
     <description>{{ vacancy.description }}</description>
   </item>
   {% endfor %}

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -134,7 +134,6 @@ def careers_rss():
     xml_sitemap = flask.render_template("careers/rss.xml", **context)
     response = flask.make_response(xml_sitemap)
     response.headers["Content-Type"] = "application/xml"
-    response.headers["Cache-Control"] = "public, max-age=43200"
 
     return response
 

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -127,6 +127,18 @@ def careers_sitemap():
     return response
 
 
+@app.route("/careers/feed")
+def careers_rss():
+    context = {"vacancies": greenhouse.get_vacancies()}
+
+    xml_sitemap = flask.render_template("careers/rss.xml", **context)
+    response = flask.make_response(xml_sitemap)
+    response.headers["Content-Type"] = "application/xml"
+    response.headers["Cache-Control"] = "public, max-age=43200"
+
+    return response
+
+
 @app.route(
     "/careers/<regex('[0-9]+'):job_id>",
     methods=["GET", "POST"],


### PR DESCRIPTION
## Done

- Add rss feed for careers sections

## QA

- Check out this feature branch
- Run the site using the command `dotrun`
- View the site locally in your web browser at: http://0.0.0.0:8002/careers/feed
- You should get a feed with all the jobs open. Each job should have a link a description and a title

## Issue / Card

Fixes #405 