### PR TITLE
Fix side nav z-index

### DIFF
--- a/templates/practice/documentation.html
+++ b/templates/practice/documentation.html
@@ -32,7 +32,7 @@
 <section class="p-strip is-deep">
   <div class="row" id="documentation">
     <aside class="col-3">
-      <div class="p-side-navigation--raw-html is-sticky" id="drawer" style="top: 4.5rem; z-index: 39;">
+      <div class="p-side-navigation--raw-html is-sticky" id="drawer" style="top: 4.5rem; z-index: 37;">
         <button class="p-side-navigation__toggle js-drawer-toggle" aria-controls="drawer">
           Toggle side navigation
         </button>


### PR DESCRIPTION
## Done

- Fix side nav appearing above dropdown menu on documentation page

## QA

- Please QA all the navigations on this page - top nav, side navigation, toggle side navigation on mobile.
- Demo at Demo starting at https://canonical-com-525.demos.haus/practice/documentation

## Issue / Card

Fixes #526 

## Screenshots

[if relevant, include a screenshot]
