### PR TITLE
Add application page for candidates

### DIFF
--- a/.env
+++ b/.env
@@ -5,3 +5,4 @@ SECRET_KEY=local_development_fake_key
 
 # https://canonical.greenhouse.io/configure/dev_center/credentials
 HARVEST_API_KEY=
+APPLICATION_CRYPTO_SECRET_KEY=super_secret

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Run image
         run: |
-          docker run --detach --env SECRET_KEY=insecure_secret_key --network host canonical-com
+          docker run --detach --env SECRET_KEY=insecure_secret_key  --env APPLICATION_CRYPTO_SECRET_KEY=insecure_secret_key --network host canonical-com
           sleep 1
           curl --head --fail --retry-delay 1 --retry 30 --retry-connrefused http://localhost
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -3,6 +3,7 @@ on: pull_request
 env:
   SECRET_KEY: insecure_test_key
   HARVEST_API_KEY: local_development_fake_key
+  APPLICATION_CRYPTO_SECRET_KEY: insecure_test_key
 
 jobs:
   run-image:

--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -16,6 +16,11 @@ env:
       key: harvest_api_key
       name: canonical-com
 
+  - name: APPLICATION_CRYPTO_SECRET_KEY
+    secretKeyRef:
+      key: application-crypto-key
+      name: greenhouse-credentials
+
 extraHosts:
   - domain: blog.canonical.com
   - domain: design.canonical.com

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ canonicalwebteam.templatefinder==1.0.0
 markdown==3.3.3
 python-slugify==4.0.1
 vcrpy-unittest==0.1.7
+cryptography

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ canonicalwebteam.templatefinder==1.0.0
 markdown==3.3.3
 python-slugify==4.0.1
 vcrpy-unittest==0.1.7
-cryptography
+cryptography==36.0.1

--- a/templates/applications/_interview-card.html
+++ b/templates/applications/_interview-card.html
@@ -1,7 +1,7 @@
 <div class="col-5 p-card--highlighted">
     <h3 class="p-card__title">{{ interview["interview"]["name"] }}</h3>
     <p class="p-card__content"><strong>When:</strong> {{ interview["start"]["datetime"].strftime('%d %B at %H:%M UTC') }} ({{ interview["duration"] }} minutes) - <a href="https://www.timeanddate.com/worldclock/converter.html?iso={{ interview['start']['datetime'].strftime('%Y%m%dT%H%M%S') }}&p1=1440">See in your timezone</a></p>
-    <p class="p-card__content"><strong>Interviewer(s):</strong> {% for interviewer in interview["interviewers"] %}{{ interviewer["name"] }}{% endfor %}</p>
+    <p class="p-card__content"><strong>Interviewer(s):</strong> {% for interviewer in interview["interviewers"] %}{% if loop.index > 1 %}, {% endif %}{{ interviewer["name"] }}{% endfor %}</p>
     {% if now("%Y%m%d") < interview["start"]["datetime"].strftime('%Y%m%d') %}
     {% if interview['video_conferencing_url'] %}
         <p class="p-card__content"><strong>Meet link:</strong> <a href="{{ interview['video_conferencing_url'] }}">{{ interview["video_conferencing_url"] }}</a></p>

--- a/templates/applications/_interview-card.html
+++ b/templates/applications/_interview-card.html
@@ -1,0 +1,12 @@
+<div class="col-5 p-card--highlighted">
+    <h3 class="p-card__title">{{ interview["interview"]["name"] }}</h3>
+    <p class="p-card__content"><strong>When:</strong> {{ interview["start"]["datetime"].strftime('%d %B at %H:%M UTC') }} ({{ interview["duration"] }} minutes) - <a href="https://www.timeanddate.com/worldclock/converter.html?iso={{ interview['start']['datetime'].strftime('%Y%m%dT%H%M%S') }}&p1=1440">See in your timezone</a></p>
+    <p class="p-card__content"><strong>Interviewer(s):</strong> {% for interviewer in interview["interviewers"] %}{{ interviewer["name"] }}{% endfor %}</p>
+    {% if now("%Y%m%d") < interview["start"]["datetime"].strftime('%Y%m%d') %}
+    {% if interview['video_conferencing_url'] %}
+        <p class="p-card__content"><strong>Meet link:</strong> <a href="{{ interview['video_conferencing_url'] }}">{{ interview["video_conferencing_url"] }}</a></p>
+    {% elif interview['location'] %}
+        <p class="p-card__content"><strong>Meet link:</strong> <a href="{{ interview['location'] }}">{{ interview["location"] }}</a></p>
+    {% endif %}
+    {% endif %}
+</div>

--- a/templates/applications/application.html
+++ b/templates/applications/application.html
@@ -43,31 +43,31 @@
         <h3>Recruiting at Canonical</h3>
         <ul>
             <li>
