### PR TITLE
Refresh /careers for canonical-v3

### DIFF
--- a/static/sass/_pattern_cards.scss
+++ b/static/sass/_pattern_cards.scss
@@ -58,12 +58,30 @@
     }
   }
 
-  .p-card--strip-thin {
+  .p-card--blue-strip {
     @extend %vf-card;
 
     border-color: $color-border-accent-alt $color-mid-light $color-mid-light $color-mid-light;
     border-style: solid;
     border-width: 3px 1px 1px 1px;
+
+    &.no-border {
+      border-width: 3px 0 0 0;
+      padding: 0.5rem 0 2rem 0;
+    }
+  }
+
+  .p-card--orange-strip {
+    @extend %vf-card;
+
+    border-color: $color-border-accent $color-mid-light $color-mid-light $color-mid-light;
+    border-style: solid;
+    border-width: 3px 1px 1px 1px;
+
+    &.no-border {
+      border-width: 3px 0 0 0;
+      padding: 0.5rem 0 2rem 0;
+    }
   }
 
   .p-card--game {

--- a/static/sass/_pattern_lists.scss
+++ b/static/sass/_pattern_lists.scss
@@ -40,10 +40,4 @@
       padding: 0;
     }
   }
-
-  .has-accent-alt-border {
-    border-top: 3px solid $color-border-accent-alt;
-    padding: 4px 0 0 0;
-  }
-
 }

--- a/static/sass/_utilities_accent-border.scss
+++ b/static/sass/_utilities_accent-border.scss
@@ -1,0 +1,11 @@
+@mixin canonical-u-accent-border {
+  .has-accent-border {
+    border-top: 3px solid $color-border-accent;
+    padding: 4px 0 0 0;
+  }
+  
+  .has-accent-alt-border {
+    border-top: 3px solid $color-border-accent-alt;
+    padding: 4px 0 0 0;
+  }
+}

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -26,8 +26,10 @@ $p-small-lh-diff: map-get($line-heights, default-text) -
 @import "pattern_navigation";
 @import "pattern_strips";
 @import "pattern_tabs";
+@import "utilities_accent-border";
 
 @include blog-p-card;
+@include canonical-u-accent-border;
 @include canonical-u-animations;
 @include canonical-p-buttons;
 @include canonical-p-card;

--- a/templates/careers/index.html
+++ b/templates/careers/index.html
@@ -12,7 +12,7 @@
     <div class="row">
       <div class="col-6">
         <h1>Careers</h1>
-        <p>Life at Canonical is anything but corporate as a company that exists to support Ubuntu, one of today's most important open source projects, we are changing the world daily. It's a collaborative environment, but one in which every member of the team takes personal responsibility for everything they produce.</p>
+        <p>Life at Canonical is anything but corporate. As a company that exists to support Ubuntu, one of today's most important open source projects, we are changing the world daily. It's a collaborative environment, but one in which every member of the team takes personal responsibility for everything they produce.</p>
         <p><a href="/careers/start" class="p-button--positive">Explore a career at Canonical</a></p>
       </div>
     </div>
@@ -20,12 +20,12 @@
   
 <section class="p-strip is-shallow u-extra-space">
   <div class="row u-equal-height">
-    <div class="col-6 p-card--orange-strip no-border">
+    <div class="col-6 has-accent-border u-sv3">
       <h2>Engineering</h2>
       <p>Open source is transforming the entire technology stack. This is your chance to be right at the centre of that revolution, to shape the platforms and tools that millions use to invent our global technology future. From bare metal to cloud to high-performance computing, from AI and big data to the web and connected devices, open-source is the critical ingredient for success.</p>
       <a href="/careers/engineering">Learn more&nbsp;&rsaquo;</a>
     </div>
-    <div class="col-6 p-card--orange-strip no-border">
+    <div class="col-6 has-accent-border u-sv3">
       <h2>TechOps</h2>
       <p>We develop, test, ship and operate the systems that drive Canonical and underpin Ubuntu. We believe in a strong customer service ethic and operations through code. The robots we are constructing to run the data centre need to be backed by humans that care about the needs of our users and customers. Our role ranges from IT and managed services to developing commercial systems.</p>
       <a href="/careers/tech-ops">Learn more&nbsp;&rsaquo;</a>
@@ -33,55 +33,55 @@
   </div>
 
   <div class="row u-equal-height">
