### PR TITLE
Revert blog service separation

### DIFF
--- a/konf/site.yaml
+++ b/konf/site.yaml
@@ -29,25 +29,9 @@ extraHosts:
 # Overrides for production
 production:
   replicas: 5
-  routes:
-    - paths: [/blog]
-      name: canonical-com-blog
-      app_name: canonical.com-blog
-      image: prod-comms.docker-registry.canonical.com/canonical.com
-      replicas: 3
-      memoryLimit: 512Mi
-      env:
-        - name: SEARCH_API_KEY
-          secretKeyRef:
-            key: google-custom-search-key
-            name: google-api
-
-        - name: SENTRY_DSN
-          value: https://aedc7a57f0bc4d22bf7c0b6d63c3e1bb@sentry.is.canonical.com//14
-
   nginxConfigurationSnippet: |
     if ($host = 'blog.canonical.com' ) {
-      rewrite ^ https://canonical.com/blog$request_uri? permanent;
+      rewrite ^ https://ubuntu.com/blog$request_uri? permanent;
     }
     if ($host = 'design.canonical.com' ) {
       rewrite ^ https://ubuntu.com/blog/topics/design permanent;
@@ -63,22 +47,6 @@ production:
 # Overrides for staging
 staging:
   replicas: 3
-  routes:
-    - paths: [/blog]
-      name: canonical-com-blog
-      app_name: canonical.com-blog
-      image: prod-comms.docker-registry.canonical.com/canonical.com
-      replicas: 3
-      memoryLimit: 512Mi
-      env:
-        - name: SEARCH_API_KEY
-          secretKeyRef:
-            key: google-custom-search-key
-            name: google-api
-
-        - name: SENTRY_DSN
-          value: https://aedc7a57f0bc4d22bf7c0b6d63c3e1bb@sentry.is.canonical.com//14
-
   nginxConfigurationSnippet: |
     more_set_headers "X-Robots-Tag: noindex";
     if ($host != 'staging.canonical.com' ) {


### PR DESCRIPTION
## Done

Revert additional code of PR https://github.com/canonical-web-and-design/canonical.com/pull/592/files

## QA

- Check that https://canonical-com-594.demos.haus/blog works
- https://blog.canonical.com should redirect to https://ubuntu.com/blog