### PR TITLE
update old certified link to point to ubuntu.com/certified

### DIFF
--- a/templates/partners/ihv-and-oem.html
+++ b/templates/partners/ihv-and-oem.html
@@ -132,7 +132,7 @@
       <p>
         The top 7 servers manufacturers in the world are all regularly engaged with Canonical on promoting their platforms as Ubuntu Certified.
       </p>
-      <a href="https://certification.ubuntu.com/certification">Learn more about Ubuntu certified hardware</a>
+      <a href="https://ubuntu.com/certified">Learn more about Ubuntu certified hardware&nbsp;&rsaquo;</a>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Done

update old certified link on /partners/ihv-and-oem to point to ubuntu.com/certified

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/partners/ihv-and-oem
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Check that the link "Learn more about Ubuntu certified hardware ›" takes you to ubuntu.com/certified, and not a 404

## Issue / Card

Fixes #509 
