### PR TITLE
Remove the full-time option on job filters

### DIFF
--- a/templates/careers/_filters.html
+++ b/templates/careers/_filters.html
@@ -10,7 +10,6 @@
       <option value="home-based">Home based</option>
       <option value="office-based">Office based</option>
       <option value="management">Management</option>
-      <option value="full-time">Full-time</option>
     </select>
   </div>
   <div class="p-form__group">


### PR DESCRIPTION
## Done
Remove the full-time option on job filters

## QA
- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/career/all
- Check there is no "Full time" option in the FIlter by