### PR TITLE
Add LinkedIn link and remove Facebook 

### DIFF
--- a/templates/partial/_footer.html
+++ b/templates/partial/_footer.html
@@ -16,7 +16,7 @@
       <div class="col-3 u-align--right">
         <ul class="p-inline-list">
           <li class="p-inline-list__item">
-              <a href="https://www.facebook.com/pages/Canonical/125818784107695?fref=ts" class="p-icon--facebook"></a>
+              <a href="https://www.linkedin.com/company/234280" class="p-icon--linkedin"></a>
           </li>
           <li class="p-inline-list__item">
             <a href="https://twitter.com/Canonical" class="p-icon--twitter"></a>


### PR DESCRIPTION
## Done

- Removed Facebook icon and link from homepage footer and added LinkedIn as per [request](https://github.com/canonical-web-and-design/canonical.com/issues/423#issue-997113587)

## QA

- View page at: https://canonical-com-425.demos.haus
- Scroll to the footer - see the Facebook link has been removed and the LinkedIn one has been added
- Check the link works and directs you to Canonical's LinkedIn page. 


## Issue / Card

Fixes #423 

## Screenshots

![Screenshot 2021-09-20 at 13 36 48](https://user-images.githubusercontent.com/58959073/134003325-d163819b-fe22-4e3e-9e76-21bc4aafb6f2.png)

