### PR TITLE
Update flask-base to the latest 1.0.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 bleach==3.3.1
-canonicalwebteam.flask-base==0.9.3
+canonicalwebteam.flask-base==1.0.2
 canonicalwebteam.http==1.0.3
 canonicalwebteam.image-template==1.3.1
 canonicalwebteam.templatefinder==1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-bleach==3.3.1
 canonicalwebteam.flask-base==1.0.2
 canonicalwebteam.http==1.0.3
 canonicalwebteam.image-template==1.3.1
 canonicalwebteam.templatefinder==1.0.0
+bleach==3.3.1
 markdown==3.3.6
 python-slugify==4.0.1
 vcrpy-unittest==0.1.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-canonicalwebteam.flask-base==1.0.2
+canonicalwebteam.flask-base==1.0.3
 canonicalwebteam.http==1.0.3
 canonicalwebteam.image-template==1.3.1
 canonicalwebteam.templatefinder==1.0.0


### PR DESCRIPTION
## Done
Update flask-base to the latest 1.0.2 to fix `ImportError: cannot import name 'soft_unicode' from 'markupsafe' (/home/ant/projects/canonical.com/.venv/lib/python3.8/site-packages/markupsafe/__init__.py)`

## QA
- Run `dotrun clean`
- Then `dotrun`
- Check the site works