-                {% if application["stage_progress"]["application"] %}<i class="p-icon--success"></i> 
+                {% if "stage_progress" in application and application["stage_progress"]["application"] %}<i class="p-icon--success"></i> 
                 {% else %}<i class="p-icon--information"></i> 
                 {% endif %}
                 Application review
             </li>
             <li>
-                {% if application["stage_progress"]["assessment"] %}<i class="p-icon--success"></i> 
+                {% if "stage_progress" in application and application["stage_progress"]["assessment"] %}<i class="p-icon--success"></i> 
                 {% else %}<i class="p-icon--information"></i> 
                 {% endif %}
                 Assessment
             </li>
             <li>
-                {% if application["stage_progress"]["early_stage"] %}<i class="p-icon--success"></i> 
+                {% if "stage_progress" in application and application["stage_progress"]["early_stage"] %}<i class="p-icon--success"></i> 
                 {% else %}<i class="p-icon--information"></i> 
                 {% endif %}
                 Early stage
             </li>
             <li>
-                {% if application["stage_progress"]["late_stage"] %}<i class="p-icon--success"></i> 
+                {% if "stage_progress" in application and application["stage_progress"]["late_stage"] %}<i class="p-icon--success"></i> 
                 {% else %}<i class="p-icon--information"></i> 
                 {% endif %}
                 Late stage
             </li>
             <li>
-                {% if application["stage_progress"]["offer"] %}<i class="p-icon--success"></i> 
+                {% if "stage_progress" in application and application["stage_progress"]["offer"] %}<i class="p-icon--success"></i> 
                 {% else %}<i class="p-icon--information"></i> 
                 {% endif %}
                 Offer
@@ -76,10 +76,7 @@
     </div>
 
     <div class="row">
-        <h2>Learn more about Canonical</h2>
-    </div>
-    <div class="row">
-        <h3>Life at Canonical</h3>
+        <h2>Life at Canonical</h2>
     </div>
     <div class="row">
         <ul>
@@ -89,36 +86,6 @@
             <li><a href="/careers/progression">Progression</a></li>
             <li><a href="/careers/diversity">Diversity</a></li>
         </ul>
-    </div>
-    <div class="row">
-        <h3>Our 4 pillars</h3>
-    </div>
-    <div class="row">
-        <div class="col-4 p-card--highlighted">
-            <h3 class="p-card__title">ACCESSIBLE</h3>
-            <p class="p-card__content">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-        </div>
-        <div class="col-4 p-card--highlighted">
-            <h3 class="p-card__title">ADROIT</h3>
-            <p class="p-card__content">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-        </div>
-    </div>
-    <div class="row">
-        <div class="col-4 p-card--highlighted">
-            <h3 class="p-card__title">PRECISE</h3>
-            <p class="p-card__content">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-        </div>
-        <div class="col-4 p-card--highlighted">
-            <h3 class="p-card__title">RELIABLE</h3>
-            <p class="p-card__content">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-        </div>
-    </div>
-    <div class="row">
-        <h2>Not interested in this role anymore? Let us know!</h2>
-        <div class="col-4">
-            <textarea></textarea>
-            <button class="p-button--negative">Remove my application</button>
-        </div>
     </div>
 </section>
 {% elif application["status"] == "hired" %}

--- a/templates/applications/application.html
+++ b/templates/applications/application.html
@@ -41,38 +41,68 @@
         {% endif %}
         </ul>
         <h3>Recruiting at Canonical</h3>
-        <ul>
-            <li>
-                {% if "stage_progress" in application and application["stage_progress"]["application"] %}<i class="p-icon--success"></i> 
-                {% else %}<i class="p-icon--information"></i> 
-                {% endif %}
-                Application review
+        <ol class="p-list">
+            <li class="p-list_item">
+                <h4 class='p-heading--5 u-no-margin--bottom'>
+                    {% if "stage_progress" in application and application["stage_progress"]["application"] %}<i class="p-icon--success"></i> 
+                    {% else %}<i class="p-icon--information"></i> 
+                    {% endif %}
+                    Application review
+                </h4>
+                <p>Initial resume screening. A fully trained hiring lead will review your application against the job criteria set for this role.</p>
             </li>
