### PR TITLE
Ensure users are sent back to a careers list from a job application

### DIFF
--- a/templates/careers/job-detail.html
+++ b/templates/careers/job-detail.html
@@ -51,7 +51,7 @@
 <section class="p-strip--suru-topped u-no-padding--bottom">
   <div class="row">
     <div class="col-6">
-      <a href="{% if request.referrer %}{{ request.referrer }}{% else %}/careers/all{% endif %}" class="u-sv2">&lsaquo;&nbsp;Back to list</a>
+      <a href="{% if request.referrer and 'careers' in request.referrer %}{{ request.referrer }}{% else %}/careers/all{% endif %}" class="u-sv2">&lsaquo;&nbsp;Back to list</a>
     </div>
   </div>
   <div class="row u-equal-height">


### PR DESCRIPTION
## Done

- Updated the "Back to list" logic to check whether the user came from a careers page. If they didn't, the link will send them to /careers/all.

## QA
**HACKY QA ALERT**
The easiest way I could find to check this worked was to drop a link to a specific job advert in a non careers section of the page.
Also - you will need the `GREENHOUSE_API_KEY` and `HARVEST_API_KEY` env variables in your local project to be able to see job listings. I can provide them if you don't have them already.

- Check out this feature branch
- Run the site using the command `./run serve`/`dotrun`
- In your code editor, add `<a href="http://0.0.0.0:8002/careers/2404733/associate-field-software-engineer-emea-remote">Job listing</a>` to any page not under /careers
- View the site locally in your web browser at: http://0.0.0.0:8002/, find the link you added and click it
- When you arrive at the job listing page, click the "Back to list" link at the top. It should take you to /careers/all
- On that page, choose engineering, and then select the first job listing (it should be the same one you saw earlier)
- The "Back to list" link should now return you to /careers/engingeering, not /careers/all

## Issue / Card

Fixes #483 
