### PR TITLE
Build page on /practice/documentation

### DIFF
--- a/templates/practice/documentation.html
+++ b/templates/practice/documentation.html
@@ -1,0 +1,187 @@
+{% extends 'base_index.html' %}
+
+{% block title %}Documentation at Canonical{% endblock %}
+
+{% block meta_copydoc %}https://docs.google.com/document/d/10tOsj5kKZRddQYYkb1PgxsES47Qic8XJc9xpRaYHd7s/edit#{% endblock %}
+
+{% block meta_description %}At Canonical, we aim to set a standard of excellence in technical documentation, by treating it as a professional discipline within our engineering practice.{% endblock %}
+
+{% block meta_image %}https://assets.ubuntu.com/v1/253da317-image-document-ubuntudocs.svg{% endblock %}
+
+{% block content %}
+<section class="p-strip--suru-topped is-bordered">
+  <div class="row">
+    <div class="col-7">
+      <h1>Documentation at Canonical</h1>
+      <p>At Canonical, we have embarked on a comprehensive, long-term project to transform documentation.</p>
+      <p>Our aim is to create and maintain documentation product and practice that will represent a standard of excellence. We want documentation to be the best it possibly can be.</p>
+    </div>
+    <div class="col-5 u-vertically-center u-align--center u-hide--small u-hide--medium">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/253da317-image-document-ubuntudocs.svg",
+        alt="",
+        width="214",
+        height="248",
+        hi_def=True,
+        loading="auto"
+        ) | safe
+      }}
+    </div>
+  </div>
+</section>
+<section class="p-strip is-deep">
+  <div class="row" id="documentation">
+    <aside class="col-3">
+      <div class="p-side-navigation is-sticky" id="drawer" style="top: 4.5rem">
+        <a href="#drawer" class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer">
+          Toggle table of contents
+        </a>
+        <div class="p-side-navigation__overlay js-drawer-toggle" aria-controls="drawer"></div>
+        <nav class="p-side-navigation__drawer" aria-label="Table of content">
+          <div class="p-side-navigation__drawer-header">
+            <button class="p-side-navigation__toggle--in-drawer js-drawer-toggle" aria-controls="drawer">
+              Toggle table of contents
+            </button>
+          </div>
+          <ul class="p-side-navigation__list">
+            <li class="p-side-navigation__item">
+              <a class="p-side-navigation__link" href="#documentation-introduction" aria-current="page">Introduction</a>
+            </li>
+            <li class="p-side-navigation__item">
+              <a class="p-side-navigation__link" href="#documentation-pillars">Four pillars</a>
+            </li>
+            <li class="p-side-navigation__item">
+              <a class="p-side-navigation__link" href="#documentation-careers">Careers</a>
+            </li>
+            <li class="p-side-navigation__item">
+              <a class="p-side-navigation__link" href="#documentation-milestones">Milestones</a>
+            </li>
+            <li class="p-side-navigation__item">
+              <a class="p-side-navigation__link" href="#documentation-readmore">Read more</a>
+            </li>
+          </ul>
+        </nav>
+      </div>
+    </aside>
+    <div class="col-9">
+      <div id="documentation-introduction" style="scroll-margin-top: 4.5rem;">
+        <h2>Introduction</h2>
+        <p>For too long in our industry, documentation has been allowed to be a secondary aspect of software development. Our approach will make documentation a core engineering concern, governed by systematic principles and requiring conscious practice, whose values inform the work not just of technical authors, but of all our engineering and product teams.</p>
+      </div>
+      <div class="p-top u-hide--large"><a href="#" class="p-top__link">Back to top</a></div>
+      <div id="documentation-pillars" style="scroll-margin-top: 4.5rem;">
+        <h2>Four pillars</h2>
+        <p>Our work identifies four pillars that support documentation success</p>
+        <div class="row">
+          <div class="col-4">
+            <h2 class="p-heading--4">Direction</h2>
+            <p>Where we want to go - the standards and quality we seek, so that documentation meets its users’ needs.</p>
+          </div>
+          <div class="col-4">
+            <h2 class="p-heading--4">Care</h2>
+            <p>Our attitude towards documentation, and a culture of documentation discipline that makes it a living concern.</p>
+          </div>
+        </div>
+        <div class="row">
+          <div class="col-4">
+            <h2 class="p-heading--4">Equipment</h2>
+            <p>The tools and machinery we adopt to write, maintain and publish documentation, that serve our work best.</p>
+          </div>
+          <div class="col-4">
+            <h2 class="p-heading--4">Execution</h2>
+            <p>How we do our work, so that we consistently produce better output with less effort and more satisfaction.</p>
+          </div>
+        </div>
+        <p><a href="https://ubuntu.com/blog/the-future-of-documentation-at-canonical">Read about our plan to put these pillars into place at Canonical&nbsp;&rsaquo;</a></p>
+      </div>
+      <div class="p-top u-hide--large"><a href="#" class="p-top__link">Back to top</a></div>
+      <div id="documentation-careers" style="scroll-margin-top: 4.5rem;">
+        <h2>Careers and opportunities</h2>
+        <p>There is a dedicated career progression in documentation at Canonical, including roles for Technical Author, Senior Technical Author and Documentation Manager.</p>
+        <p>Our plans include recruiting a cohort of technical authors to join several engineering teams, working on products across Canonical's portfolio.</p>
+        <p>Documentation is not a siloed activity. You’ll find engineers and product managers making real and substantial contributions, as part of their everyday work.</p>
+        <p>It’s a responsibility that is shared by everyone who works in engineering, product or support roles. We expect everyone to help manage that responsibility.</p>
+        <p>As an engineer, don’t be surprised to be asked about your work in - or thoughts on - documentation at a job interview. As an engineering manager or director, expect to sit an interview dedicated to documentation practice.</p>
+        <div class="p-notification--information">
+          <div class="p-notification__content">
+            <p class="p-notification__message">Don’t hesitate to mention documentation-related work that you're proud of in your application or your interview - it will be valued.</p>
+          </div>
+        </div>
+        <div class="p-card p-strip--light">
+          <h3 class="p-heading--4">Interested in exploring a career at canonical?</h3>
+          <p class="p-card__content"><a>Find out more at Canonical careers&nbsp;&rsaquo;</a></p>
+        </div>
+      </div>
+      <div class="p-top u-hide--large"><a href="#" class="p-top__link">Back to top</a></div>
+      <div id="documentation-milestones" style="scroll-margin-top: 4.5rem;">
+        <h2>Recent milestones in our work</h2>
+        <p>By its nature, documentation work is always in progress and never finished. Delivery is incremental and continuous, which means it’s not always so easy to see how far we have travelled.</p>
+        <table aria-label="Vanilla framework table example">
+          <tbody>
+            <tr>
+              <th>January 2022</th>
+              <td><a href="https://linuxcontainers.org/lxd/docs/master/">LXD</a> improved search, better usability</td>
+            </tr>
+            <tr>
+              <th>December 2021</th>
+              <td>
+                <ul class="p-list--divided u-no-margin--bottom">
+                  <li class="p-list__item"><a href="https://ubuntu.com/core/docs">Ubuntu Core</a> Diátaxis restructuring</li>
+                  <li class="p-list__item"><a href="https://charmed-kubeflow.io/docs">Charmed Kubeflow</a> Diátaxis restructuring</li>
+                  <li class="p-list__item"><a href="https://docs.openstack.org/charm-guide/latest/">Charmed OpenStack guides</a> Diátaxis restructuring</li>
+                </ul>
+              </td>
+            </tr>
+            <tr>
+              <th>November 2021</th>
+              <td>
+                <ul class="p-list--divided u-no-margin--bottom">
+                  <li class="p-list__item"><a href="https://anbox-cloud.io/docs">Anbox Cloud</a> Diátaxis restructuring</li>
+                  <li class="p-list__item"><a href="https://microk8s.io/docs">MicroK8s</a> Diátaxis restructuring</li>
+                </ul>
+              </td>
+            </tr>
+            <tr>
+              <th>October 2021</th>
+              <td><a href="https://juju.is/docs/olm">Juju OLM</a> Diátaxis restructuring</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <div class="p-top u-hide--large"><a href="#" class="p-top__link">Back to top</a></div>
+      <div id="documentation-readmore">
+        <div class="row p-divider">
+          <div class="col-4 p-divider__block">
+            <h4>Diátaxis Framework</h4>
+            <p>Read more about the Diátaxis authoring framework</p>
+            <p><a href="https://diataxis.fr/">Read more&nbsp;&rsaquo;</a></p>
+          </div>
+          <div class="col-4 p-divider__block">
+            <h4>Documentation articles</h4>
+            <p>Read our documentation articles on the Ubuntu blog</p>
+            <p><a href="https://ubuntu.com/blog/tag/documentation">View blog&nbsp;&rsaquo;</a></p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+<script>
+  var links = [].slice.call(document.querySelectorAll('.p-side-navigation li > a'));
+  var currentPath = window.location.pathname;
+
+  links.forEach(function (link) {
+    link.addEventListener('click', function () {
+      links.forEach(function (link) {
+        link.removeAttribute('aria-current');
+      });
+      this.setAttribute('aria-current', 'page');
+      this.blur();
+    });
+
+    if (link.getAttribute('href') === currentPath) {
+      link.setAttribute('aria-current', 'page');
+    }
+  });
+</script>
+{% endblock %}


### PR DESCRIPTION
## Done

Build page on /practice/documentation

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/
- Run through the following [QA steps](https://canonical-web-and-design.github.io/practices/workflow/qa-steps.html)
- Compare page with [copy doc](https://docs.google.com/document/d/10tOsj5kKZRddQYYkb1PgxsES47Qic8XJc9xpRaYHd7s/edit#)
## Issue / Card

Fixes [#4995](https://github.com/canonical-web-and-design/web-squad/issues/4995)

## Screenshots
<img width="1440" alt="Documentation at Canonical | Canonical ()" src="https://user-images.githubusercontent.com/57550290/161009889-9290e3bb-5fbd-43fa-8afb-4f6c4f40f42f.png">