-            <li>
-                {% if "stage_progress" in application and application["stage_progress"]["assessment"] %}<i class="p-icon--success"></i> 
-                {% else %}<i class="p-icon--information"></i> 
-                {% endif %}
-                Assessment
+            <li class="p-list_item">
+                <h4 class='p-heading--5 u-no-margin--bottom'>
+                    {% if "stage_progress" in application and application["stage_progress"]["assessment"] %}<i class="p-icon--success"></i> 
+                    {% else %}<i class="p-icon--information"></i> 
+                    {% endif %}
+                    Assessment
+                </h4>
+                <div>
+                    There are three parts to this stage:
+                    <ol>
+                        <li>
+                            <p class='u-no-margin--bottom'>A written interview, submitted and reviewed anonymously to reduce bias. This is your opportunity to highlight your key strengths for this position and once reviewed will be referred back at later stage interviews.</p>
+                        </li>
+                        <li>
+                            <p class='u-no-margin--bottom'>A psychometric assessment measuring fluid intelligence and behavioural traits.</p>
+                        </li>
+                        <li>
+                            <p class='u-no-margin--bottom'>Initial Meet & Greet Interview with a member of Canonical to share more about life at Canonical and to answer some of your initial basic questions.</p>
+                        </li>
+                    </ol>
+                </div>
             </li>
-            <li>
-                {% if "stage_progress" in application and application["stage_progress"]["early_stage"] %}<i class="p-icon--success"></i> 
-                {% else %}<i class="p-icon--information"></i> 
-                {% endif %}
-                Early stage
+            <li class="p-list_item">
+                <h4 class='p-heading--5 u-no-margin--bottom'>
+                    {% if "stage_progress" in application and application["stage_progress"]["early_stage"] %}
+                    <i class="p-icon--success"></i> 
+                    {% else %}<i class="p-icon--information"></i> 
+                    {% endif %}
+                    Early stage
+                </h4>
+                <p>This is a mixture of; technical assessments, competency based interviews and an interview with HR to talk about the benefits of working at Canonical, logistics and compensation.</p>
             </li>
-            <li>
-                {% if "stage_progress" in application and application["stage_progress"]["late_stage"] %}<i class="p-icon--success"></i> 
-                {% else %}<i class="p-icon--information"></i> 
-                {% endif %}
-                Late stage
+            <li class="p-list_item">
+                <h4 class='p-heading--5 u-no-margin--bottom'>
+                    {% if "stage_progress" in application and application["stage_progress"]["late_stage"] %}
+                    <i class="p-icon--success"></i> 
+                    {% else %}<i class="p-icon--information"></i> 
+                    {% endif %}
+                    Late stage                    
+                </h4>
+                <p>Once you have successfully completed your early stage interviews you’ll be invited to meet with senior leads within your management chain</p>
             </li>
-            <li>
-                {% if "stage_progress" in application and application["stage_progress"]["offer"] %}<i class="p-icon--success"></i> 
-                {% else %}<i class="p-icon--information"></i> 
-                {% endif %}
-                Offer
+            <li class="p-list_item">
+                <h4 class='p-heading--5 u-no-margin--bottom'>
+                    {% if "stage_progress" in application and application["stage_progress"]["offer"] %}
+                    <i class="p-icon--success"></i> 
+                    {% else %}<i class="p-icon--information"></i> 
+                    {% endif %}
+                    Offer
+                </h4>                
             </li>
-        </ul>
+        </ol>
     </div>
 
     <div class="row">

--- a/templates/applications/application.html
+++ b/templates/applications/application.html
@@ -9,7 +9,11 @@
 <section class="p-strip--suru-topped u-no-padding--bottom">
     <div class="row">
         <h1>Thanks for applying {{ candidate["first_name"] }}!</h1>
-        <p>You applied for the role: <a href="/careers/{{ application['job_post_id'] }}"><strong>{{ application["jobs"][0]["name"] }}</strong></a></p>
+        {% if application['source']['id'] == 2 %}
+            <p>You applied for the role: <a href="/careers/{{ application['job_post_id'] }}"><strong>{{ application["jobs"][0]["name"] }}</strong></a></p>
+        {% else %}
+            <p>You applied for the role: <strong>{{ application["jobs"][0]["name"] }}</strong></p>
+        {% endif %}
     </div>
 
     <div class="row">

--- a/templates/applications/application.html
+++ b/templates/applications/application.html
@@ -26,7 +26,7 @@
             {% endfor %}
             </ul>
             <h3>Past interviews</h3>
-            {% for interview in application["scheduled_interviews"] %}
+            {% for interview in application["scheduled_interviews"]|reverse %}
                 {% if now("%Y%m%d") > interview["start"]["datetime"].strftime('%Y%m%d') %}
                     {% include 'applications/_interview-card.html' %}
                 {% endif %}

--- a/templates/applications/application.html
+++ b/templates/applications/application.html
@@ -18,10 +18,8 @@
             <p><i class="p-icon--user"></i> {{ hiring_lead["name"] }} <a href="mailto:{{ hiring_lead['primary_email_address'] }}">{{ hiring_lead["primary_email_address"] }}</a></p>
         {% endif %}
     </div>
-
     <div class="row">
         <h2>You application progression</h2>
