### PR TITLE
Page stubs

### DIFF
--- a/templates/about-canonical.html
+++ b/templates/about-canonical.html
@@ -2,10 +2,10 @@
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1Qxvhl6_kgCDarcem1wcFPQyHk0JEFUP1zIzNsIrT3_Y/edit#heading=h.2cifs8ay7uv0{% endblock %}
 
-{% block title %}Contact us{% endblock %}
+{% block title %}About Canonical{% endblock %}
 
-{% block meta_description %}Contact information for Canonical, the publisher of Ubuntu.{% endblock %}
+{% block meta_description %}About Canonical at Canonical.{% endblock %}
 
 {% block content %}
-<h1>Opensource (2.1)</h1>
+<h1>About Canonical (2.0.1)</h1>
 {% endblock content %}

--- a/templates/customer-references.html
+++ b/templates/customer-references.html
@@ -2,10 +2,10 @@
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1Qxvhl6_kgCDarcem1wcFPQyHk0JEFUP1zIzNsIrT3_Y/edit#heading=h.2cifs8ay7uv0{% endblock %}
 
-{% block title %}Contact us{% endblock %}
+{% block title %}Customer references{% endblock %}
 
-{% block meta_description %}Contact information for Canonical, the publisher of Ubuntu.{% endblock %}
+{% block meta_description %}Canonical customer references.{% endblock %}
 
 {% block content %}
-<h1>Opensource (2.1)</h1>
+<h1>Customer references</h1>
 {% endblock content %}

--- a/templates/department-overview.html
+++ b/templates/department-overview.html
@@ -6,4 +6,6 @@
 
 {% block meta_description %}Contact information for Canonical, the publisher of Ubuntu.{% endblock %}
 
+{% block content %}
 <h1>Department overviews</h1>
+{% endblock content %}

--- a/templates/includes/_working-here.html
+++ b/templates/includes/_working-here.html
@@ -6,4 +6,7 @@
 
 {% block meta_description %}Contact information for Canonical, the publisher of Ubuntu.{% endblock %}
 
-<h1>About Canonical (2.0.1)</h1>
+{% block content %}
+    <h1>This is a working here template</h1>
+    <h2>{{ title }}</h2>
+{% endblock content %}

--- a/templates/leadership-bios.html
+++ b/templates/leadership-bios.html
@@ -6,4 +6,6 @@
 
 {% block meta_description %}Contact information for Canonical, the publisher of Ubuntu.{% endblock %}
 
+{% block content %}
 <h1>Leadership Bios (2.0.3.1-2.0.3.x)</h1>
+{% endblock content %}

--- a/templates/leadership-team.html
+++ b/templates/leadership-team.html
@@ -6,4 +6,6 @@
 
 {% block meta_description %}Contact information for Canonical, the publisher of Ubuntu.{% endblock %}
 
+{% block content %}
 <h1>Leadership team (2.0.3)</h1>
+{% endblock content %}

--- a/templates/meet-the-team.html
+++ b/templates/meet-the-team.html
@@ -2,10 +2,10 @@
 
 {% block meta_copydoc %}https://docs.google.com/document/d/1Qxvhl6_kgCDarcem1wcFPQyHk0JEFUP1zIzNsIrT3_Y/edit#heading=h.2cifs8ay7uv0{% endblock %}
 
-{% block title %}Contact us{% endblock %}
+{% block title %}Meet the team{% endblock %}
 
-{% block meta_description %}Contact information for Canonical, the publisher of Ubuntu.{% endblock %}
+{% block meta_description %}Meet the team at Canonical.{% endblock %}
 
 {% block content %}
-<h1>Opensource (2.1)</h1>
+<h1>Meet the team (2.1)</h1>
 {% endblock content %}

--- a/templates/our-code-of-conduct.html
+++ b/templates/our-code-of-conduct.html
@@ -6,4 +6,6 @@
 
 {% block meta_description %}Contact information for Canonical, the publisher of Ubuntu.{% endblock %}
 
+{% block content %}
 <h1>Our Code of Conduct (8.1)</h1>
+{% endblock content %}

--- a/templates/press.html
+++ b/templates/press.html
@@ -6,4 +6,6 @@
 
 {% block meta_description %}Press{% endblock %}
 
+{% block content %}
 <h1>Press (2.2)</h1>
+{% endblock content %}

--- a/templates/tech-culture.html
+++ b/templates/tech-culture.html
@@ -1,0 +1,8 @@
+{% with
+    id = "1",
+    title = "Tech Culture",
+    tagline = "Rigor. Insight. Discovery.",
+    description = "I love figuring out how things work and testing the limits of possibility."
+%}
+    {% include "includes/_working-here.html" %}
+{% endwith %}

--- a/templates/working-groups.html
+++ b/templates/working-groups.html
@@ -6,4 +6,6 @@
 
 {% block meta_description %}Working groups{% endblock %}
 
+{% block content %}
 <h1>Working groups (8.9.1-8.9.x)</h1>
+{% endblock content %}

--- a/templates/working-here/index.html
+++ b/templates/working-here/index.html
@@ -6,4 +6,6 @@
 
 {% block meta_description %}Contact information for Canonical, the publisher of Ubuntu.{% endblock %}
 
+{% block content %}
 <h1>Working here (8.2-8.5)</h1>
+{% endblock content %}

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -102,4 +102,3 @@ class TestRoutes(VCRTestCase):
         """
 
         self.assertEqual(self.client.get("/press").status_code, 200)
-       

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -70,15 +70,7 @@ class TestRoutes(VCRTestCase):
         """
 
         self.assertEqual(self.client.get("/contact-us").status_code, 200)
-    
-    def test_contact_us(self):
-        """
-        When given the contact-us page,
-        we should return a 200 status code
-        """
 
-        self.assertEqual(self.client.get("/contact-us").status_code, 200)
-    
     def leadership_team(self):
         """
         When given the leadership-team page,
@@ -86,7 +78,7 @@ class TestRoutes(VCRTestCase):
         """
 
         self.assertEqual(self.client.get("/leadership-team").status_code, 200)
-    
+
     def opensource(self):
         """
         When given the opensource page,
@@ -94,7 +86,7 @@ class TestRoutes(VCRTestCase):
         """
 
         self.assertEqual(self.client.get("/opensource").status_code, 200)
-    
+
     def press(self):
         """
         When given the press page,


### PR DESCRIPTION
## Done

The products page has been removed from the wireframes
The following pages have been created:

Company
About Canonical
Leadership team
Leadership bios
Customer ereferences
Open source
Press
Careers
"Working here" one template example (most likely need to create an "include")
Department overviews
Working groups
Meet the team (this could potentially be an include)
Our Code of Conduct

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the following stub pages at: http://0.0.0.0:8002/

- /about-canonical
- /leadership-team
- /customer-references
- opensource
- press
- tech-culture
- department-overviews
- working-groups
- meet-the-team
- our-code-of-conduct


## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/4589

