### PR TITLE
Add ISV partners page

### DIFF
--- a/templates/partners/isv-partners.html
+++ b/templates/partners/isv-partners.html
@@ -1,0 +1,51 @@
+{% extends 'base_index.html' %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/1qWWpFbwZykjAIt-Kf6iFCXPCnmmuKBbU5mzvILnO-q0/{% endblock %}
+
+{% block title %}ISV Embedding Programme{% endblock %}
+
+{% block meta_description %}Ubuntu is the most popular guest OS on both public and private clouds, thanks to its security, versatility and continually updated features.{% endblock %}
+
+{% block content %}
+
+<section class="p-strip--image is-dark">
+  <div class="p-strip--suru-background" style="padding-top: 3rem;">
+    <div class="u-fixed-width">
+      <h1>ISV Embedding Programme</h1>
+      <p>From containers through Ubuntu Server to MicroK8s, Canonical's portfolio is used by ISVs the world over to power SaaS, appliances and software solutions deployed within public clouds, data-centres, edge infrastructure and workstations. Our ISV Embedding programme offers the optimal technical, commercial and legal framework to enjoy cost-effective support across the lifecycle of your product.</p>
+      <a href="https://ubuntu.com/contact-us/form?product=generic-contact-us" class="p-button--positive">Become a partner</a>
+    </div>
+  </div>
+</section>
+
+<section class="p-strip is-deep">
+  <div class="row">
+    <h2>What&rsquo;s included</h2>
+    <p>There are many benefits for partners in the Canonical Public Cloud programme:</p>
+    <div class="col-6">
+      <ul class="p-list u-no-margin--bottom">
+        <li class="p-list__item is-ticked">Direct L3 engineering support for your engineering team</li>
+        <li class="p-list__item is-ticked">You support your end-customers</li>
+        <li class="p-list__item is-ticked">Familiar Ubuntu Advantage Essential, Standard and Advanced Support tiers</li>
+        <li class="p-list__item is-ticked">Security patches for up to 10 years</li>
+        <li class="p-list__item is-ticked">Modification and Redistribution rights </li>
+        <li class="p-list__item is-ticked">Be featured as a ISV Embedding Programme partner on the Canonical website, including the ability to use our trademarks and logos</li>
+      </ul>
+    </div>
+    
+    <div class="col-6">
+      <ul class="p-list u-no-margin--bottom"></ul>
+        <p class="p-heading--5">Custom Image Builds</p>
+        <li class="p-list__item is-ticked">Canonical created images tailored for your performance, platform, compliance & governance requirements</li>
+        <li class="p-list__item is-ticked">Design workshop</li>
+        <li class="p-list__item is-ticked">Ongoing image maintenance and delivery for easy CI pipeline ingestion</li>
+        <p class="p-heading--5" style="padding-top: 1rem;">Dedicated partner team</p>
+        <li class="p-list__item is-ticked">Named resources within Canonical for GTM, technical training and marketing</li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+{% include 'partial/_partners-footer.html' %}
+
+{% endblock %}

--- a/templates/partners/isv-partners.html
+++ b/templates/partners/isv-partners.html
@@ -13,7 +13,7 @@
     <div class="u-fixed-width">
       <h1>ISV Embedding Programme</h1>
       <p>From containers through Ubuntu Server to MicroK8s, Canonical's portfolio is used by ISVs the world over to power SaaS, appliances and software solutions deployed within public clouds, data-centres, edge infrastructure and workstations. Our ISV Embedding programme offers the optimal technical, commercial and legal framework to enjoy cost-effective support across the lifecycle of your product.</p>
-      <a href="https://ubuntu.com/contact-us/form?product=generic-contact-us" class="p-button--positive">Become a partner</a>
+      <a href="/partners/become-a-partner" class="p-button--positive">Become a partner</a>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

- Built ISV partners page as per [copy doc](https://docs.google.com/document/d/1qWWpFbwZykjAIt-Kf6iFCXPCnmmuKBbU5mzvILnO-q0/edit#heading=h.dzb0bs0676v)

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/partners/isv-partners
- Check copy against doc
- Test 'become a partner' button and footer links

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/4994