-
         <h3>Incoming interviews</h3>
         {% if not application["scheduled_interviews"] %}
             <p>No interview scheduled</p>
@@ -81,7 +79,7 @@
                     {% endif %}
                     Early stage
                 </h4>
-                <p>This is a mixture of; technical assessments, competency based interviews and an interview with HR to talk about the benefits of working at Canonical, logistics and compensation.</p>
+                <p>This is a mixture of: technical assessments, competency based interviews and an interview with HR to talk about the benefits of working at Canonical, logistics and compensation.</p>
             </li>
             <li class="p-list_item">
                 <h4 class='p-heading--5 u-no-margin--bottom'>
@@ -104,7 +102,6 @@
             </li>
         </ol>
     </div>
-
     <div class="row">
         <h2>Life at Canonical</h2>
     </div>

--- a/templates/applications/application.html
+++ b/templates/applications/application.html
@@ -15,14 +15,14 @@
             <p>You applied for the role: <strong>{{ application["jobs"][0]["name"] }}</strong></p>
         {% endif %}
         {% if hiring_lead %}
-            <p><i class="p-icon--user"></i> {{ hiring_lead["name"] }} <a href="mailto:{{ hiring_lead['primary_email_address'] }}">{{ hiring_lead["primary_email_address"] }}</a></p>
+            <p>Your hiring lead is {{ hiring_lead["name"] }} (<a href="mailto:{{ hiring_lead['primary_email_address'] }}">{{ hiring_lead["primary_email_address"] }}</a>)</p>
         {% endif %}
     </div>
     <div class="row">
-        <h2>You application progression</h2>
-        <h3>Incoming interviews</h3>
+        <h2>Your application</h2>
+        <h3>Upcoming interviews</h3>
         {% if not application["scheduled_interviews"] %}
-            <p>No interview scheduled</p>
+            <p><i class="p-icon--information"></i> No scheduled interviews. We do our best to keep you updated about the state of your application. Please check your spam folder.</p>
         {% else %}
             {% for interview in application["scheduled_interviews"] %}
                 {% if now("%Y%m%d") < interview["start"]["datetime"].strftime('%Y%m%d') %}
@@ -38,10 +38,10 @@
             {% endfor %}
         {% endif %}
         </ul>
-        <h3>Recruiting at Canonical</h3>
+        <h3>Our recruitment process</h3>
         <ol class="p-list">
             <li class="p-list_item">
-                <h4 class='p-heading--5 u-no-margin--bottom'>
+                <h4 class='u-no-margin--bottom'>
                     {% if "stage_progress" in application and application["stage_progress"]["application"] %}<i class="p-icon--success"></i> 
                     {% else %}<i class="p-icon--information"></i> 
                     {% endif %}
@@ -50,7 +50,7 @@
                 <p>Initial resume screening. A fully trained hiring lead will review your application against the job criteria set for this role.</p>
             </li>
             <li class="p-list_item">
-                <h4 class='p-heading--5 u-no-margin--bottom'>
+                <h4 class='u-no-margin--bottom'>
                     {% if "stage_progress" in application and application["stage_progress"]["assessment"] %}<i class="p-icon--success"></i> 
                     {% else %}<i class="p-icon--information"></i> 
                     {% endif %}
@@ -72,7 +72,7 @@
                 </div>
             </li>
             <li class="p-list_item">
-                <h4 class='p-heading--5 u-no-margin--bottom'>
+                <h4 class='u-no-margin--bottom'>
                     {% if "stage_progress" in application and application["stage_progress"]["early_stage"] %}
                     <i class="p-icon--success"></i> 
                     {% else %}<i class="p-icon--information"></i> 
@@ -82,7 +82,7 @@
                 <p>This is a mixture of: technical assessments, competency based interviews and an interview with HR to talk about the benefits of working at Canonical, logistics and compensation.</p>
             </li>
             <li class="p-list_item">
-                <h4 class='p-heading--5 u-no-margin--bottom'>
+                <h4 class='u-no-margin--bottom'>
                     {% if "stage_progress" in application and application["stage_progress"]["late_stage"] %}
                     <i class="p-icon--success"></i> 
                     {% else %}<i class="p-icon--information"></i> 
@@ -92,7 +92,7 @@
                 <p>Once you have successfully completed your early stage interviews you’ll be invited to meet with senior leads within your management chain</p>
             </li>
             <li class="p-list_item">
-                <h4 class='p-heading--5 u-no-margin--bottom'>
+                <h4 class='u-no-margin--bottom'>
                     {% if "stage_progress" in application and application["stage_progress"]["offer"] %}
                     <i class="p-icon--success"></i> 
                     {% else %}<i class="p-icon--information"></i> 

