### PR TITLE
replace conjure up product with charmed kubeflow

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -183,10 +183,10 @@
       </div>
       <div class="col-2 u-equal-height" data-animation="u-animation--slide-from-bottom">
         <div class="p-card" style="background-color: #F7F7F7; border: none;">
-          <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/7697e127-products-generic-small.svg" alt="Kubernetes logo">
-          <h5 class="p-card__title"><a href="http://conjure-up.io/">Conjure-up&nbsp;&rsaquo;</a></h5>
+          <img class="p-card__thumbnail" src="https://assets.ubuntu.com/v1/7697e127-products-generic-small.svg" alt="">
+          <h5 class="p-card__title"><a href="https://charmed-kubeflow.io/">Charmed Kubeflow&nbsp;&rsaquo;</a></h5>
           <div class="p-card__content">
-            <p><small>Publish and deploy predefined complex software stacks for cloud, CAAS and bare-metal</small></p>
+            <p><small>AI and MLOps at any scale, on any cloud</small></p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Done

Replaced "Conjure Up" in the list of products with Charmed Kubeflow, as per the [copy doc request](https://docs.google.com/document/d/16ltouT0Yo-2RccGiE_irzrCloYaEleqFyU34fmT9OiQ/edit#)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- See that Charmed Kubeflow appears in the list of products, and that the link takes you to the correct site.

## Issue / Card

Fixes [#4842](https://github.com/canonical-web-and-design/web-squad/issues/4842)
