### PR TITLE
Change jaas.ai link to juju.is

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -101,13 +101,13 @@
       <div class="col-4 u-equal-height" data-animation="u-animation--slide-from-bottom">
         <div class="p-card--strip u-no-padding">
           <div class="p-strip is-shallow">
-            <a href="https://jaas.ai">
+            <a href="https://juju.is">
               <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/1dee5076-products-juju-wht-aubergine2.svg" alt="Juju">
             </a>
           </div>
           <div class="p-card__content">
             <p>Model-driven cloud-native apps on public and private infrastructure and CAAS</p>
-            <p><a href="https://jaas.ai">jaas.ai&nbsp;&rsaquo;</a></p>
+            <p><a href="https://juju.is">juju.is&nbsp;&rsaquo;</a></p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Done

Under juju section on https://canonical.com/#products change link from jaas.ai to juju.is

## QA

- `dotrun`
- Open the website locally on http://0.0.0.0:8002/#products
- Make sure that Juju section is linked to https://juju.is

## Issue / Card

Fixes #420

## Screenshots

![Screenshot from 2021-09-13 17-09-53](https://user-images.githubusercontent.com/36013798/133109437-4f2167ef-8003-4674-bf2f-a668c58cb081.png)