--- a/templates/applications/application.html
+++ b/templates/applications/application.html
@@ -1,0 +1,138 @@
+{% extends '/careers/base_job-details.html' %}
+
+{% block extra_metatags %}
+<meta name="robots" content="noindex">
+{% endblock %}
+
+{% block careers_content %}
+{% if application["status"] == "active" %}
+<section class="p-strip--suru-topped u-no-padding--bottom">
+    <div class="row">
+        <h1>Thanks for applying {{ candidate["first_name"] }}!</h1>
+        <p>You applied for the role: <a href="/careers/{{ application['job_post_id'] }}"><strong>{{ application["jobs"][0]["name"] }}</strong></a></p>
+    </div>
+
+    <div class="row">
+        <h2>You application progression</h2>
+
+        <h3>Incoming interviews</h3>
+        {% if not application["scheduled_interviews"] %}
+            <p>No interview scheduled</p>
+        {% else %}
+            {% for interview in application["scheduled_interviews"] %}
+                {% if now("%Y%m%d") < interview["start"]["datetime"].strftime('%Y%m%d') %}
+                    {% include 'applications/_interview-card.html' %}
+                {% endif %}
+            {% endfor %}
+            </ul>
+            <h3>Past interviews</h3>
+            {% for interview in application["scheduled_interviews"] %}
+                {% if now("%Y%m%d") > interview["start"]["datetime"].strftime('%Y%m%d') %}
+                    {% include 'applications/_interview-card.html' %}
+                {% endif %}
+            {% endfor %}
+        {% endif %}
+        </ul>
+        <h3>Recruiting at Canonical</h3>
+        <ul>
+            <li>
+                {% if application["stage_progress"]["application"] %}<i class="p-icon--success"></i> 
+                {% else %}<i class="p-icon--information"></i> 
+                {% endif %}
+                Application review
+            </li>
+            <li>
+                {% if application["stage_progress"]["assessment"] %}<i class="p-icon--success"></i> 
+                {% else %}<i class="p-icon--information"></i> 
+                {% endif %}
+                Assessment
+            </li>
+            <li>
+                {% if application["stage_progress"]["early_stage"] %}<i class="p-icon--success"></i> 
+                {% else %}<i class="p-icon--information"></i> 
+                {% endif %}
+                Early stage
+            </li>
+            <li>
+                {% if application["stage_progress"]["late_stage"] %}<i class="p-icon--success"></i> 
+                {% else %}<i class="p-icon--information"></i> 
+                {% endif %}
+                Late stage
+            </li>
+            <li>
+                {% if application["stage_progress"]["offer"] %}<i class="p-icon--success"></i> 
+                {% else %}<i class="p-icon--information"></i> 
+                {% endif %}
+                Offer
+            </li>
+        </ul>
+    </div>
+
+    <div class="row">
+        <h2>Learn more about Canonical</h2>
+    </div>
+    <div class="row">
+        <h3>Life at Canonical</h3>
+    </div>
+    <div class="row">
+        <ul>
+            <li><a href="/careers/lifestyle">Lifestyle</a></li>
+            <li><a href="/careers/ethics">Ethics</a></li>
+            <li><a href="/careers/travel">Travel</a></li>
+            <li><a href="/careers/progression">Progression</a></li>
+            <li><a href="/careers/diversity">Diversity</a></li>
+        </ul>
+    </div>
+    <div class="row">
+        <h3>Our 4 pillars</h3>
+    </div>
+    <div class="row">
+        <div class="col-4 p-card--highlighted">
+            <h3 class="p-card__title">ACCESSIBLE</h3>
+            <p class="p-card__content">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+        </div>
+        <div class="col-4 p-card--highlighted">
+            <h3 class="p-card__title">ADROIT</h3>
+            <p class="p-card__content">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-4 p-card--highlighted">
+            <h3 class="p-card__title">PRECISE</h3>
+            <p class="p-card__content">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+        </div>
+        <div class="col-4 p-card--highlighted">
+            <h3 class="p-card__title">RELIABLE</h3>
+            <p class="p-card__content">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+        </div>
+    </div>
+    <div class="row">
+        <h2>Not interested in this role anymore? Let us know!</h2>
+        <div class="col-4">
+            <textarea></textarea>
+            <button class="p-button--negative">Remove my application</button>
+        </div>
+    </div>
+</section>
+{% elif application["status"] == "hired" %}
+<section class="p-strip">
+    <div class="row">
+        <h1>Thanks for applying {{ candidate["first_name"] }} {{ candidate["last_name"] }}!</h1>
+        <p>
+            <i class="p-icon--success"></i> You are hired! Welcome to Canonical.
+        </p>
+    </div>
+</section>
+{% else %}
+<section class="p-strip">
+    <div class="row">
+        <h1>Thanks for applying {{ candidate["first_name"] }} {{ candidate["last_name"] }}!</h1>
+        <p>
+            <i class="p-icon--error"></i> It seems your application on the role {{ application["jobs"][0]["name"] }} was rejected. 
+            Check out <a href="/careers">our career page</a> to see if there 
+            is another role that would match your skills!
+        </p>
+    </div>
+</section>
+{% endif %}
+{% endblock %}

