### PR TITLE
Update homepage logo and footer copyright year

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -226,6 +226,18 @@
       <div class="p-logo-section__items">
         <div class="p-logo-section__item">
           {{ image (
+            url="https://assets.ubuntu.com/v1/1ac4edd4-NVIDIA.png",
+            alt="Nvidia",
+            width="288",
+            height="289",
+            hi_def=True,
+            loading="auto",
+            attrs={"class": "p-logo-section__logo"}
+            ) | safe
+          }}
+        </div>
+        <div class="p-logo-section__item">
+          {{ image (
             url="https://assets.ubuntu.com/v1/67f81bfe-intel-new-logo.png",
             alt="Intel",
             width="288",


### PR DESCRIPTION
## Done

Added Nvidia logo and update footer

## QA

- Go to https://canonical-com-548.demos.haus/
- Check logo nvidia has been added.
- Check footer is always 2019 according to [MS comment](https://docs.google.com/document/d/1WcNN2RlQQrbLSP5ZgcIsAeQAHj5h_yDW6Yd5oBMmU3M/edit?disco=AAAACqQyp-w)

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/5293

## Screenshots

![canonical-copy-update](https://user-images.githubusercontent.com/14939793/168102419-d72f43d5-544f-4905-b2b8-6da470d5a5af.png)

