### PR TITLE
Refresh /partners/chanell-and-reseller for canonical-v3

### DIFF
--- a/static/sass/_pattern_cards.scss
+++ b/static/sass/_pattern_cards.scss
@@ -15,6 +15,22 @@
     }
   }
 
+  .p-card.has-cta {
+    @extend %vf-card;
+
+    display: flex;
+    flex-direction: column;
+
+    .p-card__content {
+      flex-grow: 1;
+      padding-bottom: $spv--medium;
+    }
+
+    .p-card__cta {
+      margin-bottom: 0;
+    }
+  }
+
   .p-card--highlighted.has-cta {
     background-color: $color-light;
     display: flex;
@@ -45,8 +61,9 @@
   .p-card--strip-thin {
     @extend %vf-card;
 
-    background-color: $color-light;
-    border-top: 4px solid $color-brand;
+    border-color: $color-border-accent-alt $color-mid-light $color-mid-light $color-mid-light;
+    border-style: solid;
+    border-width: 3px 1px 1px 1px;
   }
 
   .p-card--game {

--- a/templates/partial/_partners-footer.html
+++ b/templates/partial/_partners-footer.html
@@ -1,4 +1,4 @@
-<section class="p-strip has-accent-border--top-left">
+<section class="p-strip {% if border == "left" or None %}  has-accent-border--top-left {% elif border == "right" %} has-accent-border--top-right {% endif %}">
   <div class="row">
     <div class="col-6">
       <div class="p-media-object">

--- a/templates/partners/channel-and-reseller.html
+++ b/templates/partners/channel-and-reseller.html
@@ -7,37 +7,46 @@
 {% block meta_description %}Canonical works with channel and reseller partners around the world to ensure that Canonical offerings are available for their customers.{% endblock %}
 
 {% block content %}
-<section class="p-strip--image is-dark">
-  <div class="p-strip--suru-top">
-    <div class="row">
-      <div class="col-8">
-        <h1>Channel&sol;Reseller Programme</h1>
-        <p>Canonical works with channel and reseller partners around the world to ensure that Canonical offerings are available for their customers. Additionally these partners can both resell services and value-added offerings around our technology enabling them to grow their business.</p>
-        <p>Canonical is an industry leader in OpenStack private clouds, the reference platform for all major public clouds, and the open source software operating system that runs from the desktop and all internet connected things. Our success helps our partners build a business around our technology.</p>
-        <a href="https://partner-portal.canonical.com" class="p-button"><span>Login to the partner portal</span></a>
-      </div>
-      <div class="col-4 u-hide--small u-hide--medium u-align--center u-vertically-center">
-        <img src="https://assets.ubuntu.com/v1/80472358-Canonical-reseller-icon.svg" alt="">
-      </div>
+<section class="p-strip u-no-padding--bottom">
+  <div class="row">
+    <div class="col-8">
+      <h1>Channel&sol;Reseller Programme</h1>
+      <p>Canonical works with channel and reseller partners around the world to ensure that Canonical offerings are available for their customers. Additionally these partners can both resell services and value-added offerings around our technology enabling them to grow their business.</p>
+      <p>Canonical is an industry leader in OpenStack private clouds, the reference platform for all major public clouds, and the open source software operating system that runs from the desktop and all internet connected things. Our success helps our partners build a business around our technology.</p>
+      <a href="https://canonical.partnerprm.com/" class="p-button--positive"><span>Login to the partner portal</span></a>
+    </div>
+    <div class="col-4 u-hide--small u-hide--medium u-align--center u-vertically-center">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/44842949-canonical-reseller-icon-grey.png",
+        alt="",
+        width="859",
+        height="824",
+        hi_def=True,
+        loading="auto"
+        ) | safe
+      }}
     </div>
   </div>
 </section>
 
-<section class="p-strip--light is-shallow" style="margin-top: -1px;">
+<section class="p-strip u-no-padding--top">
+  <div class="u-fixed-width">
+    <hr class="p-separator">
+  </div>
   <div class="row">
-    <div class="col-8 col-medium-4">
-      <p>Interested in becoming an Ubuntu partner? Talk to us today to learn more about our programmes.</p>
+    <div class="col-6">
+      <p class="p-heading--tag">Partners</p>
+      <p class="p-heading--4">Interested in becoming an Ubuntu partner? Talk to us <br> today to learn more about our programmes.</p>
+      <p><a href="/partners/become-a-partner" class="p-button--positive">Become a partner</a></p>
     </div>
-    <div class="col-4 col-medium-2">
-      <a href="/partners/become-a-partner" class="p-button--positive">Become a partner</a>
-    </div>
+  </div>
   </div>
 </section>
 
 {% if partners %}
-<section class="p-strip is-deep">
+<section class="p-strip has-accent-border--top-left is-deep">
   <div class="u-fixed-width p-logo-section">
-    <h4 class="p-logo-section__title p-muted-heading u-no-max-width u-align--center">Meet some of our channel/reseller partners</h4>
+    <h4 class="p-logo-section__title p-muted-heading u-no-max-width u-align--center">Meet some of our channel partners</h4>
     <ul class="p-logo-section__items u-no-margin--bottom">
       {% for partner in partners %}
       <li class="p-logo-section__item">
