### PR TITLE
Separate the careers/start route to a simple route

### DIFF
--- a/webapp/app.py
+++ b/webapp/app.py
@@ -210,6 +210,11 @@ def job_details(job_id, job_title):
     return flask.render_template("/careers/job-detail.html", **context)
 
 
+@app.route("/careers/start")
+def start_career():
+    return flask.render_template("/careers/start.html")
+
+
 @app.route("/careers/<department_slug>", methods=["GET", "POST"])
 def department_group(department_slug):
     context = {


### PR DESCRIPTION
## Done
Added a new simple route to handle /career/start as it doesn't require the vacancy data.

## QA
- Open the demo
- Go to /careers/start?ga=123 and see it loads as expected
- Go to the live site at https://canonical.com/careers/start?ga=123 and see it 500's

## Issue / Card
Fixes https://github.com/canonical-web-and-design/canonical.com/issues/590
