### PR TITLE
add links to privacy notices on application forms

### DIFF
--- a/templates/careers/job-detail.html
+++ b/templates/careers/job-detail.html
@@ -130,6 +130,7 @@
         <button type="button" class="js-locate-me">Locate me</button>
         <span class="js-locate-error u-hide" style="color: #c7162b">Location unavailable</span>
         <hr style="margin: 1rem 0;" />
+        <p>In submitting this form, I confirm that I have read and agree to Canonical's <a href="https://ubuntu.com/legal/data-privacy/recruitment">Recruitment Privacy Notice</a> and <a href="https://ubuntu.com/legal/data-privacy/">Privacy Policy</a>.</p>
         <input type="submit" class="p-button--positive u-no-margin--bottom" name="submit" value="Submit application">
       </fieldset>
     </form>


### PR DESCRIPTION
## Done

Added links to the privacy policy and the new recruitment privacy policy on job application forms.

## QA

- Visit https://canonical-com-549.demos.haus/careers/3830645/accountant-remote (or any other job listing)
- See that there is a disclaimer above the submit button linking to the two privacy notices