-    <div class="col-4 p-card--blue-strip no-border">
-      <h4 class="p-card--blue-strip__title">Finance</h4>
-      <p class="p-card--blue-strip__content">Finance at Canonical isn't just about numbers. It's about connecting with people across the business, helping them to understand the value they bring, as well as promoting the commercial focus that will grow our brand.</p>
+    <div class="col-4 has-accent-alt-border u-sv3">
+      <h2 class="p-heading--4">Finance</h2>
+      <p>Finance at Canonical isn't just about numbers. It's about connecting with people across the business, helping them to understand the value they bring, as well as promoting the commercial focus that will grow our brand.</p>
       <a href="/careers/finance">Learn more&nbsp;&rsaquo;</a>
     </div>
-    <div class="col-4 p-card--blue-strip no-border">
-      <h4 class="p-card--blue-strip__title">Web &amp; design</h4>
-      <p class="p-card--blue-strip__content">The design team at Canonical crafts and builds the user-experience for sophisticated technical specialists across a wide range of industries and geographies. We design and build websites, complex web apps and support Ubuntu itself.</p>
+    <div class="col-4 has-accent-alt-border u-sv3">
+      <h2 class="p-heading--4">Web &amp; design</h2>
+      <p>The design team at Canonical crafts and builds the user-experience for sophisticated technical specialists across a wide range of industries and geographies. We design and build websites, complex web apps and support Ubuntu itself.</p>
       <a href="/careers/web-and-design">Learn more&nbsp;&rsaquo;</a>
     </div>
-    <div class="col-4 p-card--blue-strip no-border">
-      <h4 class="p-card--blue-strip__title">Marketing</h4>
-      <p class="p-card--blue-strip__content">We deliver the right technology message to a highly competent audience, at exactly the right moment. Success depends on having good instincts for tech trends and topics and a natural inclination to leadership.</p>
+    <div class="col-4 has-accent-alt-border u-sv3">
+      <h2 class="p-heading--4">Marketing</h2>
+      <p>We deliver the right technology message to a highly competent audience, at exactly the right moment. Success depends on having good instincts for tech trends and topics and a natural inclination to leadership.</p>
       <a href="/careers/marketing">Learn more&nbsp;&rsaquo;</a>
     </div>
   </div>
 
   <div class="row u-equal-height">
-    <div class="col-4 p-card--blue-strip no-border">
-      <h4 class="p-card--blue-strip__title">Project Management</h4>
-      <p class="p-card--blue-strip__content">Project Managers at Canonical are engaged during all phases of the project, from pre-sales support to delivery to the handoff of complete projects to support or managed services. Project managers create, manage, and maintain project-specific schedules ensuring projects are delivered within time/resources/scope expectations.</p>
+    <div class="col-4 has-accent-alt-border u-sv3">
+      <h2 class="p-heading--4">Project Management</h2>
+      <p>Project Managers at Canonical are engaged during all phases of the project, from pre-sales support to delivery to the handoff of complete projects to support or managed services. Project managers create, manage, and maintain project-specific schedules ensuring projects are delivered within time/resources/scope expectations.</p>
       <a href="/careers/project-management">Learn more&nbsp;&rsaquo;</a>
     </div>
-    <div class="col-4 p-card--blue-strip no-border">
-      <h4 class="p-card--blue-strip__title">Commercial-ops</h4>
-      <p class="p-card--blue-strip__content">Excellence in operations enables Canonical to scale efficiently. Our core operations - from IT to commercial operations or logistics - is central to the idea that we can be an effective global distributed company serving advanced customers in every geography. We celebrate relentless improvement. We look for people who are passionate about tools and efficiency.</p>
+    <div class="col-4 has-accent-alt-border u-sv3">
+      <h2 class="p-heading--4">Commercial-ops</h2>
+      <p>Excellence in operations enables Canonical to scale efficiently. Our core operations - from IT to commercial operations or logistics - is central to the idea that we can be an effective global distributed company serving advanced customers in every geography. We celebrate relentless improvement. We look for people who are passionate about tools and efficiency.</p>
       <a href="/careers/commercial-ops">Learn more&nbsp;&rsaquo;</a>
     </div>