@@ -50,53 +59,63 @@
 </section>
 {% endif %}
 
-<section class="p-strip--light is-deep">
+<section class="p-strip--suru-light-grey has-accent-border--top-right is-deep">
   <div class="u-fixed-width u-sv3">
-    <h2>What does Canonical’s channel partner programme offer?</h2>
+    <h2>What does Canonical's channel partner programme offer?</h2>
   </div>
   <div class="row">
-    <div class="col-4 p-card--highlighted">
+    <div class="col-4 p-card--strip-thin">
       <h3 class="p-card__title p-heading--4">Rich portfolio of products</h3>
       <p>Resell the full range of Canonical&rsquo;s portfolio of private and public cloud products: Openstack, Kubernetes, IoT, support, security and compliance for Ubuntu.</p>
     </div>
-    <div class="col-4 p-card--highlighted">
+    <div class="col-4 p-card--strip-thin">
       <h3 class="p-card__title p-heading--4">Sales enablement</h3>
       <p>Canonical can help train your field sales and presales teams and provide you with sales collateral and permission to use the Canonical and Ubuntu trademarks in your own materials.</p>
     </div>
-    <div class="col-4 p-card--highlighted">
+    <div class="col-4 p-card--strip-thin">
       <h3 class="p-card__title p-heading--4">Access to Canonical partner portal</h3>
       <p>We host a partner portal with product and solutions collaterals, agreed pricing, incentives and a deal registration system.</p>
     </div>
-    <div class="col-4 p-card--highlighted">
+    <div class="col-4 p-card--strip-thin">
       <h3 class="p-card__title p-heading--4">Training and certification</h3>
-      <p>Gain access to technology that is the foundation for digital transformation and expand your business through marketing support and alignment with a trusted brand</p>
+      <p>Gain access to technology that is the foundation for digital transformation and expand your business through marketing support and alignment with a trusted brand.</p>
     </div>
-    <div class="col-4 p-card--highlighted">
+    <div class="col-4 p-card--strip-thin">
       <h3 class="p-card__title p-heading--4">Technical enablement</h3>
       <p>We provide in depth technical training for your customer engineering teams with access to technical resources for your labs and customer engagements.</p>
     </div>
-    <div class="col-4 p-card--highlighted">
+    <div class="col-4 p-card--strip-thin">
       <h3 class="p-card__title p-heading--4">Go to market with Canonical</h3>
       <p>Working with our dedicated partner team, get new joint marketing opportunities and lead generation.</p>
     </div>
   </div>
 </section>
 
-<section class="p-strip is-deep">
-  <div class="u-fixed-width">
-  </div>
+<section class="p-strip has-accent-border--top-left is-deep">
   <div class="row">
+    <div class="col-6 u-vertically-center u-hide--small u-hide--medium">
+      {{ image (
+        url="https://assets.ubuntu.com/v1/a544a3b0-partner_portal_sml.png",
+        alt="",
+        width="413",
+        height="256",
+        hi_def=True,
+        loading="lazy"
+        ) | safe
+      }}
+    </div>
     <div class="col-6">
+      <p class="p-heading--tag">Partners</p>
       <h2>Co-sell with Canonical through the partner portal</h2>
       <p>Open source technology is growing in demand. We want you to benefit from this unique opportunity, and take advantage of the investment Canonical is making in its partner community. We are committed to giving you the tools and programs to succeed, from discounts and financial incentives to sales and technical support teams.</p>
-      <p><a href="https://partner-portal.canonical.com">Login to the partner portal</a></p>
-    </div>
-    <div class="col-5 col-start-large-8 u-vertically-center u-hide--small u-hide--medium">
-      <img src="https://assets.ubuntu.com/v1/a544a3b0-partner_portal_sml.png" alt="Photo of laptop running Ubuntu" width="413" height="256">
+      <p><a href="https://canonical.partnerprm.com/vert/DEfault/IT_login">Login to the partner portal&nbsp;&rsaquo;</a></p>
     </div>
   </div>
 </section>
 
-{% include 'partial/_partners-footer.html' %}
+{% with border="right" %}
+  {% include 'partial/_partners-footer.html' %}
+{% endwith %}
+
 
 {% endblock %}


### PR DESCRIPTION
## Done

- Refresh /partners/chanell-and-reseller for canonical-v3, see [doc](https://docs.google.com/document/d/1rn2f4wL8wxnILlnmfchkNQV2RzsYUMcRaCfP-d6V_5Q/edit), [design](https://app.zeplin.io/project/624ed20e0af92866116ea26d/screen/6254185f9c8cce6c8b79ade1)
- Add `p-card.has-cta`, updates `p-card--strip-thin`
**note: I used this screenshot for the hero strip iamge, not sure if we need a better one made**
![canonical-reseller-icon-grey](https://user-images.githubusercontent.com/58276363/165293954-d3369070-cfe0-432f-9c9b-96b96beb11f9.png)

## QA

- Compare agianst design

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/5155
