### PR TITLE
Replaced the field "department" with "departments"

### DIFF
--- a/templates/careers/results.html
+++ b/templates/careers/results.html
@@ -47,7 +47,7 @@ Travel regularly to interesting destinations for team, conference and customer e
             data-date="{{ vacancy.date }}"
             data-location="{{ vacancy.location }}"
             data-management="{{ vacancy.management}}"
-            data-sector="{{ vacancy.department }}"
+            data-sector="{{ vacancy.departments | map(attribute='name') | join(', ') }}"
           >
           <h3 class="p-card__title u-no-padding--top">
             <a class="p-link--soft" href="/careers/{{ vacancy.id }}/{{ vacancy.slug }}">{{ vacancy.title }}&nbsp;&rsaquo;</a>
@@ -97,7 +97,7 @@ Travel regularly to interesting destinations for team, conference and customer e
                         data-date="{{ vacancy.date }}"
                         data-location="{{ vacancy.location }}"
                         data-management="{{ vacancy.management}}"
-                        data-sector="{{ vacancy.department.slug }}"
+                        data-sector="{{ department.slug }}"
                       >
                         <a href="/careers/{{ vacancy.id }}/{{ vacancy.slug }}">
                           {{ vacancy.title }}

--- a/templates/partial/_careers-available-roles.html
+++ b/templates/partial/_careers-available-roles.html
@@ -15,7 +15,7 @@
       data-date="{{ job.date }}"
       data-location="{{ job.location }}"
       data-management="{{ job.management}}"
-      data-sector="{{ job.department }}"
+      data-sector="{{ job.departments | map(attribute='name') | join(', ') }}"
     >
       <p class="u-no-margin--bottom u-sv1">
         <small {% if checkbox %}style="padding-left: 2rem;"{% endif %}>

--- a/templates/partial/_careers-navigation.html
+++ b/templates/partial/_careers-navigation.html
@@ -28,11 +28,13 @@
       <li class="p-content-list-section__item {% if request.path|get_secondary_nav_path == 'all' %}is-active{% endif %}">
         <a href="/careers/all" class="p-link--soft">All roles</a>
         <span class="u-text--muted u-float-right" style="padding-right: 0.5rem;">
-          {% set vacancies = namespace(counter = 0) %}
+          {% set vacancies = {} %}
           {% for department in all_departments.values() %}
-            {% set vacancies.counter = vacancies.counter + (department.vacancies | length) %}
+            {% for vacancy in department.vacancies %}
+              {% set vacancies = vacancies.__setitem__(vacancy.id, vacancy) %}
+            {% endfor %}
           {% endfor %}
-          {{ vacancies.counter }}
+          {{ vacancies | length() }}
         </span>
       </li>
     </ul>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -83,13 +83,14 @@ def _group_by_department(vacancies):
         departments_by_slug[department.slug] = department
 
     for vacancy in vacancies:
-        slug = vacancy.department.slug
+        for department in vacancy.departments:
+            slug = department.slug
 
-        if slug not in vacancies_by_department:
-            vacancies_by_department[slug] = departments_by_slug[slug]
-            vacancies_by_department[slug].vacancies = [vacancy]
-        else:
-            vacancies_by_department[slug].vacancies.append(vacancy)
+            if slug not in vacancies_by_department:
+                vacancies_by_department[slug] = departments_by_slug[slug]
+                vacancies_by_department[slug].vacancies = [vacancy]
+            else:
+                vacancies_by_department[slug].vacancies.append(vacancy)
 
     return vacancies_by_department
 

--- a/webapp/greenhouse.py
+++ b/webapp/greenhouse.py
@@ -87,7 +87,7 @@ class Vacancy:
         self.employment: str = _get_metadata(job, "employment")
         self.date: str = job["updated_at"]
         self.questions: dict = job.get("questions", {})
-        self.department: str = Department(_get_metadata(job, "department"))
+        self.departments : list = list(map(lambda d: Department(d), _get_metadata(job, "departments") or []))
         self.management: str = _get_metadata(job, "management")
         self.office: str = job["offices"][0]["name"]
         self.description: str = _get_metadata(job, "description")
@@ -133,7 +133,10 @@ class Greenhouse:
         vacancies = self.get_vacancies()
 
         def department_filter(vacancy):
-            return vacancy.department.slug == department_slug
+            for department in vacancy.departments:
+                if department.slug == department_slug:
+                    return True
+            return False
 
         return list(filter(department_filter, vacancies))
 

--- a/webapp/greenhouse.py
+++ b/webapp/greenhouse.py
@@ -87,7 +87,12 @@ class Vacancy:
         self.employment: str = _get_metadata(job, "employment")
         self.date: str = job["updated_at"]
         self.questions: dict = job.get("questions", {})
-        self.departments : list = list(map(lambda d: Department(d), _get_metadata(job, "departments") or []))
+        self.departments: list = list(
+            map(
+                lambda d: Department(d),
+                _get_metadata(job, "departments") or [],
+            )
+        )
         self.management: str = _get_metadata(job, "management")
         self.office: str = job["offices"][0]["name"]
         self.description: str = _get_metadata(job, "description")


### PR DESCRIPTION
## Done

- Updated the structure of Vacancy on the backend side
- Updated the templates where there is a reference to vacancy.department

*FYI: Departments is a list where a vacancy can have one or multiple departments*

## QA

1. go to https://canonical-com-428.demos.haus/careers/all and make sure that the page is not broken
2. Here is an example of each vacancy case:

```json
[
  {
    "jobId": 3382736,
    "jobTitle": "Chief of Staff, Global Support Services",
    "department": "techops",
    "departments": ["techops"]
  },
  {
    "jobId": 3062022,
    "jobTitle": "Cloud Engineering - open source, remote",
    "department": "techops",
    "departments": ["engineering", "techops", "operations"]
  }
]

```

#### Explation of the JSON

The first one (with the id: `3382736`) is a job that belongs to only one department and the second one (with the id: `3062022`) belongs to multiple departments.


#### Steps

For each vacancy in the list you need to :
  * go to `/careers/[department]` and make sure that the job title is in the list of jobs positions for each department in the list that it belongs to (just do Ctrl+F with the title).
  * go to `/careers/[jobId]` and make sure that the page is not broken

## Issue / Card

Fixes #352