-    <div class="col-4 p-card--blue-strip no-border">
-      <h4 class="p-card--blue-strip__title">Sales</h4>
-      <p class="p-card--blue-strip__content">You build long term relationships, and you always promote the approach that is in the customers best interests, regardless of short term consequences. You are interested in the state of the art, you love to represent a company that knows how to transform customer operations, and you are keen to see new customers benefit from that knowledge.</p>
+    <div class="col-4 has-accent-alt-border u-sv3">
+      <h2 class="p-heading--4">Sales</h2>
+      <p>You build long term relationships, and you always promote the approach that is in the customers best interests, regardless of short term consequences. You are interested in the state of the art, you love to represent a company that knows how to transform customer operations, and you are keen to see new customers benefit from that knowledge.</p>
       <a href="/careers/sales">Learn more&nbsp;&rsaquo;</a>
     </div>
   </div>
 
   <div class="row u-equal-height u-sv3">
-    <div class="col-4 p-card--blue-strip no-border">
-      <h4 class="p-card--blue-strip__title">Legal</h4>
-      <p class="p-card--blue-strip__content">Canonical works at the forefront of global digital trends and the legal, licensing and regulatory frameworks that support them. We are a tight-knit team of professionals that enjoy playing a part in the rapid change.</p>
+    <div class="col-4 has-accent-alt-border u-sv3">
+      <h2 class="p-heading--4">Legal</h2>
+      <p>Canonical works at the forefront of global digital trends and the legal, licensing and regulatory frameworks that support them. We are a tight-knit team of professionals that enjoy playing a part in the rapid change.</p>
       <a href="/careers/legal">Learn more&nbsp;&rsaquo;</a>
     </div>
-    <div class="col-4 p-card--blue-strip no-border">
-      <h4 class="p-card--blue-strip__title">Administration</h4>
-      <p class="p-card--blue-strip__content">Canonical is an entirely new kind of organisation - almost entirely distributed, we are a global team of technology leaders who collaborate online to enable the transformation of enterprise software to open source.</p>
+    <div class="col-4 has-accent-alt-border u-sv3">
+      <h2 class="p-heading--4">Administration</h2>
+      <p>Canonical is an entirely new kind of organisation - almost entirely distributed, we are a global team of technology leaders who collaborate online to enable the transformation of enterprise software to open source.</p>
       <a href="/careers/admin">Learn more&nbsp;&rsaquo;</a>
     </div>
-    <div class="col-4 p-card--blue-strip no-border">
-      <h4 class="p-card--blue-strip__title">Human resources</h4>
-      <p class="p-card--blue-strip__content">Canonical provides a unique window into the world of 21st-century digital business. We work with smart individuals from a wide range of professional backgrounds in more than 40 countries worldwide</p>
+    <div class="col-4 has-accent-alt-border u-sv3">
+      <h2 class="p-heading--4">Human resources</h2>
+      <p>Canonical provides a unique window into the world of 21st-century digital business. We work with smart individuals from a wide range of professional backgrounds in more than 40 countries worldwide</p>
       <a href="/careers/hr">Learn more&nbsp;&rsaquo;</a>
     </div>
   </div>

--- a/templates/careers/index.html
+++ b/templates/careers/index.html
@@ -7,149 +7,102 @@
 {% block meta_description %}Canonical publishes Ubuntu, provides commercial services and solutions for Ubuntu, and works with hardware manufacturers, software vendors and public clouds to certify Ubuntu.{% endblock %}
 
 {% block content %}
-  <section class="p-strip--image is-dark is-deep u-no-padding--top u-no-padding--bottom u-extra-space">
-    <div class="p-strip--suru-background">
-      <div class="row">
-        <div class="col-6">
-          <h1>Careers</h1>
-        </div>
-      </div>
-    </div>
-  </section>
-  <section class="p-strip is-shallow u-extra-space">
+
+<section class="p-strip--suru-light-grey" style="margin-bottom: 2.5rem;">
     <div class="row">
-      <div class="col-12">
-        <p class="p-heading--2">Your career with Canonical</p>
-      </div>
-    </div>
-    <div class="row u-sv3">
-      <div class="col-8">
-        <p>Life at Canonical is anything but corporate. As a company that exists to support Ubuntu, one of today’s most important open source projects, we are changing the world on a daily basis. It’s a collaborative environment, but one in which every member of the team takes personal responsibility for everything they produce.</p>
-      </div>
-      <div class="col-4 u-vertically-center">
+      <div class="col-6">
+        <h1>Careers</h1>
+        <p>Life at Canonical is anything but corporate as a company that exists to support Ubuntu, one of today's most important open source projects, we are changing the world daily. It's a collaborative environment, but one in which every member of the team takes personal responsibility for everything they produce.</p>
         <p><a href="/careers/start" class="p-button--positive">Explore a career at Canonical</a></p>
       </div>
     </div>
