### PR TITLE
Add warning message if CV size is over 1MB

### DIFF
--- a/static/js/file-validation.js
+++ b/static/js/file-validation.js
@@ -1,15 +1,19 @@
 (function () {
   const allowedExtensions = /(\.pdf|\.doc|\.docx|\.txt|\.rtf)$/i;
+  const maxAllowedSize = 1048576;
   const resumeFileInput = document.getElementById("resume");
   const coverLetterFileInput = document.getElementById("cover_letter");
 
   if (resumeFileInput) {
     resumeFileInput.addEventListener("change", function () {
       const filePath = resumeFileInput.value;
+      const fileSize = resumeFileInput.files[0].size;
       if (!allowedExtensions.exec(filePath)) {
-        alert(
-          "Invalid file format selected. Allowed formats are: pdf, doc, docx, txt, rtf"
-        );
+        alert("Invalid file format selected. Allowed formats are: pdf, doc, docx, txt, rtf");
+        resumeFileInput.value = "";
+      }
+      if (fileSize >= maxAllowedSize) {
+        alert("Invalid file size. Maximum file size 1MB.");
         resumeFileInput.value = "";
       }
     });
@@ -19,9 +23,7 @@
     coverLetterFileInput.addEventListener("change", function () {
       const filePath = coverLetterFileInput.value;
       if (!allowedExtensions.exec(filePath)) {
-        alert(
-          "Invalid file format selected. Allowed formats are: pdf, doc, docx, txt, rtf"
-        );
+        alert("Invalid file format selected. Allowed formats are: pdf, doc, docx, txt, rtf");
         coverLetterFileInput.value = "";
       }
     });


### PR DESCRIPTION
## Done

**Note** Haven't addressed the form limit issue, this just adds a warning message

Adds a warning message if the CV that is being uploaded is over 1MB

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Go to canonical.com/careers, choose a job, try to add a document over the size of 1MB to check the warning appears

## Issue / Card

Fixes https://github.com/canonical-web-and-design/canonical.com/issues/269
