### PR TITLE
Add missing class

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -219,7 +219,7 @@
     </div>
   </div>
 
-  <div id="partners" class="p-strip is-slanted--top-right" style="margin-bottom: 9rem;">
+  <div id="partners" class="p-strip is-slanted--top-right js-active-target" style="margin-bottom: 9rem;">
     <div class="u-fixed-width u-align--center">
       <h4 class="p-muted-heading u-no-max-width">Meet some of our partners</h4>
     </div>


### PR DESCRIPTION
## Done

Added the missing class `js-active-target` to fix the highlight issue with the nav bar when scrolling.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Please scroll down and up the page and check if the nav bar gets highlighted properly. 

## Issue / Card

Fixes #418

## Screenshots

![image](https://user-images.githubusercontent.com/57550290/133469464-6cae4254-c739-4e87-b25e-89b7e46d4707.png)
