### PR TITLE
Remove part time filter from the careers list

### DIFF
--- a/templates/careers/_filters.html
+++ b/templates/careers/_filters.html
@@ -11,7 +11,6 @@
       <option value="office-based">Office based</option>
       <option value="management">Management</option>
       <option value="full-time">Full-time</option>
-      <option value="part-time">Part-time</option>
     </select>
   </div>
   <div class="p-form__group">


### PR DESCRIPTION
## Done
Remove part time filter from the careers list

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/career/all
- Check there is no "Part time" option in the FIlter by