--- a/templates/applications/application.html
+++ b/templates/applications/application.html
@@ -14,6 +14,9 @@
         {% else %}
             <p>You applied for the role: <strong>{{ application["jobs"][0]["name"] }}</strong></p>
         {% endif %}
+        {% if hiring_lead %}
+            <p><i class="p-icon--user"></i> {{ hiring_lead["name"] }} <a href="mailto:{{ hiring_lead['primary_email_address'] }}">{{ hiring_lead["primary_email_address"] }}</a></p>
+        {% endif %}
     </div>
 
     <div class="row">

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -16,6 +16,7 @@ import talisker.requests
 # Local
 from webapp.greenhouse import Greenhouse, Harvest
 from webapp.partners import Partners
+from webapp.application import application
 
 app = FlaskBase(
     __name__,
@@ -31,6 +32,8 @@ greenhouse = Greenhouse(
 )
 harvest = Harvest(session=session, api_key=os.environ.get("HARVEST_API_KEY"))
 partners_api = Partners(session)
+
+app.register_blueprint(application, url_prefix="/careers/application")
 
 
 @app.route("/")

--- a/webapp/application.py
+++ b/webapp/application.py
@@ -92,7 +92,6 @@ def application_page(token):
     if not candidate["first_name"].lower() == name:
         flask.abort(404)
 
-    print(application["current_stage"])
     if application["current_stage"]:
         application["stage_progress"] = stage_progress(
             application["current_stage"]["name"]

--- a/webapp/application.py
+++ b/webapp/application.py
@@ -117,19 +117,3 @@ def application_page(token):
         job=job,
         hiring_lead=hiring_lead,
     )
-
-
-@application.route(
-    "/<int:candidate_id>-<int:application_id>/delete", methods=["DELETE"]
-)
-def delete_application(candidate_id, application_id):
-    application = harvest.get_application(application_id)
-    if (
-        "candidate_id" not in application
-        or application["candidate_id"] != candidate_id
-    ):
-        flask.abort(404)
-
-    # CODE TO DELETE APPLICATION
-
-    return flask.render_template("application.html", application=application)

--- a/webapp/application.py
+++ b/webapp/application.py
@@ -17,7 +17,7 @@ application = flask.Blueprint(
 
 session = talisker.requests.get_session()
 harvest = Harvest(session=session, api_key=os.environ.get("HARVEST_API_KEY"))
-cipher = Cipher(os.environ.get("SECRET_KEY"))
+cipher = Cipher(os.environ.get("APPLICATION_CRYPTO_SECRET_KEY"))
 
 
 @application.after_request
@@ -63,16 +63,6 @@ def stage_progress(current_stage):
         "late_stage": False,
         "offer": False,
     }
-
-
-# TODO: temproray endpoint to test the endpoint "application_page(token)"
-@application.route(
-    "/d/<string:name>-<string:candidate_id>-<string:application_id>"
-)
-def encrypt(name, candidate_id, application_id):
-    return flask.jsonify(
-        {"token": cipher.encrypt(f"{name}-{candidate_id}-{application_id}")}
-    )
 
 
 @application.route("/<string:token>")

--- a/webapp/application.py
+++ b/webapp/application.py
@@ -1,0 +1,118 @@
+import os
+import socket
+from dateutil.parser import parse
+
+import flask
+import talisker.requests
+
+
+from webapp.greenhouse import Harvest
+
+
+application = flask.Blueprint(
+    "application",
+    __name__,
+    template_folder="/templates",
+    static_folder="/dist",
+)
+
+session = talisker.requests.get_session()
+harvest = Harvest(session=session, api_key=os.environ.get("HARVEST_API_KEY"))
+
+
+@application.after_request
+def add_headers(response):
+    """
+    Generic rules for headers to add to all requests
+
+    - X-Hostname: Mention the name of the host/pod running the application
+    - Cache-Control: Add cache-control headers for public and private pages
+    """
+
+    response.headers["X-Hostname"] = socket.gethostname()
+
+    if response.status_code == 200:
+        response.headers["Cache-Control"] = "private"
+
+    return response
+
+
+def stage_progress(current_stage):
+    # TODO FINISH THIS CODE (currently just for demo)
+    if current_stage == "Application Review":
+        return {
+            "application": True,
+            "assessment": False,
+            "early_stage": False,
+            "late_stage": False,
+            "offer": False,
+        }
+    if current_stage == "Written Interview":
+        return {
+            "application": True,
+            "assessment": True,
+            "early_stage": False,
+            "late_stage": False,
+            "offer": False,
+        }
+
+    return {
+        "application": True,
+        "assessment": True,
+        "early_stage": True,
+        "late_stage": False,
+        "offer": False,
+    }
+
+
+@application.route("/<int:candidate_id>-<int:application_id>")
+def application_page(candidate_id, application_id):
+    application = harvest.get_application(application_id)
+    if (
+        "candidate_id" not in application
+        or application["candidate_id"] != candidate_id
+    ):
+        flask.abort(404)
+
+    if application["current_stage"]:
+        application["stage_progress"] = stage_progress(
+            application["current_stage"]["name"]
+        )
+        application["scheduled_interviews"] = harvest.get_interviews_scheduled(
+            application_id
+        )
+
+        for interview in application["scheduled_interviews"]:
+            interview["start"]["datetime"] = parse(
+                interview["start"]["date_time"]
+            )
+            interview["end"]["datetime"] = parse(interview["end"]["date_time"])
+            difference = (
+                interview["end"]["datetime"] - interview["start"]["datetime"]
+            )
+            interview["duration"] = int(difference.total_seconds() / 60)
+
+    candidate = harvest.get_candidate(application["candidate_id"])
+
+    return flask.render_template(
+        "applications/application.html",
+        title="You application",
+        candidate=candidate,
+        application=application,
+    )
+
+
+@application.route(
+    "/<int:candidate_id>-<int:application_id>/delete", methods=["DELETE"]
+)
+def delete_application(candidate_id, application_id):
+    application = harvest.get_application(application_id)
+    if (
+        "candidate_id" not in application
+        or application["candidate_id"] != candidate_id
+    ):
+        flask.abort(404)
+
+    # CODE TO DELETE APPLICATION
+
+    return flask.render_template("application.html", application=application)

--- a/webapp/application.py
+++ b/webapp/application.py
@@ -67,7 +67,7 @@ def stage_progress(current_stage):
 
 # TODO: temproray endpoint to test the endpoint "application_page(token)"
 @application.route(
-    "/<string:name>-<string:candidate_id>-<string:application_id>"
+    "/d/<string:name>-<string:candidate_id>-<string:application_id>"
 )
 def encrypt(name, candidate_id, application_id):
     return flask.jsonify(

--- a/webapp/application.py
+++ b/webapp/application.py
@@ -49,6 +49,7 @@ def stage_progress(current_stage):
         "early_stage": (
             "Early Stage Interviews",
             "Technical Exercise",
+            "Technical Interview",
             "HR interview",
         ),
         "late_stage": (
@@ -91,6 +92,7 @@ def application_page(token):
     if not candidate["first_name"].lower() == name:
         flask.abort(404)
 
+    print(application["current_stage"])
     if application["current_stage"]:
         application["stage_progress"] = stage_progress(
             application["current_stage"]["name"]

--- a/webapp/application.py
+++ b/webapp/application.py
@@ -38,31 +38,39 @@ def add_headers(response):
 
 
 def stage_progress(current_stage):
-    # TODO FINISH THIS CODE (currently just for demo)
-    if current_stage == "Application Review":
-        return {
-            "application": True,
-            "assessment": False,
-            "early_stage": False,
-            "late_stage": False,
-            "offer": False,
-        }
-    if current_stage == "Written Interview":
-        return {
-            "application": True,
-            "assessment": True,
-            "early_stage": False,
-            "late_stage": False,
-            "offer": False,
-        }
-
-    return {
-        "application": True,
-        "assessment": True,
-        "early_stage": True,
-        "late_stage": False,
-        "offer": False,
+    milestone_stages = {
+        "application": ("Application Review"),
+        "assessment": (
+            "Written Interview",
+            "Psychometric Assessment",
+            "Meet & Greet",
+            "Hold",
+        ),
+        "early_stage": (
+            "Early Stage Interviews",
+            "Technical Exercise",
+            "HR interview",
+        ),
+        "late_stage": (
+            "Late Stage Interviews",
+            "Shortlist",
+            "Executive Review",
+        ),
+        "offer": ("Offer"),
     }
+
+    progress = {}
+    found = False
+    for milestone, stages in milestone_stages.items():
+        if current_stage in stages:
+            progress[milestone] = True
+            found = True
+        elif not found:
+            progress[milestone] = True
+        else:
+            progress[milestone] = False
+
+    return progress
 
 
 @application.route("/<string:token>")

--- a/webapp/greenhouse.py
+++ b/webapp/greenhouse.py
@@ -238,7 +238,7 @@ class Harvest:
     def get_interviews_scheduled(self, application_id):
         response = self.session.get(
             (
-                f"{self.base_url}/applications"
+                f"{self.base_url}applications"
                 f"/{application_id}/scheduled_interviews"
             ),
             headers={"Authorization": f"Basic {self.base64_key}"},
@@ -249,7 +249,7 @@ class Harvest:
 
     def get_application(self, application_id):
         response = self.session.get(
-            f"{self.base_url}/applications/{application_id}",
+            f"{self.base_url}applications/{application_id}",
             headers={"Authorization": f"Basic {self.base64_key}"},
         )
         response.raise_for_status()
@@ -258,7 +258,25 @@ class Harvest:
 
     def get_candidate(self, candidate_id):
         response = self.session.get(
-            f"{self.base_url}/candidates/{candidate_id}",
+            f"{self.base_url}candidates/{candidate_id}",
+            headers={"Authorization": f"Basic {self.base64_key}"},
+        )
+        response.raise_for_status()
+
+        return response.json()
+
+    def get_job(self, job_id):
+        response = self.session.get(
+            f"{self.base_url}jobs/{job_id}",
+            headers={"Authorization": f"Basic {self.base64_key}"},
+        )
+        response.raise_for_status()
+
+        return response.json()
+
+    def get_user(self, user_id):
+        response = self.session.get(
+            f"{self.base_url}users/{user_id}",
             headers={"Authorization": f"Basic {self.base64_key}"},
         )
         response.raise_for_status()

--- a/webapp/greenhouse.py
+++ b/webapp/greenhouse.py
@@ -234,3 +234,33 @@ class Harvest:
             [Department(department["name"]) for department in departments],
             key=lambda dept: dept.name,
         )
+
+    def get_interviews_scheduled(self, application_id):
+        response = self.session.get(
+            (
+                f"{self.base_url}/applications"
+                f"/{application_id}/scheduled_interviews"
+            ),
+            headers={"Authorization": f"Basic {self.base64_key}"},
+        )
+        response.raise_for_status()
+
+        return response.json()
+
+    def get_application(self, application_id):
+        response = self.session.get(
+            f"{self.base_url}/applications/{application_id}",
+            headers={"Authorization": f"Basic {self.base64_key}"},
+        )
+        response.raise_for_status()
+
+        return response.json()
+
+    def get_candidate(self, candidate_id):
+        response = self.session.get(
+            f"{self.base_url}/candidates/{candidate_id}",
+            headers={"Authorization": f"Basic {self.base64_key}"},
+        )
+        response.raise_for_status()
+
+        return response.json()

--- a/webapp/utils/cipher.py
+++ b/webapp/utils/cipher.py
@@ -1,0 +1,26 @@
+import base64
+import hashlib
+
+from cryptography.fernet import Fernet, InvalidToken
+
+
+class Cipher:
+    def __init__(self, secret):
+        self.cipher_suite = Fernet(
+            base64.urlsafe_b64encode(
+                hashlib.sha256(secret.encode("utf-8")).digest()
+            )
+        )
+
+    def encrypt(self, raw_text):
+        return self.cipher_suite.encrypt(
+            bytes(raw_text.encode("utf-8"))
+        ).decode("utf-8")
+
+    def decrypt(self, token):
+        try:
+            return self.cipher_suite.decrypt(
+                bytes(token.encode("utf-8"))
+            ).decode("utf-8")
+        except InvalidToken:
+            return None


### PR DESCRIPTION
## Done

- This is a page dedicated to applications for candidates that apply to jobs. This link will be shared in the emails exchanged between the recruiter and the candidate
- A candidate can have multiple pages if the candidate applies to multiple jobs
- This page will let the candidate know what is the progress of his/her application
- The page shows a list of useful information like:
  - Job link
  - Next interview (with a link to convert the time to your own timezone)
  - Previous interviews
  - What stage is the application (WIP)
  - Some useful links about Canonical (WIP)
  - A form to delete the candidate application (WIP)
- The page is not indexed 
- The link is made with `first_name`, `candidate_id` and `application_id`. This is made to avoid someone doing a bruteforce to find all those links: `/careers/application/SUPER-ENCRYPTED-LINK`
- Only the first name of the candidate is displayed on purpose in case someone finds the link 

Here is a copydocs with the proposed content: https://docs.google.com/document/d/1R3-aIHtdrs0eD0qFI8LiUPOf-fVY6IoxAsdjpd-2WO4/edit#heading=h.4ir3ufdci83f

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Test those URLs (to avoid putting any public link the URLs are in the pastebin) https://pastebin.canonical.com/p/f49wrH9mHM/

# TODO

- [x] A cool design
- [x]  What stage is the application 
- [x] A form to delete the candidate application (Can be done in another PR)
- [x] Some useful links about Canonical
- [x] Update link to be: a unique UUID, this will come with a script that should update all the candidates to add the extra variable in greenhouse.