### PR TITLE
Create thank-you page

### DIFF
--- a/templates/careers/thank-you.html
+++ b/templates/careers/thank-you.html
@@ -1,0 +1,39 @@
+{% extends 'base_index.html' %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1nsZWk9osMxoMlSnSNIXZCFCV8-Ho4PeLXo0qD-vF_Bk/edit#{% endblock meta_copydoc %}
+
+{% block title %}Thank you{% endblock %}
+
+{% block content %}
+<section class="p-strip--suru-topped">
+  <div class="row">
+    <div class="col-7">
+      <h1>Congratulations! Your application has been accepted.</h1>
+      <p class="p-heading--3">Your application has gone straight to the functional hiring lead and will now be reviewed. Don’t forget to keep an eye out for an email detailing the next steps.</p>
+      <p>Have you visited our blog site? It’s packed full of insights from our very own people. Why not take a look!</p>
+      <p><a href="https://ubuntu.com/blog" class="p-button--positive">Visit our blog</a></p>
+      <p>You can read more about a  career at Canonical from the links below.</p>
+      <ul class="p-inline-list">
+        <li class="p-inline-list__item"><a href="/careers/lifestyle">Lifestyle&nbsp;&rsaquo;</a></li>
+        <li class="p-inline-list__item"><a href="/careers/ethics">Ethics&nbsp;&rsaquo;</a></li>
+        <li class="p-inline-list__item"><a href="/careers/travel">Travel&nbsp;&rsaquo;</a></li>
+        <li class="p-inline-list__item"><a href="/careers/progression">Progression&nbsp;&rsaquo;</a></li>
+        <li class="p-inline-list__item"><a href="/careers/diversity">Diversity&nbsp;&rsaquo;</a></li>
+      </ul>
+    </div>
+    <div class="col-5 u-vertically-center u-hide--medium u-hide--small u-align--center">
+      {{
+        image(
+          url="https://assets.ubuntu.com/v1/52d53696-picto-thankyou-midaubergine.svg",
+          alt="",
+          height="200",
+          width="200",
+          loading="auto",
+          hi_def=True
+        ) | safe
+      }}
+    </div>
+  </div>
+</section>
+
+{% endblock content %}

--- a/templates/careers/thank-you.html
+++ b/templates/careers/thank-you.html
@@ -4,6 +4,8 @@
 
 {% block title %}Thank you{% endblock %}
 
+{% block meta_description %}Thanks for taking the time to apply for our position. We appreciate your interest in Canonical.{% endblock %}
+
 {% block content %}
 <section class="p-strip--suru-topped">
   <div class="row">

--- a/templates/careers/thank-you.html
+++ b/templates/careers/thank-you.html
@@ -8,11 +8,11 @@
 <section class="p-strip--suru-topped">
   <div class="row">
     <div class="col-7">
-      <h1>Congratulations! Your application has been accepted.</h1>
+      <h1>Congratulations! Your application to our {{ job.title }} has been received.</h1>
       <p class="p-heading--3">Your application has gone straight to the functional hiring lead and will now be reviewed. Don’t forget to keep an eye out for an email detailing the next steps.</p>
       <p>Have you visited our blog site? It’s packed full of insights from our very own people. Why not take a look!</p>
       <p><a href="https://ubuntu.com/blog" class="p-button--positive">Visit our blog</a></p>
-      <p>You can read more about a  career at Canonical from the links below.</p>
+      <p>You can read more about a career at Canonical from the links below.</p>
       <ul class="p-inline-list">
         <li class="p-inline-list__item"><a href="/careers/lifestyle">Lifestyle&nbsp;&rsaquo;</a></li>
         <li class="p-inline-list__item"><a href="/careers/ethics">Ethics&nbsp;&rsaquo;</a></li>
@@ -24,7 +24,7 @@
     <div class="col-5 u-vertically-center u-hide--medium u-hide--small u-align--center">
       {{
         image(
-          url="https://assets.ubuntu.com/v1/52d53696-picto-thankyou-midaubergine.svg",
+          url="https://assets.ubuntu.com/v1/d1155ae3-tick-midaubergine.svg",
           alt="",
           height="200",
           width="200",

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -193,14 +193,8 @@ def job_details(job_id, job_title):
             flask.request.form, flask.request.files, job_id
         )
         if response.status_code == 200:
-            context["message"] = {
-                "type": "positive",
-                "title": "Success",
-                "text": (
-                    "Your application has been successfully submitted."
-                    " Thank you!"
-                ),
-            }
+            return flask.redirect("/careers/thank-you")
+
         else:
             context["message"] = {
                 "type": "negative",
@@ -249,14 +243,8 @@ def department_group(department_slug):
             flask.request.files,
         )
         if response.status_code == 200:
-            message = {
-                "type": "positive",
-                "title": "Success",
-                "text": (
-                    "Your application has been successfully submitted."
-                    " Thank you!"
-                ),
-            }
+            return flask.redirect("/careers/thank-you")
+
         else:
             message = {
                 "type": "negative",

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -193,7 +193,7 @@ def job_details(job_id, job_title):
             flask.request.form, flask.request.files, job_id
         )
         if response.status_code == 200:
-            return flask.redirect("/careers/thank-you")
+            return flask.render_template("/careers/thank-you.html", **context)
 
         else:
             context["message"] = {
@@ -243,7 +243,7 @@ def department_group(department_slug):
             flask.request.files,
         )
         if response.status_code == 200:
-            return flask.redirect("/careers/thank-you")
+            return flask.render_template("/careers/thank-you.html", **context)
 
         else:
             message = {


### PR DESCRIPTION
## Done

- Create a page on `/careers/thank-you` that returns to after application submission
## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- [Copy doc](https://docs.google.com/document/d/1nsZWk9osMxoMlSnSNIXZCFCV8-Ho4PeLXo0qD-vF_Bk/edit#heading=h.qk8g5uz8h4br)
- Go to `/careers/all`, submit an application and check it goes to a thank you page after submission (Also check the position is correct in the text "Congratulations! Your application to our `___` has been received")
## Issue / Card

Fixes [#505](https://github.com/canonical-web-and-design/canonical.com/issues/505)

## Screenshots

<img width="1423" alt="image" src="https://user-images.githubusercontent.com/57550290/160556504-274ba027-c3fc-4859-9526-70e8dd4dba56.png">