### PR TITLE
Update navigation drop-down links

### DIFF
--- a/templates/partial/_navigation-careers.html
+++ b/templates/partial/_navigation-careers.html
@@ -3,9 +3,12 @@
     <a class="p-navigation__dropdown-item" href="/careers">Overview</a>
   </li>
   <li>
-    <a class="p-navigation__dropdown-item" href="/careers/all">All roles</a>
+    <a class="p-navigation__dropdown-item" href="/careers/all">Open roles</a>
   </li>
   <li>
-    <a class="p-navigation__dropdown-item" href="/careers/working-here">Working here</a>
+    <a class="p-navigation__dropdown-item" href="/careers/start">Career finder</a>
   </li>
+  <li>
+    <a class="p-navigation__dropdown-item" href="/careers/working-here">Working at Canonical</a>
+  </li>  
 </ul>

--- a/templates/partial/_navigation-company.html
+++ b/templates/partial/_navigation-company.html
@@ -1,5 +1,14 @@
 <ul class="p-navigation__dropdown" id="company-menu" aria-hidden="false">
   <li>
-    <a class="p-navigation__dropdown-item" href="/company">Overview</a>
+    <a class="p-navigation__dropdown-item" href="/company">About us</a>
   </li>
+  <li>
+    <a class="p-navigation__dropdown-item" href="/blog">Blogs</a>
+  </li>
+  <li>
+    <a class="p-navigation__dropdown-item" href="/practice">Documentation</a>
+  </li>
+  <li>
+    <a class="p-navigation__dropdown-item" href="/press">Press Centre</a>
+  </li>      
 </ul>

--- a/templates/partial/_navigation-partners.html
+++ b/templates/partial/_navigation-partners.html
@@ -1,24 +1,29 @@
 <ul class="p-navigation__dropdown" id="partners-menu" aria-hidden="false">
   <li>
-    <a class="p-navigation__dropdown-item" href="/partners">Overview</a>
+    <a class="p-navigation__dropdown-item" href="/partners">About</a>
   </li>
   <li>
-    <a class="p-navigation__dropdown-item" href="/partners/desktop">Desktop</a>
-  </li>
-  <li>
-    <a class="p-navigation__dropdown-item" href="/partners/channel-and-reseller">Channel/Reseller</a>
-  </li>
-  <li>
-    <a class="p-navigation__dropdown-item" href="/partners/iot-device">IoT device</a>
-  </li>
-  <li>
-    <a class="p-navigation__dropdown-item" href="/partners/ihv-and-oem">IHV/OEM</a>
-  </li>
-  <li>
-    <a class="p-navigation__dropdown-item" href="/partners/gsi">Global System Integrators</a>
-  </li>
-  <li>
-    <a class="p-navigation__dropdown-item" href="/partners/public-cloud">Public Cloud</a>
+    <p class="p-navigation__dropdown-item u-no-margin--bottom">Our partner programmes</p>
+    <ul class="u-no-margin--left">
+      <li>
+        <a class="p-navigation__dropdown-item p-text--small u-no-margin--bottom" href="/partners/desktop">Desktop</a>
+      </li>
+      <li>
+        <a class="p-navigation__dropdown-item p-text--small u-no-margin--bottom" href="/partners/channel-and-reseller">Channel/Reseller</a>
+      </li>
+      <li>
+        <a class="p-navigation__dropdown-item p-text--small u-no-margin--bottom" href="/partners/iot-device">Internet of Things device</a>
+      </li>
+      <li>
+        <a class="p-navigation__dropdown-item p-text--small u-no-margin--bottom" href="/partners/ihv-and-oem">IHV/OEM</a>
+      </li>
+      <li>
+        <a class="p-navigation__dropdown-item p-text--small u-no-margin--bottom" href="/partners/gsi">Global System Initiative</a>
+      </li>
+      <li>
+        <a class="p-navigation__dropdown-item p-text--small u-no-margin--bottom" href="/partners/public-cloud">Public Cloud</a>
+      </li>      
+    </ul>
   </li>
   <li>
     <a class="p-navigation__dropdown-item" href="/partners/become-a-partner">Become a partner</a>
@@ -27,6 +32,6 @@
     <a class="p-navigation__dropdown-item" href="/partners/find-a-partner">Find a partner</a>
   </li>
   <li>
-    <a class="p-navigation__dropdown-item" href="https://partner-portal.canonical.com">Partner portal</a>
+    <a class="p-navigation__dropdown-item" href="https://partner-portal.canonical.com">Log in to the Partner Portal</a>
   </li>
 </ul>

--- a/templates/partial/_navigation-products.html
+++ b/templates/partial/_navigation-products.html
@@ -1,5 +1,0 @@
-<ul class="p-navigation__dropdown" id="products-menu" aria-hidden="false">
-  <li>
-    <a class="p-navigation__dropdown-item" href="/products">Overview</a>
-  </li>
-</ul>

--- a/templates/partial/_navigation.html
+++ b/templates/partial/_navigation.html
@@ -26,9 +26,8 @@
           <a href="#company-menu" aria-controls="company-menu" class="p-navigation__link">Company</a>
           {% include "partial/_navigation-company.html" %}
         </li>
-        <li class="p-navigation__item--dropdown-toggle">
-          <a href="#products-menu" aria-controls="products-menu" class="p-navigation__link">Products</a>
-          {% include "partial/_navigation-products.html" %}
+        <li class="p-navigation__item">
+          <a href="/products" aria-controls="products-menu" class="p-navigation__link">Products</a>
         </li>
         <li class="p-navigation__item--dropdown-toggle">
           <a href="#partners-menu" aria-controls="partners-menu" class="p-navigation__link">Partners</a>

--- a/webapp/app.py
+++ b/webapp/app.py
@@ -341,10 +341,7 @@ def product_list():
     f = open("products.json")
     products = json.loads(f.read())
 
-    return flask.render_template(
-        "products/index.html",
-        products=products
-    )
+    return flask.render_template("products/index.html", products=products)
 
 
 # Template finder


### PR DESCRIPTION
## Done

- Update navigations drop-down links based on the [miro board](https://miro.com/app/board/o9J_luilNcw=/?moveToWidget=3458764526315426035&cot=14)

## QA

- Go to https://canonical-com-554.demos.haus/ and check the navigation matches the miro board and that all the links (except company/blobs, company/documentation and company/press-centre) work

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/5410
