### PR TITLE
Redesign remove button on careers game page

### DIFF
--- a/static/sass/_pattern_buttons.scss
+++ b/static/sass/_pattern_buttons.scss
@@ -70,12 +70,13 @@
   .js-button--remove {
     @extend %vf-button-base;
 
+    background-color: rgb(0,0,0,0);
     border: none;
     border-radius: 50%;
     height: 2rem;
     position: absolute;
-    right: 0.5rem;
-    top: 0.5rem;
+    right: -0.8rem;
+    top: 0.2rem;
     width: auto;
 
     & > .p-icon--close {
@@ -97,15 +98,11 @@
     }
 
     i {
-      @include vf-icon-close($color-mid-dark);
+      @include vf-icon-close($color-x-light);
     }
 
     &:hover {
       background-color: $color-negative;
-
-      i {
-        @include vf-icon-close($color-x-light);
-      }
     }
   }
 }


### PR DESCRIPTION
## Done

- Redesign remove button on careers game page
- Edited the css, which is only used in these buttons so should impact other areas

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check the button doesn't obscure the text
- Check it works on different sized screens
- Check it is still accessible 

## Issue / Card

Fixes https://github.com/canonical-web-and-design/canonical.com/issues/444

## Screenshots

*OLD*:
![image](https://user-images.githubusercontent.com/58276363/144087028-bbc27fb9-8d00-43ec-a2cf-f43d7e746541.png)

*NEW*:
![image](https://user-images.githubusercontent.com/58276363/144086880-79efdfcf-ae9f-40bf-97a6-d41666cf493a.png)

