### PR TITLE
Enable image template tag to work on canonical.com

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 bleach==3.3.0
 canonicalwebteam.flask-base==0.9.2
 canonicalwebteam.http==1.0.3
+canonicalwebteam.image-template==1.3.1
 canonicalwebteam.templatefinder==1.0.0
 markdown==3.3.3
 python-slugify==4.0.1

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -7,6 +7,7 @@ import os
 import re
 
 # Packages
+from canonicalwebteam import image_template
 from canonicalwebteam.flask_base.app import FlaskBase
 from canonicalwebteam.templatefinder import TemplateFinder
 from requests.exceptions import HTTPError
@@ -314,6 +315,11 @@ app.add_url_rule("/<path:subpath>", view_func=template_finder_view)
 @app.context_processor
 def inject_today_date():
     return {"current_year": datetime.date.today().year}
+
+
+@app.context_processor
+def utility_processor():
+    return {"image": image_template}
 
 
 @app.template_filter()


### PR DESCRIPTION
## Done

Enable image template tag to work on canonical.com

## QA

- Check out this feature branch
- Run the site using the command `./run`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Refer to [this page](https://github.com/canonical-web-and-design/canonicalwebteam.image-template)
- Try this image template tag below instead of `<img>` tag and please check if the image displays properly.
`{{
  image(
    url="https://assets.ubuntu.com/v1/450d7c2f-openstack-hero.svg",
    alt="",
    width="534",
    height="319",
    hi_def=True,
	fill=True,
    loading="auto",
    attrs={"class": "hero", "id": "openstack-hero"},
  ) | safe
}}`
## Issue / Card

Fixes #456 

