### PR TITLE
Add iot-device page on /partners

### DIFF
--- a/templates/partners/_secondary-navigation.html
+++ b/templates/partners/_secondary-navigation.html
@@ -13,6 +13,9 @@
           <a class="breadcrumbs__link {% if request.path|get_secondary_nav_path == 'channel-and-reseller' %}p-link--active{% else %}p-link--soft{% endif %}" href="/partners/channel-and-reseller">Channel/Reseller</a>
         </li>
         <li class="breadcrumbs__item">
+          <a class="breadcrumbs__link {% if request.path|get_secondary_nav_path == 'iot-device' %}p-link--active{% else %}p-link--soft{% endif %}" href="/partners/iot-device">IoT device</a>
+        </li>
+        <li class="breadcrumbs__item">
           <a class="breadcrumbs__link {% if request.path|get_secondary_nav_path == 'ihv-and-oem' %}p-link--active{% else %}p-link--soft{% endif %}" href="/partners/ihv-and-oem">IHV/OEM</a>
         </li>
         <li class="breadcrumbs__item">

--- a/templates/partners/index.html
+++ b/templates/partners/index.html
@@ -50,8 +50,16 @@
         <img src="https://assets.ubuntu.com/v1/b77d6733-Resellers.svg" alt="image for resellers" class="p-media-object__image">
         <div class="p-media-object__details">
           <h1 class="p-media-object__title"><a href="/partners/channel-and-reseller">Channel&sol;Reseller&nbsp;&rsaquo;</a></h1>
-          <p class="p-media-object__content">Channel partners ensure that local Ubuntu expertise is available on every
-            continent</p>
+          <p class="p-media-object__content">Channel partners ensure that local Ubuntu expertise is available on every continent</p>
+        </div>
+      </div>
+    </div>
+    <div class="col-4 col-medium-3">
+      <div class="p-media-object--strip">
+        <img src="https://assets.ubuntu.com/v1/4ef8b431-Devices+%26+IoT.svg" alt="image for iot" class="p-media-object__image">
+        <div class="p-media-object__details">
+          <h1 class="p-media-object__title"><a href="/partners/iot-device">IoT Device&nbsp;&rsaquo;</a></h1>
+          <p class="p-media-object__content">ODM, factory, integration and device management partners get your device to market faster</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Done
- Add `IoT Device Programme`on the `/partners` page
- Add `IoT device` on the secondary menu 

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/partners
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Refer to this [doc](https://docs.google.com/document/d/1SwCceQv625Kdc3wAvzSFBBA3qt3CxzDmc0DAfo3LJfs/edit) and [brief](https://docs.google.com/document/d/1vOIffTaJL8LeQVj-kuc1XU9p1-SQFVvQWYZHEjcDKZ8/edit)

## Issue / Card

Fixes [#4634](https://github.com/canonical-web-and-design/web-squad/issues/4634)

## Screenshots

![image](https://user-images.githubusercontent.com/57550290/144098688-75aed9f7-cb26-4bc5-8cfc-589e4af6f721.png)