-    <div class="row u-equal-height">
-      <div class="col-6 p-card--strip-thin">
-        <h2 class="p-card--strip-thin__title">Engineering</h2>
-        <p class="p-card--strip-thin__content">Open source is transforming the entire stack. This is your chance to be right at the center of that revolution, to shape the platforms and tools that millions use to invent our global technology future. From bare metal to cloud to high performance computing, from AI and big data to the web and connected devices, open source is the key ingredient for success.</p>
-        <a href="/careers/engineering">More&nbsp;&rsaquo;</a>
-      </div>
-      <div class="col-6 p-card--strip-thin">
-        <h2 class="p-card--strip-thin__title">TechOps</h2>
-        <p class="p-card--strip-thin__content">Getting it done right is the best feeling in the world. Whether it’s running complex technical infrastructure or challenging projects, your consistent focus on data, organisation and teamwork means you’re a force for good in the battle against entropy. Time zones are easy and technical customers are your favourite.</p>
-        <a href="/careers/techops">More&nbsp;&rsaquo;</a>
-      </div>
+</section>
+  
+<section class="p-strip is-shallow u-extra-space">
+  <div class="row u-equal-height">
+    <div class="col-6 p-card--orange-strip no-border">
+      <h2>Engineering</h2>
+      <p>Open source is transforming the entire technology stack. This is your chance to be right at the centre of that revolution, to shape the platforms and tools that millions use to invent our global technology future. From bare metal to cloud to high-performance computing, from AI and big data to the web and connected devices, open-source is the critical ingredient for success.</p>
+      <a href="/careers/engineering">Learn more&nbsp;&rsaquo;</a>
     </div>
+    <div class="col-6 p-card--orange-strip no-border">
+      <h2>TechOps</h2>
+      <p>We develop, test, ship and operate the systems that drive Canonical and underpin Ubuntu. We believe in a strong customer service ethic and operations through code. The robots we are constructing to run the data centre need to be backed by humans that care about the needs of our users and customers. Our role ranges from IT and managed services to developing commercial systems.</p>
+      <a href="/careers/tech-ops">Learn more&nbsp;&rsaquo;</a>
+    </div>
+  </div>
 
+  <div class="row u-equal-height">
+    <div class="col-4 p-card--blue-strip no-border">
+      <h4 class="p-card--blue-strip__title">Finance</h4>
+      <p class="p-card--blue-strip__content">Finance at Canonical isn't just about numbers. It's about connecting with people across the business, helping them to understand the value they bring, as well as promoting the commercial focus that will grow our brand.</p>
+      <a href="/careers/finance">Learn more&nbsp;&rsaquo;</a>
+    </div>
+    <div class="col-4 p-card--blue-strip no-border">
+      <h4 class="p-card--blue-strip__title">Web &amp; design</h4>
+      <p class="p-card--blue-strip__content">The design team at Canonical crafts and builds the user-experience for sophisticated technical specialists across a wide range of industries and geographies. We design and build websites, complex web apps and support Ubuntu itself.</p>
+      <a href="/careers/web-and-design">Learn more&nbsp;&rsaquo;</a>
+    </div>
+    <div class="col-4 p-card--blue-strip no-border">
+      <h4 class="p-card--blue-strip__title">Marketing</h4>
+      <p class="p-card--blue-strip__content">We deliver the right technology message to a highly competent audience, at exactly the right moment. Success depends on having good instincts for tech trends and topics and a natural inclination to leadership.</p>
+      <a href="/careers/marketing">Learn more&nbsp;&rsaquo;</a>
+    </div>
+  </div>
 
