### PR TITLE
Add isv partners page to partners subnav

### DIFF
--- a/templates/partners/_secondary-navigation.html
+++ b/templates/partners/_secondary-navigation.html
@@ -19,6 +19,9 @@
           <a class="breadcrumbs__link {% if request.path|get_secondary_nav_path == 'ihv-and-oem' %}p-link--active{% else %}p-link--soft{% endif %}" href="/partners/ihv-and-oem">IHV/OEM</a>
         </li>
         <li class="breadcrumbs__item">
+          <a class="breadcrumbs__link {% if request.path|get_secondary_nav_path == 'isv-partners' %}p-link--active{% else %}p-link--soft{% endif %}" href="/partners/isv-partners">ISV</a>
+        </li>
+        <li class="breadcrumbs__item">
           <a class="breadcrumbs__link {% if request.path|get_secondary_nav_path == 'gsi' %}p-link--active{% else %}p-link--soft{% endif %}" href="/partners/gsi">Global System Integrators</a>
         </li>
         <li class="breadcrumbs__item">

--- a/templates/partners/isv-partners.html
+++ b/templates/partners/isv-partners.html
@@ -31,6 +31,7 @@
         <li class="p-list__item is-ticked">Security patches for up to 10 years</li>
         <li class="p-list__item is-ticked">Trademark, Modification and Redistribution rights </li>
         <li class="p-list__item is-ticked">Be featured as a ISV Embedding Programme partner on the Canonical website, including the ability to use our trademarks and logos</li>
+        <li class="p-list__item is-ticked">Joint marketing: blogs, webinars and PR</li>
       </ul>
     </div>
     


### PR DESCRIPTION
## Done

- Added ISV partners page to partners subnav as per [copy doc](https://docs.google.com/document/d/1qWWpFbwZykjAIt-Kf6iFCXPCnmmuKBbU5mzvILnO-q0/edit#heading=h.dzb0bs0676v)
- Added missing bullet point to sync page with doc 

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: https://canonical-com-529.demos.haus/partners/isv-partners
- See that page has been added to subnav and that link works as expected
- See that copy was updated to reflect the doc

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/5181
