### PR TITLE
Display user error on empty results

### DIFF
--- a/templates/careers/results.html
+++ b/templates/careers/results.html
@@ -32,9 +32,11 @@ Travel regularly to interesting destinations for team, conference and customer e
 {% endblock %}
 
 {% block careers_content %}
+  {% if vacancies %}
   <div class="row">
     <h2 class="p-muted-heading">Top roles for you</h2>
   </div>
+  {% endif %}
   <div class="row u-sv3">
     {% for vacancy in vacancies %}
       {% if loop.index < 5 %}
@@ -70,12 +72,20 @@ Travel regularly to interesting destinations for team, conference and customer e
       <div class="row">
         <div class="col-8">
           {% if not vacancies %}
-            <div class="u-align--center">
-              <p>
-                There are no roles matching your selection.
-                <a href="/careers/start">Retake choices again?</a>
-              </p>
+          <caption>
+            <div class="p-strip">
+              <div class="row">
+                <div class="u-align--right col-2 col-medium-1 col-small-1">
+                  <img src="https://assets.ubuntu.com/v1/263e7c5d-iot_orange.svg" alt="">
+                </div>
+                <div class="u-align--left col-6 col-medium-3 col-small-3">
+                  <p class="p-heading--4 u-no-margin--bottom">We couldn't find matching results</p>
+                  <p>There are no roles matching your selection.</p>
+                  <a class="p-button--positive" href="/careers/start">Retake choices again?</a>
+                </div>
+              </div>
             </div>
+          </caption>
           {% else %}
             <div class="js-filter-jobs-container"><h2>
               More matches for you to consider
@@ -105,7 +115,7 @@ Travel regularly to interesting destinations for team, conference and customer e
                       </li>
                     {% endif %}
                   {% endfor %}
-                </ul>        
+                </ul>
                 <p>
                   <a href="/careers/{{ department.slug }}">
                     See all roles in {{ department.name }}&nbsp;&rsaquo;
@@ -113,7 +123,7 @@ Travel regularly to interesting destinations for team, conference and customer e
                 </p>
                 <hr />
               </div>
-            {% endfor %}          
+            {% endfor %}
             </div>
           {% endif %}
         </div>

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -55,14 +55,6 @@ class TestRoutes(VCRTestCase):
             self.client.get("/partners/ihv-and-oem").status_code, 200
         )
 
-    def test_careers_results_pages(self):
-        """
-        When given the URL for careers results with empty core_skills,
-        we should return a 200 status code
-        """
-
-        self.assertEqual(self.client.get("/careers/results").status_code, 200)
-
     def test_not_found(self):
         """
         When given a non-existent URL,

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -55,6 +55,14 @@ class TestRoutes(VCRTestCase):
             self.client.get("/partners/ihv-and-oem").status_code, 200
         )
 
+    def test_careers_results_pages(self):
+        """
+        When given the URL for careers results with empty core_skills,
+        we should return a 200 status code
+        """
+
+        self.assertEqual(self.client.get("/careers/results").status_code, 200)
+
     def test_not_found(self):
         """
         When given a non-existent URL,

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -125,9 +125,7 @@ def identity():
 def results():
     vacancies = []
 
-    core_skills = flask.request.args.get("core-skills", [])
-    if core_skills:
-        core_skills = core_skills.split(",")
+    core_skills = flask.request.args.get("core-skills", "").split(",")
     vacancies = greenhouse.get_vacancies_by_skills(core_skills)
     vacancies_by_department = _group_by_department(vacancies)
 

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -125,7 +125,9 @@ def identity():
 def results():
     vacancies = []
 
-    core_skills = flask.request.args.get("core-skills", []).split(",")
+    core_skills = flask.request.args.get("core-skills", [])
+    if core_skills:
+        core_skills = core_skills.split(",")
     vacancies = greenhouse.get_vacancies_by_skills(core_skills)
     vacancies_by_department = _group_by_department(vacancies)
 


### PR DESCRIPTION
## Done
Do not try and split a list. Check it first. 

## QA
- Go to https://canonical.com/careers/results and see you get a 500
- Open the demo
- Go to /careers/results and see the page renders with a message stating there were no vacancies matching the selection and asking the user to try again.

## Issue / Card
Fixes https://github.com/canonical-web-and-design/canonical.com/issues/546

## Screenshots

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/1413534/167934377-38f2a196-08cc-427c-8d93-a3fbd8f76bad.png) | ![image](https://user-images.githubusercontent.com/1413534/167934596-45bfaee8-6f02-41e3-abfe-5bb00241777d.png) |
