### PR TITLE
Career game mobile fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ Thumbs.db
 .LSOverride
 .spelling
 .vscode
+.idea
 
 # [cache] Cache and backup
 *.bak

--- a/static/sass/_pattern_cards.scss
+++ b/static/sass/_pattern_cards.scss
@@ -53,7 +53,7 @@
     @extend %vf-card;
 
     margin-bottom: $spv-inner--large;
-    min-height: 10rem;
+    min-height: 8rem;
     position: relative;
 
     &:hover {
@@ -127,6 +127,11 @@
       &.is-empty {
         display: none;
       }
+    }
+  }
+  @media (min-width: $breakpoint-small) {
+    .p-card--game {
+      min-height: 10rem;
     }
   }
 }

--- a/static/sass/_pattern_footer.scss
+++ b/static/sass/_pattern_footer.scss
@@ -17,7 +17,7 @@
     background-position: top right;
     background-repeat: no-repeat;
     background-size: 25% 15%, 100%;
-    clip-path: polygon(100% 0%, 100% 100%, 0% 100%, 0% calc(0% + 4rem));
+    clip-path: polygon(130% 0%, 100% 100%, 0% 100%, 0% calc(0% + 4rem));
     color: $color-mid-light;
     margin-top: -4rem;
     padding-bottom: 2.5rem;
@@ -40,6 +40,11 @@
     .p-inline-list--middot .p-inline-list__item::after {
       color: $color-mid-light;
       right: -0.8rem;
+    }
+  }
+  @media (min-width: $breakpoint-x-small) {
+    .p-footer {
+      clip-path: polygon(100% 0%, 124% 134%, 0% 124%, 0% calc(0% + 4rem));
     }
   }
 }

--- a/templates/careers/start.html
+++ b/templates/careers/start.html
@@ -32,7 +32,7 @@
           </div>
         </div>
       </div>
-      
+
       <div class="col-2 col-medium-3">
         <div class="p-card--game is-empty" id="selected-2">
           <button class="js-button--remove" data-parent="selected-2">
@@ -46,7 +46,7 @@
           </div>
         </div>
       </div>
-      
+
       <div class="col-2 col-medium-3">
         <div class="p-card--game is-empty" id="selected-3">
           <button class="js-button--remove" data-parent="selected-3">
@@ -60,7 +60,7 @@
           </div>
         </div>
       </div>
-      
+
       <div class="col-2 col-medium-3">
         <div class="p-card--game is-empty" id="selected-4">
           <button class="js-button--remove" data-parent="selected-4">
@@ -74,7 +74,7 @@
           </div>
         </div>
       </div>
-      
+
       <div class="col-2 col-medium-3">
         <div class="p-card--game is-empty" id="selected-5">
           <button class="js-button--remove" data-parent="selected-5">
@@ -88,7 +88,7 @@
           </div>
         </div>
       </div>
-    
+
       <div class="col-2 u-vertically-center u-align--center">
         <p><button class="p-button--positive js-submit-button" disabled="true">Submit choices</button></p>
       </div>
@@ -112,6 +112,11 @@
       color: #fff;
       padding-bottom: 6rem;
       padding-top: 6rem;
+    }
+    @media (min-width: 360px) and (max-width: 620px) {
+      .row.js-selected-skills .col-medium-3 {
+        grid-column: auto/span 2
+      }
     }
   </style>
   <script defer src="/static/js/careers-game.js"></script>


### PR DESCRIPTION
## Done
- changed selected skill width from 100% to 50%
- set skill `min-height` to 8rem in mobile
- fixed footer overlay in mobile

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/careers/start
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)

## Issue
Fixes #157

## Screenshots
footer overlay
![Screenshot from 2021-11-13 16-21-59](https://user-images.githubusercontent.com/44097148/141619182-722aaeab-ac75-4539-a3e9-90ba527a06a7.png)
changed skills grid
![Screenshot from 2021-11-13 16-23-51](https://user-images.githubusercontent.com/44097148/141620451-a716a47e-0069-4978-84f2-fbf370ac9458.png)
