### PR TITLE
Add rss feed tag

### DIFF
--- a/templates/careers/base.html
+++ b/templates/careers/base.html
@@ -1,5 +1,9 @@
 {% extends 'base_index.html' %} {% block content %}
 
+{% block extra_metatags %}
+  <link rel="alternate" type="application/rss+xml"  href="/careers/feed" title="All job roles | Canonical Careers">
+{% endblock %}
+
 {% block hero %}{% endblock %}
 
 <section class="p-strip u-extra-space">

--- a/templates/careers/job-detail.html
+++ b/templates/careers/job-detail.html
@@ -9,6 +9,8 @@
 {% block meta_image %}ceed7655-Canonical-Careers-image.jpg{% endblock %}
 
 {% block extra_metatags %}
+<link rel="alternate" type="application/rss+xml"  href="/careers/feed" title="All job roles | Canonical Careers">
+
 <script type="application/ld+json">
   {
     "@context" : "https://schema.org/",

--- a/templates/careers/rss.xml
+++ b/templates/careers/rss.xml
@@ -10,9 +10,13 @@
   <item>
     <title>{{ vacancy.title }}</title>
     <link>https://canonical.com/careers/{{ vacancy.id }}</link>
+    {% if vacancy.description %}
     <description>{{ vacancy.description }}</description>
+    {% else %}
+    <description>Canonical offers a truly distributed workplace for exceptional colleagues who are self-motivated and organised. Maintain a home office and experience the top of global technology strategy and engineering. Travel regularly to interesting destinations for team, conference and customer engagements.</description>
+    {% endif %}
   </item>
   {% endfor %}
 </channel>
 
-</rss> 
+</rss>


### PR DESCRIPTION
## Done

- On career pages add the metatag rss so RSS clients can notify the user to subscribe
- Fix None issue for jobs that don't have description in RSS feed

## QA

- `dotrun`
- http://0.0.0.0:8002/careers/feed
- Make sure no description have None
- http://0.0.0.0:8002/careers/all
- http://0.0.0.0:8002/careers/2593683/associate-iot-systems-engineer-remote
- Both should have the metatag:

`<link rel="alternate" type="application/rss+xml"  href="/careers/feed" title="All job roles | Canonical Careers">`
