### PR TITLE
Remove "department" field from Greenhouse lookup

### DIFF
--- a/webapp/greenhouse.py
+++ b/webapp/greenhouse.py
@@ -10,7 +10,6 @@ def _get_metadata(job, name):
     metadata_map = {
         "management": 186225,
         "employment": 149021,
-        "department": 155450,
         "departments": 2739136,
         "skills": 675557,
         "description": 2739137,
@@ -125,7 +124,7 @@ class Greenhouse:
 
         for job in feed["jobs"]:
             # Filter out those without departments or offices
-            if _get_metadata(job, "department") and job["offices"]:
+            if _get_metadata(job, "departments") and job["offices"]:
                 vacancies.append(Vacancy(job))
 
         return vacancies


### PR DESCRIPTION
## Done

- Removed the "department" field from the Greenhouse query

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: https://canonical-com-495.demos.haus/careers/all
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- You should see vacancies, rather than a "There are no open vacancies right now" message