### PR TITLE
Dynamically pull blog posts with featured tag and render then on the homepage

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,10 +2,11 @@
   "scripts": {
     "clean": "rm -rf node_modules yarn-error.log css static/css *.log *.sqlite _site/ build/ .jekyll-metadata .bundle",
     "watch": "watch -p 'static/sass/**/*.scss' -c 'yarn run build'",
-    "build": "yarn run build-css && yarn run build-js && yarn run build-latest-news",
+    "build": "yarn run build-css && yarn run build-js",
     "build-css": "sass static/sass/styles.scss static/css/styles.css --load-path=node_modules --style=compressed && postcss --map false --use autoprefixer --replace 'static/css/**/*.css'",
-    "build-js": "mkdir -p static/js/modules/cookie-policy && cp node_modules/@canonical/cookie-policy/build/js/cookie-policy.js static/js/modules/cookie-policy",
+    "build-cookie-policy": "mkdir -p static/js/modules/cookie-policy && cp node_modules/@canonical/cookie-policy/build/js/cookie-policy.js static/js/modules/cookie-policy",
     "build-latest-news": "mkdir -p static/js/modules/latest-news && cp node_modules/@canonical/latest-news/dist/latest-news.js static/js/modules/latest-news",
+    "build-js": "yarn run build-cookie-policy && yarn run build-latest-news",
     "format-python": "black --line-length 79 webapp",
     "lint-python": "flake8 --extend-ignore=E203 webapp tests && black --check --line-length 79 webapp tests",
     "lint-scss": "stylelint static/**/*.scss",

--- a/package.json
+++ b/package.json
@@ -2,9 +2,10 @@
   "scripts": {
     "clean": "rm -rf node_modules yarn-error.log css static/css *.log *.sqlite _site/ build/ .jekyll-metadata .bundle",
     "watch": "watch -p 'static/sass/**/*.scss' -c 'yarn run build'",
-    "build": "yarn run build-css && yarn run build-js",
+    "build": "yarn run build-css && yarn run build-js && yarn run build-latest-news",
     "build-css": "sass static/sass/styles.scss static/css/styles.css --load-path=node_modules --style=compressed && postcss --map false --use autoprefixer --replace 'static/css/**/*.css'",
     "build-js": "mkdir -p static/js/modules/cookie-policy && cp node_modules/@canonical/cookie-policy/build/js/cookie-policy.js static/js/modules/cookie-policy",
+    "build-latest-news": "mkdir -p static/js/modules/latest-news && cp node_modules/@canonical/latest-news/dist/latest-news.js static/js/modules/latest-news",
     "format-python": "black --line-length 79 webapp",
     "lint-python": "flake8 --extend-ignore=E203 webapp tests && black --check --line-length 79 webapp tests",
     "lint-scss": "stylelint static/**/*.scss",
@@ -17,6 +18,7 @@
   },
   "dependencies": {
     "@canonical/cookie-policy": "3.4.0",
+    "@canonical/latest-news": "1.3.0",
     "@testing-library/cypress": "8.0.0",
     "autoprefixer": "10.4.1",
     "concurrently": "5.3.0",

--- a/templates/index.html
+++ b/templates/index.html
@@ -18,28 +18,10 @@
     </div>
   </div>
 
-  <div class="row u-equal-height">
-    <div class="col-4 p-card--highlighted has-accent-alt-border">
-      <p class="p-card__tag">Whitepaper</p>
-      <h2 class="p-heading--4 u-no-padding--top">Gartner report on Juju</h2>
-      <p>Lorem ipsum Public Cloud solution Ut enim ad minim veniam, quis nostrud exercitation ullamco</p>
-      <a href="#">Working at Canonical</a>
-    </div>
+  {% with section_classes='u-no-padding--top', tag_name='Featured', tag_id='4311', limit='3' %} 
+    {% include "shared/_featured-news.html" %} 
+  {% endwith %}
 
-    <div class="col-4 p-card--highlighted has-accent-alt-border">
-      <p class="p-card__tag">New</p>
-      <h2 class="p-heading--4 u-no-padding--top">Bare metal cloud support for Ubuntu 14.04 and 16.04 LTS</h2>
-      <p>Lorem ipsum Public Cloud solution Ut enim ad minim veniam, quis nostrud</p>
-      <a href="#">Our pledge to open source</a>
-    </div>
-
-    <div class="col-4 p-card--highlighted has-accent-alt-border">
-      <p class="p-card__tag">Event</p>
-      <h2 class="p-heading--4 u-no-padding--top">Canonical at Grace Hopper 2021</h2>
-      <p>Lorem ipsum Public Cloud solution Ut enim ad minim veniam, quis nostrud exercitation ullamco</p>
-      <a href="#">Press centre</a>
-    </div>
-  </div>
 </section>
 
 <section class="p-strip">

--- a/templates/shared/_featured-news.html
+++ b/templates/shared/_featured-news.html
@@ -1,0 +1,26 @@
+<section data-js="latest-news">
+  <div class="row p-divider">
+    <div class="col-12">
+      <div id="horizontal-featured-articles" class="row"></div>
+    </div>
+  </div>
+  <template style="display:none" id="horizontal-articles-template">
+    <div class="col-4 p-card--highlighted has-accent-alt-border">
+      <p class="p-card__tag">{{ tag_name }}</p>
+      <h2 class="article-title p-heading--4 u-no-padding--top"></h2>
+      <a class="article-link ">Read more&nbsp;&rsaquo;</a>
+    </div>
+  </template>
+  <script src="{{ versioned_static('js/modules/latest-news/latest-news.js') }}"></script>
+  <script>
+    canonicalLatestNews.fetchLatestNews(
+      {
+        articlesContainerSelector: "#horizontal-featured-articles",
+        articleTemplateSelector: "#horizontal-articles-template",
+        gtmEventLabel: "canonical.com{% if tag_name %}/{{ tag_name }}{% else %} homepage{% endif %}",
+        {% if tag_name %}tagId: "{{ tag_id }}", {% endif %}
+        {% if limit %} limit: "{{ limit }}", {% endif %}
+      }
+    )
+  </script>
+</section>


### PR DESCRIPTION
## Done

**Note: This is a proof of concept and will require communication with the pdm to see what exactly information we need to pull from wordpress and thus updating of the `latest-news.js` module. We are using the `latest-news.js` module as if wordpress is down the page will still be able to load.**
- Include the `latest-news.js` module, can be found [here](https://github.com/canonical-web-and-design/latest-news)
- Add build commands to package.json
- Create custom template to render the individual cards

## QA

- Go to https://canonical-com-561.demos.haus/ and check that the most recent blog posts from the [featured tag](https://ubuntu.com/blog/tag/featured) are being rendered on the front page
- Try blocking the network request to wordpress and check the page still loads and the page flow is not ruined in any way

## Issue / Card

Fixes https://github.com/canonical-web-and-design/web-squad/issues/5439
