### PR TITLE
Hide horizontal scroll

### DIFF
--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -73,6 +73,8 @@ $p-small-lh-diff: map-get($line-heights, default-text) -
 }
 
 .p-pull-quote--inverted {
+    overflow-x: hidden;
+    
   .p-pull-quote__quote {
     &::before {
       color: $color-x-light;


### PR DESCRIPTION
## Done

Add "overflow-x : hidden" to `p-pull-quote--inverted` class

## QA

- Check out this feature branch
- Run the site using the command `./run serve`
- View the site locally in your web browser at: http://0.0.0.0:8002/#careers or https://canonical-com-563.demos.haus/#careers and check the first column

## Issue / Card

Fixes #555