-    <div class="row u-equal-height">
-      <div class="col-4 p-card--strip-thin">
-        <h4 class="p-card--strip-thin__title">Finance</h4>
-        <p class="p-card--strip-thin__content">Finance at Canonical isn’t just about numbers. It’s about connecting with people across the business, helping them to understand the value they bring, as well as promoting the commercial focus that will grow our brand.</p>
-        <a href="/careers/finance">More&nbsp;&rsaquo;</a>
-      </div>
-      <div class="col-4 p-card--strip-thin">
-        <h4 class="p-card--strip-thin__title">Web &amp; design</h4>
-        <p class="p-card--strip-thin__content">The design team at Canonical crafts and builds the user-experience for sophisticated technical specialists across a wide range of industries and geographies. We design and build websites, complex web apps and support Ubuntu itself.</p>
-        <a href="/careers/web-and-design">More&nbsp;&rsaquo;</a>
-      </div>
-      <div class="col-4 p-card--strip-thin">
-        <h4 class="p-card--strip-thin__title">Marketing</h4>
-        <p class="p-card--strip-thin__content">We deliver the right technology message to a highly competent audience, at exactly the right moment. Success depends on having good instincts for tech trends and topics and a natural inclination to leadership.</p>
-        <a href="/careers/marketing">More&nbsp;&rsaquo;</a>
-      </div>
+  <div class="row u-equal-height">
+    <div class="col-4 p-card--blue-strip no-border">
+      <h4 class="p-card--blue-strip__title">Project Management</h4>
+      <p class="p-card--blue-strip__content">Project Managers at Canonical are engaged during all phases of the project, from pre-sales support to delivery to the handoff of complete projects to support or managed services. Project managers create, manage, and maintain project-specific schedules ensuring projects are delivered within time/resources/scope expectations.</p>
+      <a href="/careers/project-management">Learn more&nbsp;&rsaquo;</a>
     </div>
+    <div class="col-4 p-card--blue-strip no-border">
+      <h4 class="p-card--blue-strip__title">Commercial-ops</h4>
+      <p class="p-card--blue-strip__content">Excellence in operations enables Canonical to scale efficiently. Our core operations - from IT to commercial operations or logistics - is central to the idea that we can be an effective global distributed company serving advanced customers in every geography. We celebrate relentless improvement. We look for people who are passionate about tools and efficiency.</p>
+      <a href="/careers/commercial-ops">Learn more&nbsp;&rsaquo;</a>
+    </div>
+    <div class="col-4 p-card--blue-strip no-border">
+      <h4 class="p-card--blue-strip__title">Sales</h4>
+      <p class="p-card--blue-strip__content">You build long term relationships, and you always promote the approach that is in the customers best interests, regardless of short term consequences. You are interested in the state of the art, you love to represent a company that knows how to transform customer operations, and you are keen to see new customers benefit from that knowledge.</p>
+      <a href="/careers/sales">Learn more&nbsp;&rsaquo;</a>
+    </div>
+  </div>
 
+  <div class="row u-equal-height u-sv3">
+    <div class="col-4 p-card--blue-strip no-border">
+      <h4 class="p-card--blue-strip__title">Legal</h4>
+      <p class="p-card--blue-strip__content">Canonical works at the forefront of global digital trends and the legal, licensing and regulatory frameworks that support them. We are a tight-knit team of professionals that enjoy playing a part in the rapid change.</p>
+      <a href="/careers/legal">Learn more&nbsp;&rsaquo;</a>
+    </div>
+    <div class="col-4 p-card--blue-strip no-border">
+      <h4 class="p-card--blue-strip__title">Administration</h4>
+      <p class="p-card--blue-strip__content">Canonical is an entirely new kind of organisation - almost entirely distributed, we are a global team of technology leaders who collaborate online to enable the transformation of enterprise software to open source.</p>
+      <a href="/careers/admin">Learn more&nbsp;&rsaquo;</a>
+    </div>
+    <div class="col-4 p-card--blue-strip no-border">
+      <h4 class="p-card--blue-strip__title">Human resources</h4>
+      <p class="p-card--blue-strip__content">Canonical provides a unique window into the world of 21st-century digital business. We work with smart individuals from a wide range of professional backgrounds in more than 40 countries worldwide</p>
+      <a href="/careers/hr">Learn more&nbsp;&rsaquo;</a>
+    </div>
+  </div>
+</section>
 
