### PR TITLE
Fixes navigation bar on mobile

### DIFF
--- a/static/sass/_pattern_navigation.scss
+++ b/static/sass/_pattern_navigation.scss
@@ -109,15 +109,8 @@ $nudge--small: 0.55rem;
       }
     }
 
-    .p-navigation__logo {
-      @media (max-width: $breakpoint-navigation-threshold) {
-        margin: 0 1rem;
-      }
-    }
-
     & &__nav {
       border-bottom: 0;
-      display: flex;
       width: 100%;
     }
 
@@ -268,10 +261,10 @@ $nudge--small: 0.55rem;
     &__toggle--open,
     &__toggle--close {
       color: $color-light !important;
-      font-size: 0.875rem;
-
-      @media (max-width: $breakpoint-x-small - 1) {
-        margin-right: map-get($grid-margin-widths, large) / 1.5 !important;
+      
+      &:hover {
+        background-color: rgba(94, 39, 80, 0.5) !important;
+        color: $color-x-light !important;
       }
     }
 

--- a/templates/partial/_navigation.html
+++ b/templates/partial/_navigation.html
@@ -4,7 +4,7 @@
   class="p-navigation{%if not request.path|get_nav_path == 'partners'%} is-sticky{% endif %}"
   role="banner">
   {% block header_banner %}
-  <div class="p-navigation__row u-fixed-width">
+  <div class="p-navigation__row is-dark u-fixed-width">
     <div class="p-navigation__banner">
       <div class="p-navigation__logo">
         <a class="p-navigation__link" href="/">
@@ -12,10 +12,12 @@
           <script>performance.mark("Logo rendered")</script>
         </a>
       </div>
+      <a href="#navigation" class="p-navigation__toggle--open" title="menu">Menu</a>
+      <a href="#navigation-closed" class="p-navigation__toggle--close" title="close menu">Close menu</a>
     </div>
     <nav class="p-navigation__nav">
       {% if request.path == '/' %}
-      <ul class="p-navigation__items">
+      <ul class="p-navigation__items" role="menu">
         <li class="p-navigation__item" role="menuitem">
           <a class="p-navigation__link" id="cta--products" href="#products">Products</a>
         </li>
@@ -27,7 +29,7 @@
         </li>
       </ul>
       {% else %}
-      <ul class="p-navigation__items u-hide js-show-nav">
+      <ul class="p-navigation__items u-hide js-show-nav" role="menu">
         <li
           class="p-navigation__item--dropdown-toggle {% if request.path|get_nav_path == 'products' %}is-selected{% endif %}"
           role="menuitem" id="products-nav"


### PR DESCRIPTION
## Done

- Hide nav items by default
- Add menu toggle button

## QA

- Go to the website https://canonical-com-432.demos.haus/ ,make sure to open the devtools and toggle the mobile view
- Make sure the nav items aren't shown by default
- The menu toggle button should work
- Make sure that the navbar is usable

- Go to the page: https://canonical-com-432.demos.haus/careers
- Make sure the nav items aren't shown by default
- The menu toggle button should work
- Make sure that the navbar is usable

## Issue / Card

Fixes #431

## Screenshots
### Before
![Screenshot from 2021-09-29 14-25-33](https://user-images.githubusercontent.com/36013798/135267918-8eb32e99-62c3-4316-9610-55e499ec973a.png)

### After
![Screenshot from 2021-09-29 14-25-07](https://user-images.githubusercontent.com/36013798/135267861-67f8a895-c812-42d2-b1ed-50136160b460.png)


