### PR TITLE
Add file size check to cover-letter upload on job application form

### DIFF
--- a/static/js/file-validation.js
+++ b/static/js/file-validation.js
@@ -3,34 +3,28 @@
   const maxAllowedSize = 1048576;
   const resumeFileInput = document.getElementById("resume");
   const coverLetterFileInput = document.getElementById("cover_letter");
+  const validateFile = (inputElement) => {
+    const filePath = inputElement.value;
+    const fileSize = inputElement.files[0].size;
+    if (!allowedExtensions.exec(filePath)) {
+      alert("Invalid file format selected. Allowed formats are: pdf, doc, docx, txt, rtf");
+      inputElement.value = "";
+    }
+    if (fileSize >= maxAllowedSize) {
+      alert("Invalid file size. Maximum file size 1MB.");
+      inputElement.value = "";
+    }
+  };
 
   if (resumeFileInput) {
     resumeFileInput.addEventListener("change", function () {
-      const filePath = resumeFileInput.value;
-      const fileSize = resumeFileInput.files[0].size;
-      if (!allowedExtensions.exec(filePath)) {
-        alert("Invalid file format selected. Allowed formats are: pdf, doc, docx, txt, rtf");
-        resumeFileInput.value = "";
-      }
-      if (fileSize >= maxAllowedSize) {
-        alert("Invalid file size. Maximum file size 1MB.");
-        resumeFileInput.value = "";
-      }
+      validateFile(resumeFileInput);
     });
   }
 
   if (coverLetterFileInput) {
     coverLetterFileInput.addEventListener("change", function () {
-      const filePath = coverLetterFileInput.value;
-      const fileSize = coverLetterFileInput.files[0].size;
-      if (!allowedExtensions.exec(filePath)) {
-        alert("Invalid file format selected. Allowed formats are: pdf, doc, docx, txt, rtf");
-        coverLetterFileInput.value = "";
-      }
-      if (fileSize >= maxAllowedSize) {
-        alert("Invalid file size. Maximum file size 1MB.");
-        coverLetterFileInput.value = "";
-      }
+      validateFile(coverLetterFileInput);
     });
   }
 })();

--- a/static/js/file-validation.js
+++ b/static/js/file-validation.js
@@ -22,8 +22,13 @@
   if (coverLetterFileInput) {
     coverLetterFileInput.addEventListener("change", function () {
       const filePath = coverLetterFileInput.value;
+      const fileSize = coverLetterFileInput.files[0].size;
       if (!allowedExtensions.exec(filePath)) {
         alert("Invalid file format selected. Allowed formats are: pdf, doc, docx, txt, rtf");
+        coverLetterFileInput.value = "";
+      }
+      if (fileSize >= maxAllowedSize) {
+        alert("Invalid file size. Maximum file size 1MB.");
         coverLetterFileInput.value = "";
       }
     });


### PR DESCRIPTION
## Done

- Add file size check to cover-letter upload on job application form, the same way we check resumes.

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/careers/3776036
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Go to a job-details page and try to attach a file over 1mb in size, it should not allow this.

## Issue / Card

Fixes https://github.com/canonical-web-and-design/canonical.com/issues/476