-    <div class="row u-equal-height">
-      <div class="col-4 p-card--strip-thin">
-        <h4 class="p-card--strip-thin__title">Project Management</h4>
-        <p class="p-card--strip-thin__content">Project Managers at Canonical are engaged during all phases of the project, from pre-sales support, to delivery to handoff of complete projects to support or managed services.  Project managers create, manage, and maintain project specific schedules ensuring projects are delivered within time/resources/scope expectations.</p>
-        <a href="/careers/project-management">More&nbsp;&rsaquo;</a>
-      </div>
-      <div class="col-4 p-card--strip-thin">
-        <h4 class="p-card--strip-thin__title">Operations</h4>
-        <p class="p-card--strip-thin__content">Excellence in operations enables Canonical to scale efficiently. Our core operations - from IT to commercial operations or logistics - is central to the idea that we can be an effective global distributed company serving advanced customers in every geography. We celebrate relentless improvement. We look for people who are passionate about tools and efficiency.</p>
-        <a href="/careers/operations">More&nbsp;&rsaquo;</a>
-      </div>
-      <div class="col-4 p-card--strip-thin">
-        <h4 class="p-card--strip-thin__title">Sales</h4>
-        <p class="p-card--strip-thin__content">You build long term relationships and you always promote the approach that is in the customers best interests. You are interested in the state of the art, you love to represent a company that knows how to transform customer operations.</p>
-        <a href="/careers/sales">More&nbsp;&rsaquo;</a>
-      </div>
+<section class="p-strip--suru-light-grey">
+  <div class="row">
+    <div class="col-6">
+      <p class="p-heading--tag">Inclusion</p>
+      <h2>Diversity in our company is part of our strength</h2>
+      <p>We believe that talent is evenly distributed around the world. No matter where you were born, or what you look like, or how you like to dress, we think you might have the brilliance and the work ethic and passion for open-source that would make you a Canonical candidate.</p>
+      <hr/>
+      <ul class="p-inline-list">
+        <li class="p-inline-list__item"><a href="/careers/lifestyle">Lifestyle&nbsp;&rsaquo;</a></li>
+        <li class="p-inline-list__item"><a href="/careers/ethics">Ethics&nbsp;&rsaquo;</a></li>
+        <li class="p-inline-list__item"><a href="/careers/travel">Travel&nbsp;&rsaquo;</a></li>
+        <li class="p-inline-list__item"><a href="/careers/progression">Progression&nbsp;&rsaquo;</a></li>
+        <li class="p-inline-list__item"><a href="/careers/diversity">Diversity&nbsp;&rsaquo;</a></li>
+      </ul>
     </div>
