### PR TITLE
Separate canonical.com/blog into a difference service

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -29,9 +29,25 @@ extraHosts:
 # Overrides for production
 production:
   replicas: 5
+  routes:
+    - paths: [/blog]
+      name: canonical-com-blog
+      app_name: canonical.com-blog
+      image: prod-comms.docker-registry.canonical.com/canonical.com
+      replicas: 3
+      memoryLimit: 512Mi
+      env:
+        - name: SEARCH_API_KEY
+          secretKeyRef:
+            key: google-custom-search-key
+            name: google-api
+
+        - name: SENTRY_DSN
+          value: https://aedc7a57f0bc4d22bf7c0b6d63c3e1bb@sentry.is.canonical.com//14
+
   nginxConfigurationSnippet: |
     if ($host = 'blog.canonical.com' ) {
-      rewrite ^ https://ubuntu.com/blog$request_uri? permanent;
+      rewrite ^ https://canonical.com/blog$request_uri? permanent;
     }
     if ($host = 'design.canonical.com' ) {
       rewrite ^ https://ubuntu.com/blog/topics/design permanent;
@@ -47,6 +63,22 @@ production:
 # Overrides for staging
 staging:
   replicas: 3
+  routes:
+    - paths: [/blog]
+      name: canonical-com-blog
+      app_name: canonical.com-blog
+      image: prod-comms.docker-registry.canonical.com/canonical.com
+      replicas: 3
+      memoryLimit: 512Mi
+      env:
+        - name: SEARCH_API_KEY
+          secretKeyRef:
+            key: google-custom-search-key
+            name: google-api
+
+        - name: SENTRY_DSN
+          value: https://aedc7a57f0bc4d22bf7c0b6d63c3e1bb@sentry.is.canonical.com//14
+
   nginxConfigurationSnippet: |
     more_set_headers "X-Robots-Tag: noindex";
     if ($host != 'staging.canonical.com' ) {


### PR DESCRIPTION
## Done

- Separate canonical blog into a separate k8s service
- Redirect blog.canonical.com -> canonical.com/blog

## QA

- Go to https://blog.canonical.com/ should redirect now to https://canonical.com/blog
- Not sure how to QA the new /blog service, I don't think it will show up on `kubectl get deployments` until it's deploy to prod


## Issue / Card

Fixes https://github.com/canonical-web-and-design/ubuntu.com/issues/11841
Fixes https://github.com/canonical-web-and-design/canonical.com/issues/572

