### PR TITLE
Updates yarn run to use --production tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN --mount=type=cache,target=/root/.cache/pip pip3 install --user --requirement
 FROM node:12 AS yarn-dependencies
 WORKDIR /srv
 ADD package.json .
-RUN --mount=type=cache,target=/usr/local/share/.cache/yarn yarn install
+RUN --mount=type=cache,target=/usr/local/share/.cache/yarn yarn install --production
 
 # Build stage: Run "yarn run build-js"
 # ===

--- a/package.json
+++ b/package.json
@@ -18,11 +18,11 @@
     "autoprefixer": "10.2.1",
     "concurrently": "5.3.0",
     "postcss": "8.2.10",
-    "postcss-cli": "8.3.1",
     "sass": "1.27.0",
     "vanilla-framework": "2.33.1"
   },
   "devDependencies": {
+    "postcss-cli": "8.3.1",
     "prettier": "2.2.1",
     "stylelint": "13.8.0",
     "stylelint-config-prettier": "8.0.2",


### PR DESCRIPTION
## Done

- Updates  Dockerfile 'yarn run' to use --production tag

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)

