### PR TITLE
Fix the responsiveness of the filter on /careers/all

### DIFF
--- a/static/sass/_pattern_forms.scss
+++ b/static/sass/_pattern_forms.scss
@@ -6,18 +6,20 @@
       flex-direction: row;
       flex-wrap: nowrap;
       justify-content: space-between;
-      // width: 100%;
       > * {
         margin: 0;
       }
     }
 
     .p-form__group {
-      
       @media screen and (min-width: $breakpoint-medium) {
         display: flex;
-        width: auto;
+        width: 100%;
 
+        + .p-form__group,
+        + [class*="p-button"] {
+          margin-left: $sph-inner--large;
+        }
         .p-form__label,
         .p-form__control,
         .p-form-validation__message {
@@ -27,17 +29,15 @@
 
         .p-form__label {
           flex-shrink: 0;
-          max-width: 4rem;
           padding-right: $sph-inner/4;
+          width: 4rem;
         }
 
         .p-form__control {
-          display: inline-block;
+          display: block;
+          min-width: unset;
           padding-right: $sph-inner;
         }
-      }
-      @media screen and (max-width: 1080px) {
-        flex-wrap: wrap;
       }
     }
   }

--- a/static/sass/_pattern_forms.scss
+++ b/static/sass/_pattern_forms.scss
@@ -29,8 +29,8 @@
 
         .p-form__label {
           flex-shrink: 0;
-          padding-right: $sph-inner/4;
-          width: 4rem;
+          min-width: 4rem;
+          white-space : nowrap; 
         }
 
         .p-form__control {

--- a/static/sass/_pattern_forms.scss
+++ b/static/sass/_pattern_forms.scss
@@ -39,6 +39,9 @@
           padding-right: $sph-inner;
         }
       }
+      @media screen and (max-width: 1080px) {
+        flex-wrap: wrap;
+      }
     }
   }
 }

--- a/static/sass/_pattern_forms.scss
+++ b/static/sass/_pattern_forms.scss
@@ -2,23 +2,21 @@
   .p-form--inline {
     @media screen and (min-width: $breakpoint-medium) {
       align-items: baseline;
-      display: inline-flex;
+      display: flex;
       flex-direction: row;
-
+      flex-wrap: nowrap;
+      justify-content: space-between;
+      // width: 100%;
       > * {
         margin: 0;
       }
     }
 
     .p-form__group {
+      
       @media screen and (min-width: $breakpoint-medium) {
         display: flex;
         width: auto;
-
-        + .p-form__group,
-        + [class*="p-button"] {
-          margin-left: $sph-inner--large;
-        }
 
         .p-form__label,
         .p-form__control,
@@ -29,18 +27,17 @@
 
         .p-form__label {
           flex-shrink: 0;
+          max-width: 4rem;
           padding-right: $sph-inner/4;
-          width: 4rem;
         }
 
         .p-form__control {
           display: inline-block;
           padding-right: $sph-inner;
-
-          .p-form__control {
-            width: 10rem;
-          }
         }
+      }
+      @media screen and (max-width: 1080px) {
+        flex-wrap: wrap;
       }
     }
   }

--- a/static/sass/_pattern_lists.scss
+++ b/static/sass/_pattern_lists.scss
@@ -13,9 +13,12 @@
       }
 
       &__item {
+        align-items: end;
+        display:flex;
+        justify-content: space-between;
         padding-bottom: $sp-x-small;
         padding-top: $sp-x-small;
-
+        
         &:last-child {
           margin-bottom: 1.5rem;
         }

--- a/templates/partial/_careers-navigation.html
+++ b/templates/partial/_careers-navigation.html
@@ -3,7 +3,7 @@
     <ul class="p-content-list-section" style="font-size: 1.1rem;">
       {% for department in all_departments.values() %}
         <li class="p-content-list-section__item {% if request.path|get_secondary_nav_path == department.slug %}is-active{% endif %}">
-          <a href="/careers/{{ department.slug }}" class="p-link--soft">{{ department.name }}&nbsp;</a><span class="u-text--muted u-float-right" style="padding-right: 0.5rem;">{{ department.vacancies | length }}</span>
+          <a href="/careers/{{ department.slug }}" class="p-link--soft">{{ department.name }}&nbsp;</a><span class="u-text--muted" style="padding-right: 0.5rem;">{{ department.vacancies | length }}</span>
         </li>
       {% endfor %}
     </ul>


### PR DESCRIPTION
## Done
- Fix the responsiveness of the filter on /careers/all
- Fix the side bar 
## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/careers/all
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Please check if the filter and the side bar is responsive on all screens. 
- [Demo](https://canonical-com-455.demos.haus/careers/all)

## Issue / Card

Fixes #448 

## Screenshots
Filter : 
Before 
![image](https://user-images.githubusercontent.com/57550290/144839650-6651aa0e-fefb-47b9-acc2-743ec7db2281.png)
After 
![image](https://user-images.githubusercontent.com/57550290/144874832-5de6dc96-38b0-4572-a74a-a00e9ca39334.png)
Side bar:
Before
![image](https://user-images.githubusercontent.com/57550290/144839741-61eab4f0-d871-40b2-bc16-7e2d59a6b741.png)
After
![image](https://user-images.githubusercontent.com/57550290/144839767-2197f9c7-aeb9-4177-a248-ae8f11492b43.png)