-    <div class="row u-equal-height u-sv3">
-      <div class="col-4 p-card--strip-thin">
-        <h4 class="p-card--strip-thin__title">Legal</h4>
-        <p class="p-card--strip-thin__content">Canonical works at the forefront of global digital trends and the legal, licensing and regulatory frameworks that support them. We are a tight-knit team of professionals that enjoy playing a part in the rapid change.
-        </p>
-        <a href="/careers/legal">More&nbsp;&rsaquo;</a>
-      </div>
-      <div class="col-4 p-card--strip-thin">
-        <h4 class="p-card--strip-thin__title">Admin</h4>
-        <p class="p-card--strip-thin__content">Canonical is a completely new kind of organisation - almost entirely distributed, we are a global team of technology leaders who collaborate online to enable the transformation of enterprise software to open source.
-        </p>
-        <a href="/careers/admin">More&nbsp;&rsaquo;</a>
-      </div>
-      <div class="col-4 p-card--strip-thin">
-        <h4 class="p-card--strip-thin__title">Human resources</h4>
-        <p class="p-card--strip-thin__content">Canonical provides a unique window into the world of 21st-century digital business. We work with smart individuals from a wide range of professional backgrounds in more than 40 countries worldwide, bringing together.
-        </p>
-        <a href="/careers/human-resources">More&nbsp;&rsaquo;</a>
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-12">
-        <h2>Diversity in our company is part of our strength</h2>
-        <p>We believe that talent is evenly distributed around the world. No matter where you were born, or what you look like, or how you like to dress, we think you might have the brilliance and the work ethic and the passion for open source that would make you a Canonical candidate.
-        </p>
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-12">
-        <hr/>
-      </div>
-    </div>
-    <div class="row">
-      <div class="col-12">
-        <ul class="p-inline-list">
-          <li class="p-inline-list__item"><a href="/careers/lifestyle">Lifestyle&nbsp;&rsaquo;</a></li>
-          <li class="p-inline-list__item"><a href="/careers/ethics">Ethics&nbsp;&rsaquo;</a></li>
-          <li class="p-inline-list__item"><a href="/careers/travel">Travel&nbsp;&rsaquo;</a></li>
-          <li class="p-inline-list__item"><a href="/careers/progression">Progression&nbsp;&rsaquo;</a></li>
-          <li class="p-inline-list__item"><a href="/careers/diversity">Diversity&nbsp;&rsaquo;</a></li>
-        </ul>
-      </div>
-    </div>
-  </section>
-  <style>
-    .p-strip--suru-background {
-      background-image:
-        linear-gradient(to top right, rgba(74,24,60,0) 0%, rgba(74,24,60,0) 49.9%, rgba(74, 24, 60, 0.4) 50%, rgba(74, 24, 60, 0.4) 100%),
-        linear-gradient(to top left, #fff 0%, #fff 49%, transparent 50%),
-        linear-gradient(to bottom right, rgba(210,180,202,0.05) 0%, rgba(210,180,202,0.05) 49.9%, rgba(210,180,202,0) 50%, rgba(210,180,202,0) 100%),
-        linear-gradient(120deg, #2C001E  4%, #4C193E 54.9%, transparent 55%),
-        url('https://assets.ubuntu.com/v1/5c69a4be-AdobeStock_193792692.jpg');
-      background-position: right top, bottom -1px right -1px, top left, top left, center right, right bottom;
-      background-repeat: no-repeat;
-      background-size: 85% 100%, 105% 25%, 70% 80%, 100% 100%, 55% auto;
-      padding-bottom: 6rem;
-      padding-top: 6rem;
-    }
+  </div>
+</section>
 
-    @media (max-width: 620px) {
-      .p-strip--suru-background {
-        background-image:
-          linear-gradient(to top right, rgba(74,24,60,0) 0%, rgba(74,24,60,0) 49.9%, rgba(74, 24, 60, 0.4) 50%, rgba(74, 24, 60, 0.4) 100%),
-          linear-gradient(to top left, #fff 0%, #fff 49%, transparent 50%),
-          linear-gradient(to bottom right, rgba(210,180,202,0.05) 0%, rgba(210,180,202,0.05) 49.9%, rgba(210,180,202,0) 50%, rgba(210,180,202,0) 100%),
-          linear-gradient(120deg, #2C001E  4%, #4C193E 100%);
-        background-position: right top, bottom right, top left, top left, center right;
-        background-repeat: no-repeat;
-        background-size: 100% 100%, 105% 25%, 70% 80%, 100% 100%;
-      }
-    }
-  </style>
 {% endblock %}

--- a/templates/partners/desktop.html
+++ b/templates/partners/desktop.html
@@ -33,39 +33,39 @@
     <div class="col-12 col-medium-6">
       <h2 style="margin-bottom: 3rem;">Why buy a certified Ubuntu desktop?</h2>
     </div>
-    <div class="col-4 col-medium-2 p-card--strip-thin">
+    <div class="col-4 col-medium-2 p-card--blue-strip">
       <h3 class="p-heading--4">Preloaded with Ubuntu</h3>
       <p>Ubuntu certified PCs ship with a clean version of Ubuntu, straight from Canonical</p>
     </div>
-    <div class="col-4 col-medium-2 p-card--strip-thin">
+    <div class="col-4 col-medium-2 p-card--blue-strip">
       <h3 class="p-heading--4">Works out of the box</h3>
       <p>Canonical performs 100s of stringent tests to ensure all Ubuntu functionality works out-of-the-box</p>
     </div>
-    <div class="col-4 col-medium-2 p-card--strip-thin">
+    <div class="col-4 col-medium-2 p-card--blue-strip">
       <h3 class="p-heading--4">5 years support</h3>
       <p>Certified PCs are continuously tested throughout the lifetime of the preloaded Ubuntu release</p>
     </div>
-    <div class="col-4 col-medium-2 p-card--strip-thin">
+    <div class="col-4 col-medium-2 p-card--blue-strip">
       <h3 class="p-heading--4">Optimised images</h3>
       <p>PCs preloaded with Ubuntu at the factory come with an optimised image to provide users with the best experience for their hardware</p>
     </div>
-    <div class="col-4 col-medium-2 p-card--strip-thin">
+    <div class="col-4 col-medium-2 p-card--blue-strip">
       <h3 class="p-heading--4">Latest hardware</h3>
       <p class="p-matrix__desc">Collaboration with Intel, Nvidia and AMD guarantees Ubuntu runs flawlessly on the latest CPUs and GPUs</p>
     </div>
-    <div class="col-4 col-medium-2 p-card--strip-thin">
+    <div class="col-4 col-medium-2 p-card--blue-strip">
       <h3 class="p-heading--4">Battery life</h3>
       <p class="p-matrix__desc">Ubuntu certified PCs meet the most stringent energy regulations &mdash; Energy Star, CEC</p>
     </div>
-    <div class="col-4 col-medium-2 p-card--strip-thin">
+    <div class="col-4 col-medium-2 p-card--blue-strip">
       <h3 class="p-heading--4">Reliability</h3>
       <p>Ubuntu certified PCs undergo rigorous testing to ensure they perform flawlessly after 30+ suspend/resume cycles</p>
     </div>
-    <div class="col-4 col-medium-2 p-card--strip-thin">
+    <div class="col-4 col-medium-2 p-card--blue-strip">
       <h3 class="p-heading--4">Ready for Enterprise</h3>
       <p>Ubuntu certified PCs are eligible for <a href="https://buy.ubuntu.com">Ubuntu Advantage</a>, the most comprehensive Linux enterprise subscription</p>
     </div>
-    <div class="col-4 col-medium-2 p-card--strip-thin">
+    <div class="col-4 col-medium-2 p-card--blue-strip">
       <h3 class="p-heading--4">The key to corporate fleet</h3>
       <p>With 100s of certified models, ranging from low-cost tower PCs to AI workstations</p>
     </div>

--- a/templates/partners/ihv-and-oem.html
+++ b/templates/partners/ihv-and-oem.html
@@ -51,7 +51,7 @@
     <h2>Benefits of the IHV and OEM Partner Programme</h2>
   </div>
   <div class="row">
-    <div class="col-4 p-card--strip-thin">
+    <div class="col-4 p-card--blue-strip">
       <h3 class="p-card__title p-heading--4">Certification</h3>
       <ul class="p-list">
         <li class="p-list__item is-ticked">Promote your hardware as 'Ubuntu Certified'</li>
@@ -59,7 +59,7 @@
         <li class="p-list__item is-ticked">Public postings on our Ubuntu Certified hardware page</li>
       </ul>
     </div>
-    <div class="col-4 p-card--strip-thin">
+    <div class="col-4 p-card--blue-strip">
       <h3 class="p-card__title p-heading--4">Sales enablement access</h3>
       <ul class="p-list">
         <li class="p-list__item is-ticked">Opportunity registration</li>
@@ -68,7 +68,7 @@
         <li class="p-list__item is-ticked">Sales training</li>
       </ul>
     </div>
-    <div class="col-4 p-card--strip-thin">
+    <div class="col-4 p-card--blue-strip">
       <h3 class="p-card__title p-heading--4">Joint marketing</h3>
       <ul class="p-list">
         <li class="p-list__item is-ticked">Tailored campaigns</li>
@@ -77,19 +77,19 @@
         <li class="p-list__item is-ticked">Logos and joint branding</li>
       </ul>
     </div>
-    <div class="col-4 p-card--strip-thin">
+    <div class="col-4 p-card--blue-strip">
       <h3 class="p-card__title p-heading--4">Dedicated partner team</h3>
       <ul class="p-list">
         <li class="p-list__item is-ticked">Named resources within Canonical for alliances, sales, technical training, marketing and certification</li>
       </ul>
     </div>
-    <div class="col-4 p-card--strip-thin">
+    <div class="col-4 p-card--blue-strip">
       <h3 class="p-card__title p-heading--4">Reference architecture</h3>
       <ul class="p-list">
         <li class="p-list__item is-ticked">Develop joint hardware-based reference architectures for predictable and repeatable customer deployments</li>
       </ul>
     </div>
-    <div class="col-4 p-card--strip-thin">
+    <div class="col-4 p-card--blue-strip">
       <h3 class="p-card__title p-heading--4">Roadmap alignment</h3>
       <ul class="p-list">
         <li class="p-list__item is-ticked">Weekly alignment calls with alliances and certification team</li>


### PR DESCRIPTION
## Done

- Refresh /careers for canonical-v3 absed on [design](https://app.zeplin.io/project/624ed20e0af92866116ea26d/screen/6254185a9c8cce6c8b79ace1) and [copydoc](https://docs.google.com/document/d/1pNyOXfR07FiBr6TmEMRdB7NZUB5SeBz6COuSxO3ylC0/edit#)
- Updates `p-card--strip-thin` to `p-card--orange-strip` and `p-card--blue-strip` and adds a `no-border` option to the sass class
- Updates instances where these classes were used
## QA

- Compare against design and copydoc

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/4713