### PR TITLE
Remove api call for all-departments from 'job-details' view

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -170,10 +170,7 @@ def careers_rss():
     "/careers/<regex('[0-9]+'):job_id>/<job_title>", methods=["GET", "POST"]
 )
 def job_details(job_id, job_title):
-    context = {
-        "all_departments": _group_by_department(greenhouse.get_vacancies())
-    }
-    context["bleach"] = bleach
+    context = {"bleach": bleach}
 
     try:
         context["job"] = greenhouse.get_vacancy(job_id)


### PR DESCRIPTION
## Done

- Removes api call for all-departments from 'job-details' view

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/careers/3776344/dedicated-linux-engineer-emea-remote
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check job details page still functions appropriately

## Issue / Card

Fixes https://github.com/canonical-web-and-design/canonical.com/issues/487
