### PR TITLE
Page stubs

### DIFF
--- a/templates/about.html
+++ b/templates/about.html
@@ -1,0 +1,9 @@
+{% extends 'base_index.html' %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1Qxvhl6_kgCDarcem1wcFPQyHk0JEFUP1zIzNsIrT3_Y/edit#heading=h.2cifs8ay7uv0{% endblock %}
+
+{% block title %}Contact us{% endblock %}
+
+{% block meta_description %}Contact information for Canonical, the publisher of Ubuntu.{% endblock %}
+
+<h1>About Canonical (2.0.1)</h1>

--- a/templates/base_v3.html
+++ b/templates/base_v3.html
@@ -1,0 +1,105 @@
+<!doctype html>
+
+<html lang="en" dir="ltr">
+
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description"
+      content="{% block meta_description %}Canonical produces Ubuntu, provides commercial services for Ubuntu’s users, and works with hardware manufacturers, software vendors and cloud partners to certify Ubuntu.{% endblock %}" />
+    <meta name="copydoc" content="{% block meta_copydoc %}https://drive.google.com/drive/folders/0B8feV0jqaac3TmExU3NDcHhFTGc{% endblock %}">
+    <meta name="author" content="Canonical Ltd" />
+
+    <meta name="theme-color" content="#E95420">
+    <meta name="twitter:account_id" content="169015850">
+    <meta name="twitter:site" content="@canonical">
+    <meta property="og:type" content="website">
+    <meta property="og:url" content="{{ request.url }}">
+    <meta property="og:site_name" content="Canonical">
+
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-M5BPGQ6');</script>
+
+    <!-- Google optomise -->
+    <script async src="https://www.googleoptimize.com/optimize.js?id=OPT-KMJNW6P"></script>
+
+    <title>{% block title %}Publisher of Ubuntu{% endblock %} | Canonical</title>
+    {% if self.title() %}
+    <meta name="twitter:title" content="{{ self.title() }} | Canonical">
+    <meta property="og:title" content="{{ self.title() }} | Canonical">
+    {% endif %}
+    {% if self.meta_description() %}
+    <meta name="twitter:description" content="{{ self.meta_description() }}">
+    <meta property="og:description" content="{{ self.meta_description() }}">
+    {% endif %}
+
+    {# Define the required meta_keywords block #}
+    <!-- Meta keywords: {% block meta_keywords %}{% endblock %} -->
+    {% if self.meta_keywords() %}
+    <!-- added for internal helps -->
+    <meta name="keywords" content="{{ self.meta_keywords() }}">
+    {% endif %}
+
+    {# Define the required meta_image block #}
+    <!-- Meta image: {% block meta_image %}{% endblock %} -->
+    {% if self.meta_image() %}
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:image" content="{% if 'http' not in self.meta_image() %}https://assets.ubuntu.com/v1/{% endif %}{{ self.meta_image() }}">
+    <meta property="og:image" content="{% if 'http' not in self.meta_image() %}https://assets.ubuntu.com/v1/{% endif %}{{ self.meta_image() }}">
+    {% endif %}
+
+
+    {% block extra_metatags %}{% endblock %}
+
+    <link rel="shortcut icon" href="https://assets.ubuntu.com/v1/0843d517-favicon.ico" type="image/x-icon" />
+    <link rel="apple-touch-icon-precomposed" sizes="144x144"
+      href="https://assets.ubuntu.com/v1/9864667f-apple-touch-icon-144x144-precomposed.png">
+    <link rel="apple-touch-icon-precomposed" sizes="114x114"
+      href="https://assets.ubuntu.com/v1/f2ddbdc6-apple-touch-icon-114x114-precomposed.png">
+    <link rel="apple-touch-icon-precomposed" sizes="72x72"
+      href="https://assets.ubuntu.com/v1/f193fb82-apple-touch-icon-72x72-precomposed.png">
+    <link rel="apple-touch-icon-precomposed"
+      href="https://assets.ubuntu.com/v1/205d458b-apple-touch-icon-precomposed.png">
+
+    <link rel="preconnect" href="https://assets.ubuntu.com">
+
+    <link rel="preload" as="font" type="font/woff2" href="https://assets.ubuntu.com/v1/e8c07df6-Ubuntu-L_W.woff2"
+      crossorigin>
+    <link rel="preload" as="font" type="font/woff2" href="https://assets.ubuntu.com/v1/7f100985-Ubuntu-Th_W.woff2"
+      crossorigin>
+    <link rel="preload" as="font" type="font/woff2" href="https://assets.ubuntu.com/v1/f8097dea-Ubuntu-LI_W.woff2"
+      crossorigin>
+    <link rel="preload" as="font" type="font/woff2" href="https://assets.ubuntu.com/v1/fff37993-Ubuntu-R_W.woff2"
+      crossorigin>
+
+    <script src="{{ versioned_static('js/navigation.js') }}" defer></script>
+
+    <link rel="stylesheet" type="text/css" media="screen" href="{{ versioned_static('css/styles.css') }}" />
+  </head>
+
+  <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-M5BPGQ6"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+
+    <div id="main-content">
+      {% include "partial/_navigation.html" %}
+      {% if request.path|get_nav_path and request.path|get_nav_path == 'partners' %}
+        {% include request.path|get_nav_path + '/_secondary-navigation.html' %}
+      {% endif %}
+
+      {% block content %}{% endblock content %}
+    </div>
+    {% include 'partial/_footer.html' %}
+
+    <script src="{{ versioned_static('js/modules/cookie-policy/cookie-policy.js') }}"></script>
+    <script>
+      cpNs.cookiePolicy();
+    </script>
+  </body>
+
+</html>

--- a/templates/department-overview.html
+++ b/templates/department-overview.html
@@ -1,0 +1,9 @@
+{% extends 'base_v3.html' %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1Qxvhl6_kgCDarcem1wcFPQyHk0JEFUP1zIzNsIrT3_Y/edit#heading=h.2cifs8ay7uv0{% endblock %}
+
+{% block title %}Contact us{% endblock %}
+
+{% block meta_description %}Contact information for Canonical, the publisher of Ubuntu.{% endblock %}
+
+<h1>Department overviews</h1>

--- a/templates/leadership-bios.html
+++ b/templates/leadership-bios.html
@@ -1,0 +1,9 @@
+{% extends 'base_v3.html' %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1Qxvhl6_kgCDarcem1wcFPQyHk0JEFUP1zIzNsIrT3_Y/edit#heading=h.2cifs8ay7uv0{% endblock %}
+
+{% block title %}Contact us{% endblock %}
+
+{% block meta_description %}Contact information for Canonical, the publisher of Ubuntu.{% endblock %}
+
+<h1>Leadership Bios (2.0.3.1-2.0.3.x)</h1>

--- a/templates/leadership-team.html
+++ b/templates/leadership-team.html
@@ -1,0 +1,9 @@
+{% extends 'base_v3.html' %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1Qxvhl6_kgCDarcem1wcFPQyHk0JEFUP1zIzNsIrT3_Y/edit#heading=h.2cifs8ay7uv0{% endblock %}
+
+{% block title %}Contact us{% endblock %}
+
+{% block meta_description %}Contact information for Canonical, the publisher of Ubuntu.{% endblock %}
+
+<h1>Leadership team (2.0.3)</h1>

--- a/templates/opensource.html
+++ b/templates/opensource.html
@@ -1,0 +1,1 @@
+<h1>Opensource (2.1)</h1>

--- a/templates/our-code-of-conduct.html
+++ b/templates/our-code-of-conduct.html
@@ -1,0 +1,9 @@
+{% extends 'base_v3.html' %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1Qxvhl6_kgCDarcem1wcFPQyHk0JEFUP1zIzNsIrT3_Y/edit#heading=h.2cifs8ay7uv0{% endblock %}
+
+{% block title %}Contact us{% endblock %}
+
+{% block meta_description %}Contact information for Canonical, the publisher of Ubuntu.{% endblock %}
+
+<h1>Our Code of Conduct (8.1)</h1>

--- a/templates/press.html
+++ b/templates/press.html
@@ -1,0 +1,9 @@
+{% extends 'base_v3.html' %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1Qxvhl6_kgCDarcem1wcFPQyHk0JEFUP1zIzNsIrT3_Y/edit#heading=h.2cifs8ay7uv0{% endblock %}
+
+{% block title %}Press{% endblock %}
+
+{% block meta_description %}Press{% endblock %}
+
+<h1>Press (2.2)</h1>

--- a/templates/working-groups.html
+++ b/templates/working-groups.html
@@ -1,0 +1,9 @@
+{% extends 'base_v3.html' %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1Qxvhl6_kgCDarcem1wcFPQyHk0JEFUP1zIzNsIrT3_Y/edit#heading=h.2cifs8ay7uv0{% endblock %}
+
+{% block title %}Working groups{% endblock %}
+
+{% block meta_description %}Working groups{% endblock %}
+
+<h1>Working groups (8.9.1-8.9.x)</h1>

--- a/templates/working-here/index.html
+++ b/templates/working-here/index.html
@@ -1,0 +1,9 @@
+{% extends 'base_index.html' %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1Qxvhl6_kgCDarcem1wcFPQyHk0JEFUP1zIzNsIrT3_Y/edit#heading=h.2cifs8ay7uv0{% endblock %}
+
+{% block title %}Contact us{% endblock %}
+
+{% block meta_description %}Contact information for Canonical, the publisher of Ubuntu.{% endblock %}
+
+<h1>Working here (8.2-8.5)</h1>

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -62,3 +62,44 @@ class TestRoutes(VCRTestCase):
         """
 
         self.assertEqual(self.client.get("/not-found-url").status_code, 404)
+
+    def test_contact_us(self):
+        """
+        When given the contact-us page,
+        we should return a 200 status code
+        """
+
+        self.assertEqual(self.client.get("/contact-us").status_code, 200)
+    
+    def test_contact_us(self):
+        """
+        When given the contact-us page,
+        we should return a 200 status code
+        """
+
+        self.assertEqual(self.client.get("/contact-us").status_code, 200)
+    
+    def leadership_team(self):
+        """
+        When given the leadership-team page,
+        we should return a 200 status code
+        """
+
+        self.assertEqual(self.client.get("/leadership-team").status_code, 200)
+    
+    def opensource(self):
+        """
+        When given the opensource page,
+        we should return a 200 status code
+        """
+
+        self.assertEqual(self.client.get("/opensource").status_code, 200)
+    
+    def press(self):
+        """
+        When given the press page,
+        we should return a 200 status code
+        """
+
+        self.assertEqual(self.client.get("/press").status_code, 200)
+       

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -17,6 +17,12 @@ import talisker.requests
 # Local
 from webapp.greenhouse import Greenhouse, Harvest
 from webapp.partners import Partners
+from webapp.views import (
+    leadership_team,
+    customer_references,
+    opensource,
+    press,
+)
 
 app = FlaskBase(
     __name__,
@@ -305,6 +311,27 @@ def partners_sitemap():
     response.headers["Cache-Control"] = "public, max-age=43200"
 
     return response
+
+
+# Canonical v3
+# ===
+app.add_url_rule(
+    "/leadership-team/<bios>",
+    view_func=leadership_team,
+)
+app.add_url_rule(
+    "/customer-references",
+    view_func=customer_references,
+)
+
+app.add_url_rule(
+    "/opensource/<bios>",
+    view_func=opensource,
+)
+app.add_url_rule(
+    "/press",
+    view_func=press,
+)
 
 
 # Template finder

--- a/webapp/views.py
+++ b/webapp/views.py
@@ -1,0 +1,21 @@
+import flask
+
+
+def leadership_team():
+
+    return flask.render_template("leadership-team.html")
+
+
+def customer_references():
+
+    return flask.render_template("customer-references.html")
+
+
+def opensource():
+
+    return flask.render_template("opensource.html")
+
+
+def press():
+
+    return flask.render_template("press.html")


### PR DESCRIPTION
## Done

The products page has been removed from the wireframes
The following pages have been created:

Company
About Canonical
Leadership team
Leadership bios
Customer ereferences
Open source
Press
Careers
"Working here" one template example (most likely need to create an "include")
Department overviews
Working groups
Meet the team (this could potentially be an include)
Our Code of Conduct

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the following stub pages at: http://0.0.0.0:8002/

- /about-canonical
- /leadership-team
- /customer-references
- opensource
- press
- tech-culture
- department-overviews
- working-groups
- meet-the-team
- our-code-of-conduct


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/4589

